### PR TITLE
docs: ASC CLI distribution research and install script

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,0 +1,152 @@
+# Installing mktg
+
+## Quick Start
+
+```bash
+# One-liner (recommended)
+curl -fsSL https://raw.githubusercontent.com/MoizIbnYousaf/mktg/main/install.sh | bash
+
+# Or install directly with bun
+bun install -g mktg
+
+# Or with npm
+npm install -g mktg
+```
+
+## What Gets Installed
+
+1. **`mktg` CLI** — the command-line tool, installed globally
+2. **38 marketing skills** — SKILL.md files installed to `~/.claude/skills/`
+3. **`/cmo` skill** — the orchestrator skill that teaches agents how to use everything
+
+## Post-Install Setup
+
+After installing, run `mktg init` in any project directory:
+
+```bash
+cd your-project
+mktg init
+```
+
+This will:
+- Detect your project (reads package.json, README, etc.)
+- Scaffold the `brand/` directory with starter templates
+- Install marketing skills to `~/.claude/skills/`
+- Run `mktg doctor` to verify everything works
+
+### Non-Interactive Mode (for agents/CI)
+
+```bash
+# With defaults
+mktg init --yes
+
+# With specific input
+mktg init --json '{"business":"My App","goal":"launch"}'
+```
+
+## Requirements
+
+| Requirement | Version | Required |
+|------------|---------|----------|
+| Bun | latest | Recommended |
+| Node.js | 18+ | Alternative to Bun |
+| Claude Code | latest | For skill usage |
+
+### Optional Tools
+
+These enhance specific skills but aren't required:
+
+| Tool | Purpose |
+|------|---------|
+| `gws` | Email sending via Gmail |
+| `playwright-cli` | Social media posting |
+| `ffmpeg` | Video processing |
+
+Run `mktg doctor` to check which tools are available.
+
+## Updating
+
+```bash
+# Update the CLI
+bun update -g mktg
+# or
+npm update -g mktg
+
+# Update skills only
+mktg update
+```
+
+Or re-run the install script — it always installs the latest version:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/MoizIbnYousaf/mktg/main/install.sh | bash
+```
+
+## Verifying Installation
+
+```bash
+# Check CLI is installed
+mktg --help
+
+# Run health checks
+mktg doctor
+
+# List available skills
+mktg list
+```
+
+## Uninstalling
+
+```bash
+# Remove the CLI
+bun remove -g mktg
+# or
+npm uninstall -g mktg
+
+# Remove installed skills (optional)
+rm -rf ~/.claude/skills/mktg-*
+```
+
+## Troubleshooting
+
+### `mktg: command not found`
+
+The global bin directory isn't in your PATH. Add it:
+
+```bash
+# For bun
+export PATH="$HOME/.bun/bin:$PATH"
+
+# For npm
+export PATH="$(npm bin -g):$PATH"
+```
+
+Add the appropriate line to your shell profile (`~/.zshrc`, `~/.bashrc`).
+
+### `mktg init` fails
+
+1. Make sure you're in a project directory (one with a package.json or README)
+2. Run `mktg doctor` to see what's missing
+3. Try with `--yes` flag: `mktg init --yes`
+
+### Skills not installing
+
+Check that `~/.claude/` exists and is writable:
+
+```bash
+ls -la ~/.claude/
+mkdir -p ~/.claude/skills
+```
+
+### Permission errors on install
+
+```bash
+# Option 1: Use bun (installs to ~/.bun, no sudo needed)
+bun install -g mktg
+
+# Option 2: Fix npm permissions
+mkdir -p ~/.npm-global
+npm config set prefix '~/.npm-global'
+export PATH="$HOME/.npm-global/bin:$PATH"
+npm install -g mktg
+```

--- a/docs/research/asc-cli-distribution.md
+++ b/docs/research/asc-cli-distribution.md
@@ -1,0 +1,103 @@
+# ASC CLI Distribution & Self-Bootstrap Patterns
+
+Research analysis of how [ASC CLI](https://github.com/rudrankriyam/App-Store-Connect-CLI) handles installation, distribution, and self-bootstrapping — extracted for mktg's distribution story.
+
+## 1. install.sh — OS/Arch Detection & Binary Download
+
+ASC uses a single `install.sh` that:
+
+1. **Detects OS** via `uname -s` → maps Darwin→macOS, Linux→linux
+2. **Detects architecture** via `uname -m` → normalizes to amd64/arm64
+3. **Resolves latest version** by following the GitHub `/releases/latest` redirect URL and extracting the tag from the final URL
+4. **Downloads the platform-specific binary** from `github.com/{repo}/releases/download/{version}/{bin}_{version}_{os}_{arch}`
+5. **Verifies checksum** (SHA-256) against a checksums.txt file published alongside release assets
+6. **Installs to `~/.local/bin`** by default (falls back to `/usr/local/bin`), using `sudo` only when the directory isn't writable
+7. **Warns about PATH** if the install directory isn't on `$PATH`
+
+**Key patterns:**
+- `set -euo pipefail` — fail fast, no silent errors
+- `trap 'rm -rf "${TMP_DIR}"' EXIT` — always clean up temp files
+- Graceful degradation: if checksums can't be downloaded or verified, it warns but continues
+- `INSTALL_DIR` is overridable via environment variable
+- Uses `install -m 755` for proper permissions (not just `cp`)
+
+**What mktg adapts:**
+- mktg is a Bun/Node tool distributed via npm, not a compiled binary. The install.sh equivalent is `bun install -g mktg` or `npm install -g mktg`.
+- The install.sh for mktg should: (1) detect if bun is available, (2) fall back to npm, (3) install globally, (4) run `mktg init` post-install.
+
+## 2. Release Workflow
+
+ASC uses a GitHub Actions workflow triggered by semver tags (`[0-9]*.[0-9]*.[0-9]*`):
+
+1. **Guardrails before release:** format-check, lint, docs sync, full test suite
+2. **Multi-platform builds:** macOS (amd64 + arm64), Linux (amd64 + arm64), Windows (amd64)
+3. **Code signing:** Apple Developer ID codesigning for macOS binaries
+4. **Checksums:** SHA-256 checksums file published with every release
+5. **GitHub Release:** created via `softprops/action-gh-release` with auto-generated release notes
+6. **Homebrew tap update:** automatically updates a separate homebrew-tap repo with the new version and SHA
+
+**Key patterns:**
+- Version, commit hash, and build date are injected at compile time via `-ldflags`
+- Release runs on `macos-latest` (needed for codesigning)
+- Homebrew formula update is non-blocking (graceful failure if token not set)
+- Uses `generate_release_notes: true` for automatic changelogs
+
+**What mktg adapts:**
+- npm handles distribution, so the release workflow is simpler: test → publish to npm
+- Version injection can be done via package.json version field
+- Auto-generated release notes from GitHub are still valuable
+
+## 3. Versioning & Changelogs
+
+- **Versioning:** Git tags in semver format trigger releases. Version is derived from `git describe --tags`
+- **Changelogs:** GitHub's auto-generated release notes (based on PR titles/labels since last tag)
+- **No manual CHANGELOG.md** — relies on GitHub releases page as the changelog
+
+**What mktg adapts:**
+- Use `npm version patch/minor/major` → git tag → push tag → CI publishes
+- GitHub auto-generated release notes
+
+## 4. Self-Update Patterns
+
+ASC does **not** have a built-in self-update command. Users update via:
+- `brew upgrade asc` (Homebrew)
+- Re-running the install script (which always fetches latest)
+
+**What mktg adapts:**
+- `mktg update` already exists for updating skills
+- For CLI self-update: `bun update -g mktg` or `npm update -g mktg`
+- The install.sh can double as an update mechanism (re-run = update)
+
+## 5. Doctor/Health Check Patterns
+
+ASC doesn't have a formal `doctor` command, but it uses several validation patterns:
+
+- **Pre-release guardrails:** format-check, lint, docs sync, test suite all must pass
+- **`make dev`:** runs format → lint → test → build as a single dev-readiness check
+- **Integration tests:** opt-in, require real credentials via env vars
+- **`ASC_BYPASS_KEYCHAIN=1`:** allows tests to run in CI without macOS keychain access
+
+**What mktg already has:**
+- `mktg doctor` checks brand files, installed skills, and CLI dependencies — this is more sophisticated than ASC's approach
+
+## 6. Distribution Philosophy Summary
+
+| Aspect | ASC CLI | mktg |
+|--------|---------|------|
+| **Language** | Go (compiled binary) | TypeScript/Bun (npm package) |
+| **Primary install** | `brew install asc` | `bun install -g mktg` |
+| **Fallback install** | `curl \| bash` (downloads binary) | `curl \| bash` (installs via bun/npm) |
+| **Post-install** | Manual `asc auth login` | Automatic `mktg init` |
+| **Update** | `brew upgrade` / re-run install.sh | `bun update -g mktg` / re-run install.sh |
+| **Health check** | Pre-release CI guardrails | `mktg doctor` (runtime) |
+| **Versioning** | Git tags → goreleaser | npm version → npm publish |
+| **Skills** | Separate repo of agent skills | Bundled with CLI |
+
+## 7. Key Takeaways for mktg
+
+1. **The `curl | bash` pattern is table stakes** — even with npm as primary, a one-liner install script removes friction
+2. **Post-install bootstrapping is the differentiator** — ASC requires manual auth setup; mktg's `init` auto-scaffolds everything
+3. **Graceful degradation matters** — ASC's install.sh warns but continues when checksums can't verify; mktg should similarly handle missing optional tools
+4. **Checksum verification is good practice** — even though npm handles integrity, the install.sh should verify bun/npm is legitimate
+5. **Keep the release workflow simple** — ASC's workflow is complex because of cross-platform Go compilation; mktg just needs test → npm publish
+6. **PATH awareness** — warn users if the install location isn't on PATH (ASC does this well)

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# mktg installer — one-liner install for AI marketing CLI
+# Usage: curl -fsSL https://raw.githubusercontent.com/MoizIbnYousaf/mktg/main/install.sh | bash
+#
+# Inspired by ASC CLI's install.sh patterns:
+# - OS detection, graceful fallbacks, PATH awareness, post-install bootstrap
+
+PACKAGE_NAME="mktg"
+MIN_NODE_VERSION=18
+
+# Colors (disabled if not a terminal)
+if [ -t 1 ]; then
+  GREEN='\033[0;32m'
+  YELLOW='\033[0;33m'
+  RED='\033[0;31m'
+  DIM='\033[2m'
+  BOLD='\033[1m'
+  NC='\033[0m'
+else
+  GREEN='' YELLOW='' RED='' DIM='' BOLD='' NC=''
+fi
+
+info()  { printf "${GREEN}✓${NC} %s\n" "$1"; }
+warn()  { printf "${YELLOW}!${NC} %s\n" "$1"; }
+fail()  { printf "${RED}✗${NC} %s\n" "$1"; exit 1; }
+step()  { printf "${BOLD}[%s/%s]${NC} %s\n" "$1" "$2" "$3"; }
+
+# Detect OS
+OS="$(uname -s)"
+case "${OS}" in
+  Darwin) OS="macOS" ;;
+  Linux)  OS="linux" ;;
+  MINGW*|MSYS*|CYGWIN*) OS="windows" ;;
+  *) fail "Unsupported OS: ${OS}" ;;
+esac
+
+# Detect architecture
+ARCH="$(uname -m)"
+case "${ARCH}" in
+  x86_64|amd64)   ARCH="x64" ;;
+  arm64|aarch64)   ARCH="arm64" ;;
+  *) fail "Unsupported architecture: ${ARCH}" ;;
+esac
+
+printf "\n${BOLD}mktg installer${NC} ${DIM}(${OS} ${ARCH})${NC}\n\n"
+
+TOTAL_STEPS=3
+INSTALLER=""
+
+# Step 1: Find a package manager
+step 1 "${TOTAL_STEPS}" "Detecting package manager..."
+
+if command -v bun >/dev/null 2>&1; then
+  INSTALLER="bun"
+  BUN_VERSION="$(bun --version 2>/dev/null || echo "unknown")"
+  info "bun ${BUN_VERSION} found (recommended)"
+elif command -v npm >/dev/null 2>&1; then
+  INSTALLER="npm"
+  # Check Node.js version
+  if command -v node >/dev/null 2>&1; then
+    NODE_VERSION="$(node -v | sed 's/^v//' | cut -d. -f1)"
+    if [ "${NODE_VERSION}" -lt "${MIN_NODE_VERSION}" ]; then
+      fail "Node.js ${MIN_NODE_VERSION}+ required (found v${NODE_VERSION}). Install from https://nodejs.org"
+    fi
+    info "npm found with Node.js v$(node -v | sed 's/^v//')"
+  else
+    fail "npm found but node is missing"
+  fi
+else
+  # Try to install bun
+  warn "No package manager found. Installing bun..."
+  if [ "${OS}" = "windows" ]; then
+    fail "Automatic bun install not supported on Windows. Install bun from https://bun.sh or use npm."
+  fi
+  curl -fsSL https://bun.sh/install | bash
+  # Source the updated PATH
+  export BUN_INSTALL="${HOME}/.bun"
+  export PATH="${BUN_INSTALL}/bin:${PATH}"
+  if command -v bun >/dev/null 2>&1; then
+    INSTALLER="bun"
+    info "bun installed successfully"
+  else
+    fail "Failed to install bun. Install manually from https://bun.sh or use npm."
+  fi
+fi
+
+# Step 2: Install mktg
+step 2 "${TOTAL_STEPS}" "Installing ${PACKAGE_NAME}..."
+
+case "${INSTALLER}" in
+  bun)
+    bun install -g "${PACKAGE_NAME}" 2>/dev/null && info "Installed via bun" || {
+      warn "Global bun install failed, trying npm fallback..."
+      if command -v npm >/dev/null 2>&1; then
+        npm install -g "${PACKAGE_NAME}" && info "Installed via npm (fallback)" || fail "Installation failed"
+      else
+        fail "Installation failed. Try: bun install -g ${PACKAGE_NAME}"
+      fi
+    }
+    ;;
+  npm)
+    npm install -g "${PACKAGE_NAME}" && info "Installed via npm" || fail "Installation failed. Try: sudo npm install -g ${PACKAGE_NAME}"
+    ;;
+esac
+
+# Verify installation
+if ! command -v mktg >/dev/null 2>&1; then
+  # Check common global bin locations
+  for dir in "${HOME}/.bun/bin" "${HOME}/.local/bin" "/usr/local/bin" "${HOME}/.npm-global/bin"; do
+    if [ -x "${dir}/mktg" ]; then
+      warn "${PACKAGE_NAME} installed to ${dir} but it's not in your PATH"
+      printf "  Add to your shell profile:\n"
+      printf "    ${DIM}export PATH=\"%s:\$PATH\"${NC}\n" "${dir}"
+      break
+    fi
+  done
+fi
+
+# Step 3: Post-install bootstrap
+step 3 "${TOTAL_STEPS}" "Running post-install setup..."
+
+if command -v mktg >/dev/null 2>&1; then
+  # Run init with --yes for non-interactive setup
+  mktg init --yes 2>/dev/null && info "Project initialized" || warn "Init skipped (run 'mktg init' manually in your project directory)"
+
+  printf "\n${GREEN}${BOLD}Ready!${NC}\n"
+  printf "  ${DIM}cd your-project && mktg init${NC}  — set up marketing for a project\n"
+  printf "  ${DIM}mktg doctor${NC}                    — check installation health\n"
+  printf "  ${DIM}mktg list${NC}                      — see available marketing skills\n"
+  printf "\n"
+else
+  warn "mktg command not found in PATH after install"
+  printf "  Try opening a new terminal, or run:\n"
+  printf "    ${DIM}export PATH=\"\$(${INSTALLER} bin -g 2>/dev/null || echo /usr/local/bin):\$PATH\"${NC}\n"
+  printf "\n"
+fi


### PR DESCRIPTION
## Summary
- Analyzed ASC CLI's `install.sh`, release workflow (`release.yml`), Makefile, and distribution patterns
- Created cross-platform `install.sh` for mktg that detects bun/npm, installs globally, and runs `mktg init` post-install
- Added `docs/research/asc-cli-distribution.md` with detailed analysis of ASC's OS detection, checksum verification, versioning, and self-update patterns
- Added `docs/INSTALL.md` with complete installation, updating, and troubleshooting docs

Closes #19

## Test plan
- [x] `install.sh` passes `bash -n` syntax validation
- [x] All 525 existing tests pass
- [x] Install script handles macOS + Linux OS detection
- [x] Install script gracefully falls back from bun → npm → auto-install bun
- [x] Research doc captures key ASC patterns and maps them to mktg's needs