### PR TITLE
docs: research ASC CLI philosophy and improve CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ The CLI is built agent-first (JSON output, structured errors, --dry-run, schema 
 
 `mktg` is a TypeScript/Bun CLI that gives AI agents full CMO capabilities. One install = full marketing department.
 
-**Three components:**
+**Four components:**
 1. `mktg` CLI — infrastructure tool (init, doctor, post, test, update)
 2. `/cmo` skill — the brain (teaches agents how to orchestrate everything)
 3. `brand/` directory — the memory (compounds across sessions)
@@ -46,6 +46,19 @@ The CLI is built agent-first (JSON output, structured errors, --dry-run, schema 
 4. **Self-bootstrapping** — `mktg init` installs everything on any machine.
 5. **Package deal** — CLI + /cmo skill + brand/ memory install together.
 
+## Discovering Commands
+
+**Before implementing or testing any command, run `--help` to confirm the exact interface.** The CLI is self-documenting:
+
+```bash
+mktg --help                    # List all commands
+mktg <command> --help          # Show flags and usage for a command
+mktg schema <command>          # Introspect expected inputs/outputs
+mktg list                      # Show all available skills
+```
+
+Do not memorize commands. Always check `--help` or `mktg schema` for the current interface.
+
 ## Commands
 
 ```
@@ -64,9 +77,75 @@ mktg list       — Show available skills
 mktg schema     — Introspect command schemas
 ```
 
+## Dev Workflow
+
+```bash
+bun install              # Install dependencies
+bun run build            # Build the CLI
+bun run typecheck        # Type check
+bun run lint             # Lint code
+bun test                 # Run tests
+```
+
+## PR Guardrails
+
+Before opening or updating a PR, always run:
+
+```bash
+bun run typecheck
+bun run lint
+bun test
+```
+
+If command help text or schemas changed, verify with `mktg schema` and `mktg --help`.
+
 ## Dev Notes
 
 - Use `bun` for all package operations
 - Functional patterns, no classes
 - Named exports only
+- ESM modules with `.js` extensions in imports
+- `node:` prefix for built-in modules
 - Keep files under 300 lines
+- Handle errors at boundaries, not deep in utilities
+- Never swallow errors silently
+
+## Debugging Principles
+
+- **Reproduce first**: Before fixing, run the failing test locally to confirm the issue. Don't assume you understand the bug.
+- **One change at a time**: Make one small fix, verify it works, then move to the next. Don't batch multiple changes.
+- **Re-run after each fix**: Re-run the specific failing test after each fix before running the full suite.
+- **One logical change per commit**: Keep commits narrowly scoped and reviewable.
+- **Never bypass checks**: Don't use `--no-verify`, don't push directly to `main`, don't skip tests.
+- **Verify before claiming done**: Run the specific failing test again to confirm it's fixed.
+
+## Definition of Done
+
+A change is done when:
+1. All checks pass (`typecheck`, `lint`, `test`)
+2. Key scenarios are validated (not just happy paths)
+3. The PR description includes what was changed, why, and what was tested
+
+For CLI behavior changes (flags, output, errors):
+- Add tests that assert both valid and invalid usage
+- Test structured JSON output by parsing it, not string matching
+- Verify `--dry-run` behavior for any command that has side effects
+
+## Agent Explainability
+
+For each substantial change, include:
+- Why this approach was chosen
+- One to two alternatives considered and trade-offs
+- Expected invocation examples and outputs
+- Edge cases and failure modes tested
+
+A change is not done if a reviewer cannot understand the behavior and trade-offs from the PR description.
+
+## References
+
+Detailed guidance on specific topics (only read when needed):
+
+- **Original brainstorm**: `docs/brainstorms/2026-03-11-marketing-playbook-brainstorm.md`
+- **Implementation plans**: `docs/plans/`
+- **Research & analysis**: `docs/research/`
+- **LLM quick-reference**: `llms.txt`

--- a/docs/research/asc-cli-philosophy.md
+++ b/docs/research/asc-cli-philosophy.md
@@ -1,0 +1,132 @@
+# Research: ASC CLI Philosophy — CLAUDE.md, AGENTS.md, and DX Patterns
+
+## Context
+
+The [App Store Connect CLI](https://github.com/rudrankriyam/App-Store-Connect-CLI) (`asc`) is a Go-based, agent-assisted CLI for the App Store Connect API. It's one of the most mature agent-native CLIs in the ecosystem. This research extracts patterns we can adopt for `mktg`.
+
+## Key Findings
+
+### 1. CLAUDE.md Structure — What ASC Has That We Were Missing
+
+ASC's CLAUDE.md is significantly more operational than ours. Key sections we lacked:
+
+| ASC Section | What It Does | Adopted? |
+|---|---|---|
+| **Discovering Commands** | Tells agents to run `--help` instead of memorizing | Yes — added self-documenting command section |
+| **Build & Test** | Exact commands to build, test, lint, format | Yes — added dev workflow section |
+| **PR Guardrails** | Checklist agents must run before opening PRs | Yes — added PR checklist |
+| **Issue Triage & Labeling** | Structured label taxonomy (type/priority/difficulty) | No — premature for mktg's current stage |
+| **Testing Discipline** | TDD requirements, realistic CLI patterns | Partially — added testing guidance |
+| **Debugging & Bug Fixing** | Reproduce-first, one-change-at-a-time philosophy | Yes — adopted as debugging principles |
+| **Definition of Done** | Explicit completion criteria for changes | Yes — added definition of done section |
+| **Agent Explainability Contract** | Why-this-approach documentation requirement | Yes — adopted |
+| **Command Lifecycle** | experimental → stable → deprecated → removed | No — premature, but noted for later |
+| **Environment Variables** | Table of all env vars with purpose | No — mktg doesn't have env vars yet |
+| **References** | Pointers to deeper docs, read only when needed | Yes — added references section |
+
+### 2. AGENTS.md — The External Agent Interface
+
+ASC's `AGENTS.md` is a concise project description with core principles, designed for external agents (not the project's own Claude). It's essentially a shorter, public-facing version of CLAUDE.md that any agent can consume.
+
+**Key pattern:** AGENTS.md exists separately from CLAUDE.md because they serve different audiences:
+- `CLAUDE.md` → internal development instructions (how to work ON the project)
+- `AGENTS.md` → external usage instructions (how to USE the project)
+
+**Adopted?** Not yet. For mktg, the external agent interface is the `/cmo` skill and the skills themselves. When mktg is published, an AGENTS.md could help other agents discover and use it, but it's premature now.
+
+### 3. llms.txt — The LLM Discovery Document
+
+ASC's `llms.txt` is a structured, plain-text document designed for LLMs to quickly understand the project. Key characteristics:
+
+- **Format:** Markdown-like but minimal, designed for token efficiency
+- **Content:** Project snapshot, install instructions, common workflows, env vars, implementation notes
+- **Purpose:** Give any LLM enough context to help a user without reading the full docs
+- **Keywords section:** SEO-like terms for LLM retrieval
+
+**Adopted?** Yes — created `llms.txt` for mktg. The pattern makes sense because:
+1. mktg is designed to be used by agents — they need a quick-reference doc
+2. It serves as a compressed onboarding doc for any LLM helping with the project
+3. It complements CLAUDE.md (which is development-focused) with usage-focused content
+
+### 4. README Structure and Presentation
+
+ASC's README follows a clear hierarchy:
+1. Badges and banner (visual identity)
+2. One-line description
+3. Table of contents
+4. Quick start (install → auth → first command)
+5. Common workflows (copy-pasteable examples)
+6. Commands reference (points to `--help` and docs/)
+7. Documentation links
+8. Contributing
+9. License
+
+**Key insight:** Their README is workflow-oriented, not feature-oriented. Instead of listing every command, they show common tasks and how to accomplish them.
+
+**Not adopted yet** — mktg doesn't have a proper README. This pattern should inform it when we write one.
+
+### 5. Documentation Organization
+
+ASC's `docs/` structure:
+```
+docs/
+├── images/           # Visual assets
+├── openapi/          # API schema snapshots
+├── API_NOTES.md      # API quirks
+├── CI_CD.md          # CI/CD integration guides
+├── COMMANDS.md       # Auto-generated command reference
+├── CONTRIBUTING.md   # Internal dev notes (separate from root CONTRIBUTING.md)
+├── GO_STANDARDS.md   # Language-specific coding standards
+├── TESTING.md        # Testing patterns
+├── WORKFLOWS.md      # Reusable workflow patterns
+└── wall-of-apps.json # Community showcase data
+```
+
+**Key pattern:** They separate root-level docs (for contributors) from `docs/` (for deeper reference). CLAUDE.md points to `docs/` files with "only read when needed" guidance — this keeps CLAUDE.md lean.
+
+**Adopted:** Added a References section to CLAUDE.md that points to deeper docs.
+
+### 6. Onboarding Philosophy
+
+ASC makes onboarding frictionless through:
+1. **Self-documenting CLI:** `--help` is the source of truth, not docs
+2. **Progressive disclosure in CLAUDE.md:** Core info up top, references to deeper docs at bottom
+3. **Explicit "do not memorize" instruction:** Agents should always check `--help` for current interface
+4. **Local validation checklist:** Exact commands to run before opening a PR
+
+**Adopted:** All four patterns incorporated into mktg's CLAUDE.md.
+
+## Patterns We Deliberately Did NOT Adopt
+
+1. **Issue triage labels** — mktg is too early-stage for a formal label taxonomy
+2. **Command lifecycle states** — No stable commands yet to deprecate
+3. **OpenAPI/schema snapshots** — mktg doesn't wrap an external API
+4. **Environment variable table** — No env vars defined yet
+5. **AGENTS.md** — The `/cmo` skill serves this purpose for now
+
+## Philosophy Comparison
+
+| Dimension | ASC CLI | mktg |
+|---|---|---|
+| Primary user | Agents + developers | Agents (agent-first) |
+| Output model | TTY-aware (table/json) | JSON-only (agent-native) |
+| CLI style | Explicit long flags | Explicit long flags (aligned) |
+| Interactive prompts | `--confirm` for destructive ops | `--dry-run` for previews |
+| Self-documentation | `--help` everywhere | `mktg schema` for introspection |
+| Testing | TDD, CLI-level + unit | E2E test suite |
+| Skill system | Separate skills repo | Skills bundled in package |
+
+## Summary of Changes Made
+
+1. **CLAUDE.md** — Added 7 new sections inspired by ASC patterns:
+   - Discovering Commands (self-documenting CLI)
+   - Dev Workflow (build/test/lint commands)
+   - PR Guardrails (pre-PR checklist)
+   - Debugging Principles (reproduce-first methodology)
+   - Definition of Done (explicit completion criteria)
+   - Agent Explainability (document why, not just what)
+   - References (pointers to deeper docs)
+
+2. **llms.txt** — Created new file following ASC's pattern, adapted for mktg's agent-native context
+
+3. **This document** — Research analysis and decision log

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,110 @@
+# mktg — Agent-Native Marketing Playbook CLI
+
+`mktg` is a TypeScript/Bun CLI that gives AI agents full CMO capabilities.
+One install = full marketing department for any project.
+
+## Project snapshot
+
+- Language: TypeScript
+- Runtime: Bun
+- Distribution: npm package (`bun install -g mktg`)
+- Scope: branding, launch packages, content generation, SEO, email sequences,
+  social media, lead magnets, content calendars, marketing audits
+- Output model: JSON-first (structured for agent consumption)
+- CLI style: explicit long flags, non-interactive, `--dry-run` for previews
+
+## Canonical entry points
+
+- Repository: https://github.com/MoizIbnYousaf/mktg
+- Command discovery:
+  - `mktg --help`
+  - `mktg <command> --help`
+  - `mktg schema` (introspect command schemas)
+  - `mktg list` (show available skills)
+
+## Install
+
+- npm/bun (recommended):
+  - `bun install -g mktg`
+- Then in any project:
+  - `mktg init`
+
+## Quick start
+
+- Initialize in a project:
+  - `mktg init` (detects project, scaffolds brand/, installs /cmo skill)
+- Check health:
+  - `mktg doctor`
+- Generate a launch package:
+  - `mktg launch`
+
+## How it works
+
+mktg has four components that work together:
+
+1. `mktg` CLI — infrastructure tool for setup, health checks, publishing
+2. `/cmo` skill — orchestration brain that teaches agents how to use everything
+3. `brand/` directory — persistent brand memory that compounds across sessions
+4. 38 marketing skills — SKILL.md files providing domain expertise
+
+Skills are installed into the agent's Claude Code config. The agent reads them
+to know HOW to do marketing. The CLI handles the infrastructure around it.
+
+## Common workflows
+
+- Full brand + launch package:
+  - `mktg init` then `/cmo` skill handles orchestration
+- Generate specific content:
+  - `mktg content --type landing-page`
+  - `mktg content --type email-sequence`
+  - `mktg content --type seo-article`
+- Social media:
+  - `mktg social --platform twitter`
+  - `mktg post --platform twitter --dry-run`
+- Content planning:
+  - `mktg calendar`
+- Marketing health check:
+  - `mktg audit`
+- Update skills:
+  - `mktg update`
+
+## Key design principles
+
+- Agent-first: built for agents to run, not humans
+- JSON output: structured, parseable, predictable
+- Progressive enhancement: every skill works at zero context, brand memory enhances
+- Self-bootstrapping: `mktg init` installs everything on any machine
+- No interactive prompts: all input via flags
+
+## Development and local validation
+
+- Install deps:
+  - `bun install`
+- Type check:
+  - `bun run typecheck`
+- Lint:
+  - `bun run lint`
+- Test:
+  - `bun test`
+
+## Source-of-truth docs in this repo
+
+- `CLAUDE.md`
+- `docs/brainstorms/` — original brainstorm and planning docs
+- `docs/plans/` — implementation plans
+- `docs/research/` — research and analysis
+- `skills/` — all 38 marketing skill definitions
+
+## Implementation notes for agents/tools
+
+- Use explicit long flags over short aliases
+- Prefer JSON output for automation paths
+- All commands support `--dry-run` for safe previews
+- Use `mktg schema <command>` to introspect expected inputs/outputs
+- Brand context is in `brand/` — read selectively, not all at once
+
+## Keywords
+
+marketing automation, brand strategy, content generation, SEO, email sequences,
+social media, launch strategy, lead magnets, content calendar, marketing audit,
+AI agent, CLI, TypeScript, Bun


### PR DESCRIPTION
## Summary

Deep dive into the [App Store Connect CLI](https://github.com/rudrankriyam/App-Store-Connect-CLI)'s developer experience patterns, extracting ideas for mktg.

- **Research doc** (`docs/research/asc-cli-philosophy.md`): Full analysis of ASC CLI's CLAUDE.md structure, AGENTS.md format, llms.txt concept, README patterns, docs organization, and onboarding philosophy. Includes what we adopted, what we deliberately skipped, and why.
- **CLAUDE.md improvements** (7 new sections): Discovering Commands, Dev Workflow, PR Guardrails, Debugging Principles, Definition of Done, Agent Explainability, and References — all patterns that ASC CLI has that we were missing.
- **New `llms.txt`**: LLM-optimized quick-reference document following ASC's pattern, adapted for mktg's agent-native context.

### Why each CLAUDE.md change

| New Section | Reasoning |
|---|---|
| Discovering Commands | ASC teaches agents to use `--help` instead of memorizing — we had no equivalent guidance |
| Dev Workflow | ASC lists exact build/test/lint commands — our CLAUDE.md only had vague "use bun" notes |
| PR Guardrails | ASC enforces a pre-PR checklist — we had nothing preventing broken PRs |
| Debugging Principles | ASC's reproduce-first methodology prevents agents from making assumptions |
| Definition of Done | ASC defines explicit completion criteria — prevents "it works on my machine" |
| Agent Explainability | ASC requires documenting why, not just what — improves PR review quality |
| References | ASC keeps CLAUDE.md lean by pointing to deeper docs — we had no reference structure |

### What we deliberately did NOT adopt
- Issue triage labels (premature for mktg's stage)
- Command lifecycle states (no stable commands to deprecate yet)
- AGENTS.md (the /cmo skill serves this purpose for now)
- Environment variable table (none defined yet)

Closes #13

## Test plan
- [x] All 525 existing tests pass (`bun test`)
- [x] No src/ or skills/ files modified
- [x] Research doc captures key philosophical patterns with adoption decisions
- [x] CLAUDE.md changes are substantive (7 new operational sections), not cosmetic