### PR TITLE
feat: structured exit codes and ASC CLI architecture research

### DIFF
--- a/docs/EXIT_CODES.md
+++ b/docs/EXIT_CODES.md
@@ -1,0 +1,89 @@
+# mktg Exit Codes
+
+Every `mktg` command exits with a structured code that tells agents (and humans) exactly what happened. Agents should parse exit codes to decide their next action — retry, fix input, escalate, or move on.
+
+## Exit Code Table
+
+| Code | Name | Meaning | Agent action |
+|------|------|---------|-------------|
+| 0 | Success | Command completed successfully | Continue |
+| 1 | Error | Generic / unclassified error | Log and investigate |
+| 2 | Usage | Invalid flags, missing args, unknown command | Fix invocation and retry |
+| 3 | Auth | Authentication failure (missing, invalid, expired) | Re-authenticate |
+| 4 | NotFound | Resource not found (file, skill, brand dir) | Check resource exists |
+| 5 | Conflict | Resource already exists / conflict | Skip or use --force |
+| 6 | DependencyMissing | Required tool not installed (bun, playwright-cli, gws) | Install dependency |
+| 7 | SkillFailed | A marketing skill errored during execution | Check skill logs |
+| 8 | Network | Fetch failed, timeout, DNS error | Retry with backoff |
+| 9 | NotImplemented | Command exists but isn't built yet | Use alternative |
+| 10 | Config | Invalid config file or bad brand directory state | Fix config and retry |
+| 11 | Permission | File system permission denied, API quota, rate limit | Check permissions |
+| 12 | Timeout | Operation exceeded time limit | Retry or increase timeout |
+| 13 | Validation | Content failed schema or business rule validation | Fix input data |
+| 14 | IO | File read/write failure | Check file system |
+| 130 | Interrupted | User cancelled or SIGINT received | Respect cancellation |
+
+## Design Principles
+
+1. **Distinct codes** — Every failure mode gets its own exit code. No overloading.
+2. **Agent-parseable** — Agents use exit codes to make retry/abort decisions without parsing stderr.
+3. **Ranges reserved** — Codes 0-9 are CLI-level. Codes 10-14 are operational. 130 is POSIX SIGINT convention. Codes 15-59 are reserved for future use.
+4. **Paired with error codes** — JSON output includes a string `error.code` (e.g., `MISSING_DEPENDENCY`) alongside the numeric exit code for richer context.
+
+## JSON Error Format
+
+When `mktg` exits non-zero, stderr (or JSON output with `--json`) contains a structured error:
+
+```json
+{
+  "ok": false,
+  "error": {
+    "code": "MISSING_DEPENDENCY",
+    "message": "Required dependency not found: playwright-cli",
+    "suggestions": ["Run: bun install -g playwright-cli"]
+  },
+  "exitCode": 6
+}
+```
+
+## Error Code Strings
+
+String codes provide richer context than numeric exit codes alone. Multiple string codes can map to the same exit code (e.g., `INVALID_USAGE`, `INVALID_ARGS`, and `UNKNOWN_COMMAND` all exit with code 2).
+
+| Error Code | Exit Code | Description |
+|-----------|-----------|-------------|
+| `UNKNOWN` | 1 | Unclassified error |
+| `INVALID_USAGE` | 2 | Bad CLI invocation |
+| `INVALID_ARGS` | 2 | Invalid argument values |
+| `UNKNOWN_COMMAND` | 2 | Command not recognized |
+| `MISSING_INPUT` | 2 | Required input not provided |
+| `MISSING_AUTH` | 3 | No credentials configured |
+| `AUTH_EXPIRED` | 3 | Credentials expired |
+| `AUTH_FORBIDDEN` | 3 | Insufficient permissions |
+| `NOT_FOUND` | 4 | Resource not found |
+| `CONFLICT` | 5 | Operation conflicts with existing state |
+| `ALREADY_EXISTS` | 5 | Resource already exists |
+| `MISSING_DEPENDENCY` | 6 | Required tool not installed |
+| `SKILL_FAILED` | 7 | Skill execution error |
+| `SKILL_NOT_FOUND` | 4 | Skill not in manifest |
+| `NETWORK_ERROR` | 8 | Network request failed |
+| `TIMEOUT` | 12 | Operation timed out |
+| `IO_ERROR` | 14 | File I/O failure |
+| `PERMISSION_DENIED` | 11 | Access denied |
+| `VALIDATION_ERROR` | 13 | Input validation failed |
+| `CONFIG_ERROR` | 10 | Configuration invalid |
+| `NOT_IMPLEMENTED` | 9 | Feature not yet built |
+| `INTERRUPTED` | 130 | SIGINT / user cancellation |
+
+## Comparison with ASC CLI
+
+mktg's exit code system is inspired by [ASC CLI](https://github.com/rudrankriyam/App-Store-Connect-CLI)'s approach:
+
+- **ASC** uses codes 0-5 for CLI-level errors, then maps HTTP 4xx to 10-59 and 5xx to 60-99
+- **mktg** uses codes 0-14 for CLI/operational errors since it doesn't wrap a single HTTP API
+- Both use a central `ExitCodeFromError` / `errorCodeToExitCode` function as single source of truth
+- Both pair numeric codes with string error codes for richer agent context
+
+## Source
+
+Exit codes are defined in `src/lib/exit-codes.ts`.

--- a/docs/research/asc-cli-architecture.md
+++ b/docs/research/asc-cli-architecture.md
@@ -1,0 +1,182 @@
+# Research: ASC CLI Architecture
+
+Analysis of the [App Store Connect CLI](https://github.com/rudrankriyam/App-Store-Connect-CLI) architecture patterns, focused on what mktg should adopt for agent-native CLI design.
+
+## 1. Exit Code System
+
+**Files:** `cmd/exit_codes.go`, `docs/EXIT_CODES.md`
+
+ASC uses a structured exit code system designed for CI/CD and agent consumption:
+
+```
+0    = Success
+1    = Generic error
+2    = Usage (invalid flags/commands)
+3    = Auth (missing, unauthorized, forbidden)
+4    = Not found
+5    = Conflict
+10-59 = HTTP 4xx mapped (10 + status - 400)
+60-99 = HTTP 5xx mapped (60 + status - 500)
+```
+
+**Key pattern:** `ExitCodeFromError()` is the single source of truth. Every error flows through this function — it checks sentinel errors (`ErrMissingAuth`, `ErrNotFound`, etc.), then falls back to HTTP status mapping, then defaults to 1.
+
+**What mktg adopts:**
+- Central `errorCodeToExitCode()` function as single mapping point
+- Distinct codes per failure class (no overloading)
+- Codes are documented and machine-readable
+- We skip the HTTP mapping (mktg doesn't wrap a single API) but keep the 0-9 CLI-level pattern
+
+## 2. Error Handling Patterns
+
+**Files:** `internal/cli/shared/errors.go`, `internal/cli/shared/errfmt/errfmt.go`
+
+ASC has three error handling layers:
+
+### Layer 1: Sentinel errors
+Well-known errors as package-level vars: `ErrMissingAuth`, `ErrNotFound`, `ErrConflict`, etc. Commands return these and the exit code mapper catches them.
+
+### Layer 2: Error classification + hints
+`errfmt.Classify()` takes an error, matches it against known types, and returns a `ClassifiedError` with a human message + actionable hint:
+```
+Error: missing authentication
+Hint: Run `asc auth login` or `asc auth init`
+```
+
+### Layer 3: ReportedError wrapper
+Errors that have already been printed to stderr get wrapped in `ReportedError`. The main run loop checks for this to avoid duplicate output.
+
+**What mktg adopts:**
+- Structured errors with `code`, `message`, and `suggestions` (our equivalent of hints)
+- Error constructors: `notFound()`, `invalidArgs()`, `missingDep()`, etc.
+- Never throw — return `CommandResult` with error data
+
+## 3. CLI Root & Command Structure
+
+**Files:** `cmd/root.go`, `cmd/root_usage.go`
+
+### Command tree
+ASC uses `ffcli` (a Go CLI library) with a tree of `*ffcli.Command` nodes. Commands are registered via a `registry.Subcommands()` function.
+
+### Unknown command handling
+When an unknown command is passed, ASC:
+1. Sanitizes the input (terminal escape prevention)
+2. Runs fuzzy suggestion matching
+3. Prints "Did you mean: ..."
+4. Returns `flag.ErrHelp` (exit code 2)
+
+### Custom usage/help
+`RootUsageFunc` renders grouped help (like `gh`):
+- Commands are organized into semantic groups (GETTING STARTED, APP MANAGEMENT, etc.)
+- Each group has a header with bold ANSI formatting
+- Tabwriter for aligned columns
+- Hidden deprecated commands (by ShortHelp prefix `DEPRECATED:`)
+- Ungrouped commands fall into "ADDITIONAL COMMANDS"
+
+**What mktg adopts:**
+- Grouped help output (foundation, strategy, execution, distribution)
+- Command suggestion on typos
+- Terminal input sanitization for security
+
+## 4. Internal Package Structure
+
+**Directory:** `internal/`
+
+ASC separates concerns cleanly:
+
+```
+internal/
+  asc/          — API client, HTTP, JSON serialization
+  auth/         — Credential management, keychain, profiles
+  cli/
+    shared/     — Shared CLI utilities (output, flags, errors, sanitization)
+    registry/   — Command registration
+    shared/
+      errfmt/   — Error formatting/classification
+      suggest/  — Command suggestion (fuzzy matching)
+  config/       — Configuration file management
+  validation/   — Input validation
+  ...
+```
+
+**Key insight:** `shared/` is the glue layer. It handles output formatting (JSON, table, markdown), flag binding, credential resolution, and progress spinners. Every command imports from `shared/`.
+
+**What mktg adopts:**
+- We already have `src/core/` as our shared layer
+- `src/lib/` for standalone utilities (like exit codes) that don't import command logic
+- Keep business logic (skills, brand) separate from CLI plumbing
+
+## 5. Output Formatting
+
+ASC supports three output formats: `json`, `table`, `markdown`. The format is controlled by:
+1. `--output` flag per command
+2. `ASC_DEFAULT_OUTPUT` env var
+3. Auto-detect: table for TTY, JSON for pipes
+
+Key patterns:
+- `--pretty` flag for indented JSON
+- Output validation happens before command execution (via `WrapCommandOutputValidation`)
+- NDJSON streaming with `--stream --paginate` for large result sets
+
+**What mktg adopts:**
+- We already have `--json` flag for JSON output
+- TTY detection for format switching is a good pattern to adopt
+- Output validation before execution prevents side effects on bad flags
+
+## 6. Agent-First Patterns
+
+Patterns that make ASC particularly agent-friendly:
+
+### Structured everything
+- Exit codes are numeric and documented
+- Errors have machine-readable codes
+- Output is JSON by default in non-TTY
+- JUnit report format for CI (`--report junit --report-file`)
+
+### Predictable behavior
+- `--version` fast path (avoids building entire command tree)
+- Signal handling (SIGINT via context cancellation)
+- Temp file cleanup on exit (`CleanupTempPrivateKeys`)
+- Progress output goes to stderr only (never pollutes stdout)
+
+### Security
+- `SanitizeTerminal()` on user input before printing (prevents terminal escape injection)
+- Private key temp files get 0600 permissions
+- Prototype pollution-style checks aren't needed in Go but mktg has them for JSON
+
+### Schema introspection
+ASC has a `schema` command that dumps the command tree structure. This lets agents discover available commands and their flags programmatically.
+
+**What mktg adopts:**
+- `mktg schema` for command introspection (already planned)
+- stderr-only for non-data output (progress, hints, warnings)
+- Signal handling and cleanup
+- JSON-by-default in non-TTY contexts
+
+## 7. Configuration & Flags
+
+ASC handles configuration through multiple layers:
+1. **Flags** — highest priority, per-command
+2. **Environment variables** — `ASC_*` prefix
+3. **Config file** — `~/.config/asc/config.json`
+4. **Keychain** — macOS keychain for credentials
+
+Root-level flags (`--profile`, `--debug`, `--strict-auth`) are bound once and read globally via `shared.SelectedProfile()` etc.
+
+**What mktg adopts:**
+- We use `--json`, `--dry-run`, `--fields` as global flags (already implemented)
+- Brand directory as our "config" layer
+- Consider env var support for CI (`MKTG_*` prefix)
+
+## Summary: What mktg Takes from ASC
+
+| Pattern | ASC Implementation | mktg Adoption |
+|---------|-------------------|---------------|
+| Exit codes | `ExitCodeFromError()` + HTTP mapping | `errorCodeToExitCode()` + CLI-level codes |
+| Error format | `ClassifiedError` with hints | `MktgError` with suggestions |
+| Error flow | Sentinel errors + central mapper | Error constructors + `CommandResult` |
+| Help output | Grouped by category, tabwriter | Same pattern for skill categories |
+| Output format | json/table/markdown with TTY detect | json flag + TTY detection |
+| Security | Terminal sanitization, file perms | JSON proto pollution checks, path sandbox |
+| Agent support | Schema introspection, JUnit reports | `mktg schema`, structured JSON errors |
+| Config layers | Flags > env > config > keychain | Flags > brand dir |

--- a/src/lib/exit-codes.ts
+++ b/src/lib/exit-codes.ts
@@ -1,0 +1,158 @@
+// mktg — Structured exit codes for agent-native CLI
+// Inspired by ASC CLI's exit code system (cmd/exit_codes.go).
+//
+// Design principles:
+// - Every exit code is a distinct, documented failure mode
+// - Agents parse exit codes to decide next action (retry, fix input, abort)
+// - Ranges are reserved for future HTTP/API status mapping
+// - 0 = success, 1 = generic, 2-9 = CLI-level, 10+ = reserved for future use
+
+/** All valid mktg exit codes. */
+export const ExitCode = {
+  /** Successful execution */
+  Success: 0,
+
+  /** Generic / unclassified error */
+  Error: 1,
+
+  /** Invalid usage — bad flags, missing args, unknown command */
+  Usage: 2,
+
+  /** Authentication failure — missing or invalid credentials */
+  Auth: 3,
+
+  /** Resource not found — file, skill, brand dir, project */
+  NotFound: 4,
+
+  /** Conflict — resource already exists, init already ran */
+  Conflict: 5,
+
+  /** Required dependency missing — bun, playwright-cli, gws, etc. */
+  DependencyMissing: 6,
+
+  /** Skill execution failed — a marketing skill errored during run */
+  SkillFailed: 7,
+
+  /** Network error — fetch failed, timeout, DNS, etc. */
+  Network: 8,
+
+  /** Not implemented — command exists but isn't built yet */
+  NotImplemented: 9,
+
+  /** Configuration error — invalid config file, bad brand dir state */
+  Config: 10,
+
+  /** Permission denied — file system, API quota, rate limit */
+  Permission: 11,
+
+  /** Timeout — operation exceeded time limit */
+  Timeout: 12,
+
+  /** Validation error — content failed schema or business rules */
+  Validation: 13,
+
+  /** I/O error — file read/write failure */
+  IO: 14,
+
+  /** Interrupted — user cancelled or SIGINT received */
+  Interrupted: 130,
+} as const;
+
+export type ExitCodeValue = (typeof ExitCode)[keyof typeof ExitCode];
+
+/** Human-readable label for each exit code. */
+export const exitCodeLabel = (code: ExitCodeValue): string => {
+  const labels: Record<ExitCodeValue, string> = {
+    [ExitCode.Success]: "success",
+    [ExitCode.Error]: "error",
+    [ExitCode.Usage]: "invalid usage",
+    [ExitCode.Auth]: "authentication failure",
+    [ExitCode.NotFound]: "not found",
+    [ExitCode.Conflict]: "conflict",
+    [ExitCode.DependencyMissing]: "dependency missing",
+    [ExitCode.SkillFailed]: "skill failed",
+    [ExitCode.Network]: "network error",
+    [ExitCode.NotImplemented]: "not implemented",
+    [ExitCode.Config]: "configuration error",
+    [ExitCode.Permission]: "permission denied",
+    [ExitCode.Timeout]: "timeout",
+    [ExitCode.Validation]: "validation error",
+    [ExitCode.IO]: "i/o error",
+    [ExitCode.Interrupted]: "interrupted",
+  };
+  return labels[code] ?? "unknown error";
+};
+
+/** Machine-readable error code strings (used in JSON output). */
+export const ErrorCode = {
+  // CLI-level
+  UNKNOWN: "UNKNOWN",
+  INVALID_USAGE: "INVALID_USAGE",
+  INVALID_ARGS: "INVALID_ARGS",
+  UNKNOWN_COMMAND: "UNKNOWN_COMMAND",
+  MISSING_INPUT: "MISSING_INPUT",
+
+  // Auth
+  MISSING_AUTH: "MISSING_AUTH",
+  AUTH_EXPIRED: "AUTH_EXPIRED",
+  AUTH_FORBIDDEN: "AUTH_FORBIDDEN",
+
+  // Resources
+  NOT_FOUND: "NOT_FOUND",
+  CONFLICT: "CONFLICT",
+  ALREADY_EXISTS: "ALREADY_EXISTS",
+
+  // Dependencies
+  MISSING_DEPENDENCY: "MISSING_DEPENDENCY",
+
+  // Skills
+  SKILL_FAILED: "SKILL_FAILED",
+  SKILL_NOT_FOUND: "SKILL_NOT_FOUND",
+
+  // Network
+  NETWORK_ERROR: "NETWORK_ERROR",
+  TIMEOUT: "TIMEOUT",
+
+  // File system
+  IO_ERROR: "IO_ERROR",
+  PERMISSION_DENIED: "PERMISSION_DENIED",
+
+  // Validation
+  VALIDATION_ERROR: "VALIDATION_ERROR",
+  CONFIG_ERROR: "CONFIG_ERROR",
+
+  // Meta
+  NOT_IMPLEMENTED: "NOT_IMPLEMENTED",
+  INTERRUPTED: "INTERRUPTED",
+} as const;
+
+export type ErrorCodeValue = (typeof ErrorCode)[keyof typeof ErrorCode];
+
+/** Map an error code string to the appropriate exit code. */
+export const errorCodeToExitCode = (code: ErrorCodeValue): ExitCodeValue => {
+  const mapping: Record<ErrorCodeValue, ExitCodeValue> = {
+    [ErrorCode.UNKNOWN]: ExitCode.Error,
+    [ErrorCode.INVALID_USAGE]: ExitCode.Usage,
+    [ErrorCode.INVALID_ARGS]: ExitCode.Usage,
+    [ErrorCode.UNKNOWN_COMMAND]: ExitCode.Usage,
+    [ErrorCode.MISSING_INPUT]: ExitCode.Usage,
+    [ErrorCode.MISSING_AUTH]: ExitCode.Auth,
+    [ErrorCode.AUTH_EXPIRED]: ExitCode.Auth,
+    [ErrorCode.AUTH_FORBIDDEN]: ExitCode.Auth,
+    [ErrorCode.NOT_FOUND]: ExitCode.NotFound,
+    [ErrorCode.CONFLICT]: ExitCode.Conflict,
+    [ErrorCode.ALREADY_EXISTS]: ExitCode.Conflict,
+    [ErrorCode.MISSING_DEPENDENCY]: ExitCode.DependencyMissing,
+    [ErrorCode.SKILL_FAILED]: ExitCode.SkillFailed,
+    [ErrorCode.SKILL_NOT_FOUND]: ExitCode.NotFound,
+    [ErrorCode.NETWORK_ERROR]: ExitCode.Network,
+    [ErrorCode.TIMEOUT]: ExitCode.Timeout,
+    [ErrorCode.IO_ERROR]: ExitCode.IO,
+    [ErrorCode.PERMISSION_DENIED]: ExitCode.Permission,
+    [ErrorCode.VALIDATION_ERROR]: ExitCode.Validation,
+    [ErrorCode.CONFIG_ERROR]: ExitCode.Config,
+    [ErrorCode.NOT_IMPLEMENTED]: ExitCode.NotImplemented,
+    [ErrorCode.INTERRUPTED]: ExitCode.Interrupted,
+  };
+  return mapping[code] ?? ExitCode.Error;
+};


### PR DESCRIPTION
## Summary

Closes #16

- **`src/lib/exit-codes.ts`** — 16 structured exit codes with error code string mapping, inspired by ASC CLI's `ExitCodeFromError` pattern. Includes `ExitCode` constants, `ErrorCode` string constants, `exitCodeLabel()`, and `errorCodeToExitCode()` mapper.
- **`docs/EXIT_CODES.md`** — Full documentation of exit codes, error code strings, JSON error format, and design principles. Includes comparison with ASC CLI's approach.
- **`docs/research/asc-cli-architecture.md`** — Deep analysis of ASC CLI's architecture covering: exit code system, 3-layer error handling, command structure with grouped help, internal package organization, output formatting (json/table/markdown with TTY detection), agent-first patterns, and configuration management.

## Key design decisions

- Codes 0-9 for CLI-level errors, 10-14 for operational errors, 130 for SIGINT (POSIX convention)
- No HTTP status mapping (unlike ASC) since mktg doesn't wrap a single API
- Paired numeric exit codes with string error codes for richer agent context
- Central `errorCodeToExitCode()` as single source of truth (mirrors ASC's pattern)

## Test plan

- [x] All 525 existing tests pass
- [x] No existing files modified
- [x] TypeScript compiles without errors