### PR TITLE
feat: add deepen-plan and document-review marketing skills

### DIFF
--- a/skills/deepen-plan/SKILL.md
+++ b/skills/deepen-plan/SKILL.md
@@ -1,0 +1,320 @@
+---
+name: deepen-plan
+description: "Enhance a marketing plan with parallel research agents for each section to add depth, best practices, and implementation details. Use when a marketing plan, launch plan, content calendar, or campaign brief exists and needs deeper research — audience insights, competitive analysis, keyword data, channel-specific best practices."
+argument-hint: "[path to plan file]"
+metadata:
+  version: 1.0.0
+category: strategy
+tier: meta
+reads:
+  - brand/voice-profile.md
+  - brand/positioning.md
+  - brand/audience.md
+  - brand/learnings.md
+writes: []
+triggers:
+  - deepen plan
+  - research plan
+  - enhance plan
+  - add depth
+---
+
+# Deepen Plan — Marketing Research Enhancement
+
+**Note: The current year is 2026.** Use this when searching for recent marketing data and best practices.
+
+This command takes an existing marketing plan and enhances each section with parallel research agents. Each major element gets its own dedicated research sub-agent to find:
+- Audience insights and buyer psychology
+- Competitive positioning and differentiation opportunities
+- Keyword and SEO data for content sections
+- Channel-specific best practices (email, social, landing pages)
+- Conversion optimization patterns
+- Real-world marketing examples and benchmarks
+
+The result is a deeply grounded, execution-ready marketing plan with concrete tactics and data.
+
+## Plan File
+
+<plan_path> #$ARGUMENTS </plan_path>
+
+**If the plan path above is empty:**
+1. Check for recent plans: `ls -la marketing/` and `ls -la docs/plans/`
+2. Ask the user: "Which marketing plan would you like to deepen? Please provide the path."
+
+Do not proceed until you have a valid plan file path.
+
+## On Activation
+
+1. Check if `brand/` directory exists in the project root.
+2. If it does, read available files: `voice-profile.md`, `positioning.md`, `audience.md`, `learnings.md`.
+3. Use brand context to ground all research in the project's specific positioning.
+4. If `brand/` does not exist, proceed without it — this skill works standalone.
+
+## Main Tasks
+
+### 1. Parse and Analyze Plan Structure
+
+Read the plan file and extract:
+- [ ] Goal or objective statement
+- [ ] Target audience sections
+- [ ] Channel strategy (email, social, SEO, ads, etc.)
+- [ ] Content deliverables (landing pages, emails, blog posts, etc.)
+- [ ] Timeline or phases
+- [ ] Success metrics or KPIs
+- [ ] Budget or resource constraints
+- [ ] Competitive context
+
+**Create a section manifest:**
+```
+Section 1: [Title] — [What marketing research would strengthen this]
+Section 2: [Title] — [What marketing research would strengthen this]
+...
+```
+
+### 2. Discover and Apply Available Marketing Skills
+
+**Step 1: Discover marketing skills from the mktg installation**
+
+```bash
+# Check for mktg skills
+mktg list 2>/dev/null || true
+
+# Check local skills directory
+ls skills/
+
+# Check installed skill locations
+ls ~/.claude/skills/ 2>/dev/null
+```
+
+**Step 2: Match skills to plan sections**
+
+For each section in the plan, identify which marketing skills could enhance it:
+
+| Plan Section | Relevant Skills |
+|---|---|
+| Audience/personas | `audience-research`, `marketing-psychology` |
+| Positioning | `positioning-angles`, `competitive-intel` |
+| Content strategy | `seo-content`, `keyword-research`, `content-atomizer` |
+| Email campaigns | `email-sequences`, `direct-response-copy` |
+| Landing pages | `page-cro`, `direct-response-copy` |
+| Launch timeline | `launch-strategy` |
+| Pricing | `pricing-strategy` |
+| Social media | `content-atomizer` |
+| SEO | `seo-audit`, `ai-seo`, `keyword-research` |
+| Lead generation | `lead-magnet`, `free-tool-strategy` |
+| Retention | `churn-prevention`, `referral-program` |
+| Conversion | `conversion-flow-cro`, `page-cro` |
+
+**Step 3: Spawn a sub-agent for EVERY matched skill**
+
+For each matched skill, spawn a separate sub-agent:
+
+```
+Task general-purpose: "You have the [skill-name] skill available at skills/[skill-name]/SKILL.md.
+
+YOUR JOB: Use this skill to research and enhance this section of the marketing plan.
+
+1. Read the skill: cat skills/[skill-name]/SKILL.md
+2. Apply the skill's domain expertise to this content:
+
+[relevant plan section]
+
+3. Return concrete recommendations, examples, and data points.
+
+Do NOT execute the full skill workflow — just use its expertise to provide research insights for the plan."
+```
+
+**Spawn ALL skill sub-agents in PARALLEL.** One sub-agent per matched skill, all running simultaneously.
+
+### 3. Launch Per-Section Research Agents
+
+For each major section in the plan, spawn dedicated research sub-agents:
+
+**Audience Research Agent:**
+```
+Task Explore: "Research audience insights for [target audience].
+Find:
+- Demographics and psychographics
+- Pain points and motivations
+- Where they spend time online
+- What content formats they prefer
+- Buying behavior patterns
+Return concrete, data-backed insights."
+```
+
+**Competitive Research Agent:**
+```
+Task Explore: "Research competitors in the [market/niche] space.
+Find:
+- How competitors position themselves
+- Their content strategy and channels
+- Pricing and packaging approaches
+- Gaps and differentiation opportunities
+- What's working for them (and what isn't)
+Return actionable competitive intelligence."
+```
+
+**Keyword Research Agent:**
+```
+Task Explore: "Research keywords and search intent for [topic/product].
+Find:
+- High-intent keywords with reasonable competition
+- Long-tail opportunities
+- Content gaps in search results
+- Questions people ask (PAA, forums, Reddit)
+- Trending topics in this space
+Return keyword clusters with intent mapping."
+```
+
+**Channel Best Practices Agent:**
+```
+Task Explore: "Research current best practices for [channels mentioned in plan].
+Find:
+- Platform-specific tactics (2025-2026)
+- Optimal posting times, formats, lengths
+- Algorithm changes and how to adapt
+- High-performing examples in this niche
+Return channel-by-channel playbook."
+```
+
+**Also use web search for current marketing data:**
+Search for recent (2025-2026) benchmarks, case studies, and tactics relevant to the plan's channels and audience.
+
+### 4. Check Brand Learnings
+
+If `brand/learnings.md` exists, read it and check for:
+- Past campaign results that inform this plan
+- What has worked or failed before
+- Audience preferences discovered from prior marketing
+- Channel performance data
+
+Incorporate relevant learnings into the research synthesis.
+
+### 5. Synthesize All Research
+
+**Collect outputs from ALL sources:**
+
+1. **Skill-based sub-agents** — Domain expertise from matched marketing skills
+2. **Audience research** — Demographics, psychographics, behavior data
+3. **Competitive research** — Positioning gaps, differentiation opportunities
+4. **Keyword research** — SEO data, content gaps, search intent
+5. **Channel research** — Platform-specific best practices
+6. **Brand learnings** — Historical performance data
+
+**For each agent's findings, extract:**
+- [ ] Concrete recommendations (actionable tactics)
+- [ ] Data points and benchmarks (numbers to target)
+- [ ] Examples and templates (copy-paste ready)
+- [ ] Anti-patterns to avoid (common mistakes)
+- [ ] Channel-specific optimizations
+- [ ] Audience insights that affect messaging
+
+**Deduplicate and prioritize:**
+- Merge similar recommendations from multiple agents
+- Prioritize by expected impact on plan goals
+- Flag conflicting advice for human review
+- Group by plan section
+
+### 6. Enhance Plan Sections
+
+**Enhancement format for each section:**
+
+```markdown
+## [Original Section Title]
+
+[Original content preserved]
+
+### Research Insights
+
+**Audience Data:**
+- [Insight backed by research]
+- [Behavioral pattern discovered]
+
+**Competitive Landscape:**
+- [Gap or opportunity identified]
+- [Differentiation angle]
+
+**Best Practices:**
+- [Concrete tactic with supporting data]
+- [Platform-specific optimization]
+
+**Recommended Tactics:**
+- [Specific action item with expected outcome]
+- [Template or example to follow]
+
+**Benchmarks:**
+- [Industry metric to target]
+- [Realistic KPI based on research]
+
+**References:**
+- [Source 1]
+- [Source 2]
+```
+
+### 7. Add Enhancement Summary
+
+At the top of the plan, add:
+
+```markdown
+## Enhancement Summary
+
+**Deepened on:** [Date]
+**Sections enhanced:** [Count]
+**Research agents used:** [List]
+
+### Key Improvements
+1. [Major improvement 1]
+2. [Major improvement 2]
+3. [Major improvement 3]
+
+### New Opportunities Discovered
+- [Finding 1]
+- [Finding 2]
+```
+
+### 8. Update Plan File
+
+Write the enhanced plan:
+- Preserve original filename
+- Add `-deepened` suffix if user prefers a new file
+- Update any timestamps or metadata
+
+## Output Format
+
+Update the plan file in place (or create a `-deepened` variant if requested).
+
+## Quality Checks
+
+Before finalizing:
+- [ ] All original content preserved
+- [ ] Research insights clearly marked and attributed
+- [ ] Recommendations are specific and actionable (not generic advice)
+- [ ] Data points include sources where possible
+- [ ] No contradictions between sections
+- [ ] Enhancement summary accurately reflects changes
+- [ ] Brand context applied consistently (if available)
+
+## Post-Enhancement Options
+
+After writing the enhanced plan, ask:
+
+**Question:** "Plan deepened at `[plan_path]`. What would you like to do next?"
+
+**Options:**
+1. **View diff** — Show what was added/changed
+2. **Review document** — Run `/document-review` on the enhanced plan
+3. **Start executing** — Begin implementing the marketing plan
+4. **Deepen further** — Run another round of research on specific sections
+5. **Revert** — Restore original plan
+
+## mktg CLI Integration
+
+Where relevant, reference these `mktg` commands in recommendations:
+- `mktg audit` — Run marketing analysis on the project
+- `mktg content` — Generate specific content types from the plan
+- `mktg social` — Generate social content
+- `mktg email` — Generate email sequences
+- `mktg calendar` — Create a 30-day content calendar from the plan
+- `mktg launch` — Execute the full launch package
+
+NEVER CODE! Just research and enhance the marketing plan.

--- a/skills/document-review/SKILL.md
+++ b/skills/document-review/SKILL.md
@@ -1,0 +1,208 @@
+---
+name: document-review
+description: "Review marketing documents (brand guides, content calendars, campaign briefs, launch plans, positioning docs) for completeness, clarity, and actionability. Use when a marketing document exists and needs refinement before execution."
+metadata:
+  version: 1.0.0
+category: strategy
+tier: meta
+reads:
+  - brand/voice-profile.md
+  - brand/positioning.md
+  - brand/audience.md
+triggers:
+  - review document
+  - review plan
+  - review brief
+  - check document
+  - refine plan
+---
+
+# Document Review — Marketing Document Refinement
+
+Improve marketing documents through structured review, ensuring they are clear, complete, and ready for execution.
+
+## Step 1: Get the Document
+
+**If a document path is provided:** Read it, then proceed to Step 2.
+
+**If no document is specified:** Ask which document to review, or look for the most recent marketing document in:
+- `marketing/` — campaign briefs, content calendars, email sequences
+- `brand/` — brand guides, voice profiles, positioning docs
+- `docs/plans/` — marketing plans, launch plans
+
+## On Activation
+
+1. Check if `brand/` directory exists in the project root.
+2. If it does, read available files: `voice-profile.md`, `positioning.md`, `audience.md`.
+3. Use brand context to evaluate whether the document aligns with established brand direction.
+4. If `brand/` does not exist, proceed without it — this skill works standalone.
+
+## Step 2: Identify Document Type
+
+Classify the document to apply the right review criteria:
+
+| Document Type | Key Review Focus |
+|---|---|
+| **Brand guide** | Consistency, completeness of voice/visual/messaging sections |
+| **Content calendar** | Coverage across channels, realistic cadence, variety |
+| **Campaign brief** | Clear objective, defined audience, measurable success criteria |
+| **Launch plan** | Timeline feasibility, channel coverage, pre/during/post phases |
+| **Positioning doc** | Differentiation clarity, audience alignment, proof points |
+| **Email sequence** | Flow logic, CTA progression, value-to-ask ratio |
+| **Landing page copy** | Headline clarity, benefit focus, objection handling |
+| **SEO content plan** | Keyword coverage, intent mapping, content gaps |
+
+## Step 3: Assess
+
+Read through the document and ask:
+
+**Clarity:**
+- Is the goal or objective crystal clear?
+- Would someone executing this know exactly what to do?
+- Are there vague phrases ("consider," "explore," "possibly") that need to be concrete?
+
+**Completeness:**
+- Are all required sections present for this document type?
+- Is the target audience defined specifically (not just "our users")?
+- Are success metrics defined and measurable?
+- Are timelines or deadlines specified?
+- Are channels and tactics named, not just categories?
+
+**Actionability:**
+- Can someone execute this tomorrow without asking clarifying questions?
+- Are deliverables specific (not "create content" but "write 3 LinkedIn posts targeting X")?
+- Are dependencies and prerequisites called out?
+
+**Brand Alignment** (if `brand/` context is loaded):
+- Does the messaging match the brand voice profile?
+- Is the positioning consistent with the positioning doc?
+- Does the audience match the defined buyer personas?
+
+**Marketing Effectiveness:**
+- Is there a clear value proposition or hook?
+- Are there conversion points defined?
+- Is there a follow-up or nurture strategy?
+- Is the content-to-promotion ratio reasonable?
+
+These questions surface issues. Don't fix yet — just note what you find.
+
+## Step 4: Evaluate
+
+Score the document against these criteria:
+
+| Criterion | What to Check |
+|---|---|
+| **Clarity** | Goal is explicit, no vague language, audience is specific |
+| **Completeness** | All sections for this doc type present, metrics defined, timeline set |
+| **Actionability** | Specific enough to execute — deliverables, channels, owners, dates |
+| **Brand Consistency** | Aligns with voice, positioning, and audience (if brand/ exists) |
+| **YAGNI** | No hypothetical campaigns, simplest approach chosen, focused scope |
+
+Rate each criterion: Strong / Adequate / Needs Work / Missing
+
+## Step 5: Identify the Critical Improvement
+
+Among everything found in Steps 3-4, does one issue stand out? Common critical issues in marketing documents:
+
+- **No clear objective** — The doc describes activities but not the goal
+- **Undefined audience** — Generic targeting that leads to generic content
+- **Missing metrics** — No way to know if the marketing worked
+- **No conversion path** — Content strategy without CTAs or next steps
+- **Unrealistic scope** — Too much for the timeline or resources available
+- **Brand disconnect** — Messaging doesn't match established positioning
+
+Highlight the single most impactful improvement prominently.
+
+## Step 6: Make Changes
+
+Present your findings, then:
+
+1. **Auto-fix** minor issues without asking:
+   - Vague language → specific language
+   - Missing metric placeholders → add "[define metric]" markers
+   - Formatting inconsistencies
+   - Unclear timelines → add "[specify date]" markers
+
+2. **Ask approval** before substantive changes:
+   - Restructuring sections
+   - Removing content
+   - Changing the target audience or positioning
+   - Altering the campaign strategy or channel mix
+
+3. **Update** the document inline — no separate files, no metadata sections
+
+### Simplification Guidance
+
+**Simplify when:**
+- Content serves hypothetical future campaigns, not the current one
+- Sections repeat information already in `brand/` files
+- Detail exceeds what's needed to start execution
+- Multiple channels are listed "just in case" without commitment
+
+**Don't simplify:**
+- Audience segmentation that affects messaging
+- Rationale for why a channel or tactic was chosen
+- Competitive context that informs positioning
+- Open questions that need resolution before execution
+
+### Marketing-Specific Checks
+
+Run these additional checks based on document type:
+
+**For content calendars:**
+- Is there variety in content types (not all blog posts)?
+- Are promotional vs. value posts balanced?
+- Are key dates and events incorporated?
+- Is the cadence sustainable?
+
+**For email sequences:**
+- Does the first email deliver immediate value?
+- Is there a clear escalation toward the CTA?
+- Are subject lines specific (not generic)?
+- Is there a re-engagement path for non-openers?
+
+**For launch plans:**
+- Are pre-launch, launch day, and post-launch phases defined?
+- Is there a specific ask or CTA for launch day?
+- Are distribution channels listed with specific actions?
+- Is there a contingency if the primary channel underperforms?
+
+**For landing pages:**
+- Is the headline benefit-focused (not feature-focused)?
+- Are objections addressed?
+- Is social proof or credibility included?
+- Is there exactly one clear CTA?
+
+## Step 7: Suggest mktg CLI Commands
+
+Where relevant, suggest `mktg` commands that could enhance the document:
+
+- `mktg audit` — If the document lacks competitive context or market data
+- `mktg content` — If the document needs specific content pieces generated
+- `mktg calendar` — If the content calendar section needs fleshing out
+- `mktg social` — If social media tactics need specific post examples
+- `mktg email` — If email sequences need drafting
+- `mktg doctor` — If brand context seems incomplete or outdated
+
+## Step 8: Offer Next Action
+
+After changes are complete, ask:
+
+1. **Refine again** — Another review pass
+2. **Deepen** — Run `/deepen-plan` to add research depth
+3. **Review complete** — Document is ready for execution
+
+### Iteration Guidance
+
+After 2 refinement passes, recommend completion — diminishing returns are likely. But if the user wants to continue, allow it.
+
+Return control to the caller (workflow or user) after selection.
+
+## What NOT to Do
+
+- Do not rewrite the entire document
+- Do not add new campaigns or channels the user didn't discuss
+- Do not over-engineer or add complexity
+- Do not create separate review files or add metadata sections
+- Do not add generic marketing advice — be specific to this document
+- Do not remove competitive context or rationale sections


### PR DESCRIPTION
## Summary

Closes #5

- **`skills/deepen-plan/SKILL.md`** — Enhances marketing plans with parallel research agents. Spawns sub-agents for audience research, competitive analysis, keyword data, and channel-specific best practices. Adapts CE's multi-agent research pattern for marketing context.
- **`skills/document-review/SKILL.md`** — Structured review of marketing documents (brand guides, content calendars, campaign briefs, launch plans) for clarity, completeness, actionability, and brand alignment. Includes document-type-specific checklists.

Both skills follow the existing SKILL.md format with frontmatter metadata, integrate with `brand/` context, and reference `mktg` CLI commands where relevant.

## Test plan

- [x] All 525 existing tests pass
- [x] No src/ files modified
- [x] No existing skills modified
- [x] Skills follow CE SKILL.md format (frontmatter + structured workflow)
- [x] Marketing-domain specific research and review patterns
- [x] References mktg CLI commands (`mktg audit`, `mktg content`, `mktg calendar`, etc.)