### PR TITLE
feat: add skill-creator skill for creating new marketing skills

### DIFF
--- a/skills/create-skill/SKILL.md
+++ b/skills/create-skill/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: create-skill
+description: >
+  Create new marketing skills for the mktg system. Use when building a new
+  skill from scratch, when porting an existing workflow into a skill, or when
+  the user says "create a skill", "new skill", "build a marketing skill".
+  Guides through requirements gathering, structure decisions, content writing,
+  and validation. Produces a complete skill directory with SKILL.md and
+  optional supporting files. Dependencies: none (meta-skill).
+category: meta
+tier: foundation
+triggers:
+  - create a skill
+  - new skill
+  - build a marketing skill
+  - add a skill
+  - make a skill
+---
+
+## On Activation
+
+1. Read `references/skill-structure.md` for the required format and fields.
+2. Read `templates/marketing-skill.md` for the output template.
+3. Read `workflows/create-new-skill.md` for the step-by-step process.
+
+# /create-skill — Marketing Skill Creator
+
+Every skill in the mktg system follows a consistent pattern. This meta-skill
+teaches you how to create new marketing skills that integrate seamlessly with
+the existing system — proper frontmatter, brand context loading, progressive
+disclosure, and the right level of actionable detail.
+
+## Quick Start
+
+When the user wants to create a new marketing skill:
+
+1. **Gather requirements** — What marketing problem does this skill solve? What are
+   the inputs and outputs? Does it read from or write to `brand/`?
+2. **Choose structure** — Simple (single SKILL.md) or complex (with workflows,
+   references, templates)?
+3. **Write the skill** — Use the template from `templates/marketing-skill.md`
+4. **Validate** — Run through the checklist in `references/skill-structure.md`
+
+## What Would You Like To Do?
+
+1. **Create a new marketing skill** — Build from scratch following the mktg pattern
+2. **Port an existing workflow** — Convert a manual process into a reusable skill
+3. **Get guidance** — Understand how mktg skills work before building
+
+For option 1 or 2, follow `workflows/create-new-skill.md`.
+For option 3, read `references/skill-structure.md`.
+
+## Key Principles
+
+### Brand Context Pattern
+
+Every mktg skill follows the same brand context loading pattern:
+
+```markdown
+## On Activation
+
+1. Check if `brand/` directory exists in the project root.
+2. If it does, read available files: `voice-profile.md`, `positioning.md`,
+   `audience.md`, `creative-kit.md`, `stack.md`, `learnings.md`.
+3. Apply any loaded brand context to enhance output quality.
+4. If `brand/` does not exist, proceed without it — this skill works standalone.
+```
+
+This is **required** for any skill that produces marketing content. Skills that
+are purely analytical (audit, research) should still read brand context but note
+that it's optional.
+
+### Progressive Enhancement
+
+Every skill must work at zero context. Brand memory enhances output quality but
+never gates functionality. A user with no `brand/` directory should still get
+useful output.
+
+### Frontmatter Conventions
+
+mktg skills use extended frontmatter beyond the standard Claude Code fields:
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `category` | Yes | One of: brand, content, growth, analytics, meta |
+| `tier` | Yes | One of: foundation, growth, advanced |
+| `reads` | No | Brand files this skill reads from |
+| `writes` | No | Brand files this skill writes to |
+| `triggers` | Yes | Phrases that should activate this skill |
+
+### File Size Rule
+
+Keep SKILL.md under 500 lines. If a skill needs more detail, split into:
+- `references/` — Domain knowledge the skill needs
+- `workflows/` — Step-by-step procedures
+- `templates/` — Output structures to copy and fill
+
+## Reference Files
+
+- [skill-structure.md](references/skill-structure.md) — Complete format reference
+- [marketing-skill.md](templates/marketing-skill.md) — Template for new skills
+- [create-new-skill.md](workflows/create-new-skill.md) — Step-by-step workflow
+
+## Success Criteria
+
+A new skill is complete when:
+- [ ] SKILL.md has valid frontmatter with all required mktg fields
+- [ ] Description includes what it does AND trigger conditions
+- [ ] Brand context loading pattern is present (if content-producing)
+- [ ] Skill works standalone without `brand/` directory
+- [ ] All referenced files exist and are properly linked
+- [ ] SKILL.md is under 500 lines
+- [ ] Tested with a real invocation

--- a/skills/create-skill/references/skill-structure.md
+++ b/skills/create-skill/references/skill-structure.md
@@ -1,0 +1,169 @@
+# Skill Structure Reference
+
+This document defines the format and conventions for mktg marketing skills.
+
+## Directory Layout
+
+Every skill lives in `skills/{skill-name}/` with at minimum a `SKILL.md` file:
+
+```
+skills/{skill-name}/
+├── SKILL.md              # Entry point (required)
+├── workflows/            # Step-by-step procedures (optional)
+│   └── {workflow}.md
+├── references/           # Domain knowledge (optional)
+│   └── {reference}.md
+└── templates/            # Output structures (optional)
+    └── {template}.md
+```
+
+**Rules:**
+- Directory name must match the `name` field in frontmatter
+- Use lowercase-with-hyphens for all names
+- Keep SKILL.md under 500 lines
+- Keep supporting files one level deep from SKILL.md
+- Use forward slashes in all file paths
+
+## Frontmatter Format
+
+### Standard Claude Code Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | No | Lowercase letters, numbers, hyphens. Max 64 chars. Defaults to directory name. |
+| `description` | Yes | What it does AND when to use it. Max 1024 chars. |
+| `argument-hint` | No | Hint for autocomplete, e.g., `[url]` |
+| `disable-model-invocation` | No | `true` to prevent auto-loading. For side-effect skills. |
+| `user-invocable` | No | `false` to hide from `/` menu. For background knowledge. |
+| `allowed-tools` | No | Tools without permission prompts. |
+| `model` | No | `haiku`, `sonnet`, or `opus` |
+| `context` | No | `fork` for isolated subagent execution |
+| `agent` | No | Subagent type when using `context: fork` |
+
+### mktg Extension Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `category` | Yes | `brand`, `content`, `growth`, `analytics`, or `meta` |
+| `tier` | Yes | `foundation`, `growth`, or `advanced` |
+| `reads` | No | List of `brand/` files this skill reads |
+| `writes` | No | List of `brand/` files this skill writes |
+| `triggers` | Yes | Natural language phrases that should activate this skill |
+
+### Category Definitions
+
+- **brand** — Define or extract brand identity (voice, positioning, audience)
+- **content** — Produce marketing content (copy, emails, SEO, social posts)
+- **growth** — Drive acquisition or retention (launch, referral, pricing, lead magnets)
+- **analytics** — Measure or analyze (audit, competitive intel, CRO)
+- **meta** — Skills about the system itself (create-skill, cmo)
+
+### Tier Definitions
+
+- **foundation** — Works standalone, zero dependencies. Entry point skills.
+- **growth** — Enhanced by foundation outputs (voice profile, positioning, audience).
+- **advanced** — Orchestrates multiple skills or requires significant brand context.
+
+## Body Structure
+
+### Required Sections
+
+Every mktg skill must have:
+
+1. **On Activation** — Brand context loading instructions
+2. **Title + Hook** — Why this skill exists (under the `# /skill-name` heading)
+3. **Quick Start** — First 3-5 actions when invoked
+4. **Core Process** — Step-by-step instructions
+5. **Success Criteria** — Measurable completion checklist
+
+### On Activation Pattern
+
+Every content-producing skill must include this exact pattern:
+
+```markdown
+## On Activation
+
+1. Check if `brand/` directory exists in the project root.
+2. If it does, read available files: `voice-profile.md`, `positioning.md`,
+   `audience.md`, `creative-kit.md`, `stack.md`, `learnings.md`.
+3. Apply any loaded brand context to enhance output quality.
+4. If `brand/` does not exist, proceed without it — this skill works standalone.
+```
+
+### Heading Convention
+
+Use standard markdown headings (`##`, `###`). The SKILL.md body follows this
+hierarchy:
+
+```
+## On Activation
+# /skill-name — Skill Title        (H1 — only one per file)
+## Quick Start
+## Core Process
+### Step 1: ...
+### Step 2: ...
+## Output Format
+## Guidelines
+## Success Criteria
+```
+
+## Description Best Practices
+
+The description is how Claude discovers and activates skills. It must include:
+
+1. **What it does** — Concrete action, not vague ("Define brand voice" not "Help with branding")
+2. **When to use it** — Trigger conditions ("Use when starting a project, when copy sounds generic")
+3. **What it produces** — Output type ("Outputs a voice profile saved to brand/voice-profile.md")
+4. **Dependencies** — What other skills enhance it ("Dependencies: none" or "Dependencies: brand-voice")
+
+**Good:**
+```yaml
+description: >
+  Build email sequences that convert subscribers into customers. Use when
+  setting up onboarding, nurture, or launch email flows. Outputs complete
+  email sequences with subject lines, body copy, and send timing.
+  Dependencies: brand-voice, audience-research. Reads: voice-profile.md,
+  audience.md. Writes: none (outputs to marketing/emails/).
+```
+
+**Bad:**
+```yaml
+description: Helps write emails
+```
+
+## Trigger Best Practices
+
+Triggers should be natural language phrases a user would actually say:
+
+- Include 3-5 triggers per skill
+- Mix action phrases ("write email sequence") and problem phrases ("my emails aren't converting")
+- Use lowercase
+- Be specific enough to avoid false matches
+
+## Anti-Patterns
+
+| Anti-Pattern | Why It's Bad | Do This Instead |
+|---|---|---|
+| Vague description | Agent can't decide when to activate | Include what, when, and output |
+| No On Activation | Brand context never loads | Always include the pattern |
+| Gates on brand context | Skill fails without `brand/` | Progressive enhancement — works at zero context |
+| Over 500 lines | Agent loads too much context | Split into references/workflows |
+| Generic triggers | False activations | Be specific to the skill's domain |
+| Hard-coded paths | Breaks in different project structures | Use relative paths from project root |
+
+## Validation Checklist
+
+Before finalizing any skill:
+
+- [ ] YAML frontmatter is valid
+- [ ] `name` matches directory name (lowercase-with-hyphens)
+- [ ] `description` includes what, when, output, and dependencies
+- [ ] `category` is one of: brand, content, growth, analytics, meta
+- [ ] `tier` is one of: foundation, growth, advanced
+- [ ] `triggers` has 3-5 natural language phrases
+- [ ] On Activation section present (if content-producing)
+- [ ] Works without `brand/` directory
+- [ ] SKILL.md under 500 lines
+- [ ] All referenced files exist and are properly linked
+- [ ] Success criteria are measurable
+- [ ] Tested with real invocation

--- a/skills/create-skill/templates/marketing-skill.md
+++ b/skills/create-skill/templates/marketing-skill.md
@@ -1,0 +1,117 @@
+# Marketing Skill Template
+
+Copy this template when creating a new mktg skill. Replace all `{{PLACEHOLDER}}`
+values with your skill's specifics.
+
+---
+
+```markdown
+---
+name: {{skill-name}}
+description: >
+  {{What this skill does in 1-2 sentences}}. Use when {{trigger conditions —
+  be specific about when the agent should activate this}}. Outputs {{what it
+  produces}}. Dependencies: {{other skills or "none"}}.
+  Reads: {{brand files it reads, e.g., "positioning.md, audience.md"}}.
+  Writes: {{brand files it writes, e.g., "content-calendar.md"}}.
+category: {{brand | content | growth | analytics | meta}}
+tier: {{foundation | growth | advanced}}
+reads:
+  - brand/{{file-it-reads}}.md
+writes:
+  - brand/{{file-it-writes}}.md
+triggers:
+  - {{trigger phrase 1}}
+  - {{trigger phrase 2}}
+  - {{trigger phrase 3}}
+---
+
+
+## On Activation
+
+1. Check if `brand/` directory exists in the project root.
+2. If it does, read available files: `voice-profile.md`, `positioning.md`,
+   `audience.md`, `creative-kit.md`, `stack.md`, `learnings.md`.
+3. Apply any loaded brand context to enhance output quality.
+4. If `brand/` does not exist, proceed without it — this skill works standalone.
+
+# /{{skill-name}} — {{Skill Title}}
+
+{{1-3 sentences explaining WHY this skill exists. What problem does it solve?
+What's the insight that makes this approach better than the obvious one?}}
+
+## Quick Start
+
+{{Immediate actionable guidance. What should the agent do FIRST when this
+skill is invoked? Keep it to 3-5 steps.}}
+
+1. {{First action}}
+2. {{Second action}}
+3. {{Third action}}
+
+## Core Process
+
+### Step 1: {{Phase Name}}
+
+{{Detailed instructions for this phase. Be specific — agents follow
+instructions literally.}}
+
+### Step 2: {{Phase Name}}
+
+{{Next phase. Include decision points and branching logic if needed.}}
+
+### Step 3: {{Phase Name}}
+
+{{Final phase. Include output format expectations.}}
+
+## Output Format
+
+{{Describe exactly what the skill should produce. Include a markdown template
+if the output is a document.}}
+
+```markdown
+# {{Output Title}}
+
+## {{Section 1}}
+{{What goes here}}
+
+## {{Section 2}}
+{{What goes here}}
+```
+
+## Guidelines
+
+- {{Rule 1 — what to always do}}
+- {{Rule 2 — what to never do}}
+- {{Rule 3 — quality standard}}
+
+## Success Criteria
+
+{{Skill name}} is complete when:
+- [ ] {{First measurable outcome}}
+- [ ] {{Second measurable outcome}}
+- [ ] {{Third measurable outcome}}
+- [ ] Output saved to {{where it goes}}
+```
+
+---
+
+## Template Notes
+
+**Category definitions:**
+- `brand` — Skills that define or extract brand identity (voice, positioning, audience)
+- `content` — Skills that produce marketing content (copy, emails, SEO, social)
+- `growth` — Skills that drive acquisition or retention (launch, referral, pricing)
+- `analytics` — Skills that measure or analyze (audit, competitive intel, CRO)
+- `meta` — Skills about the system itself (create-skill, cmo)
+
+**Tier definitions:**
+- `foundation` — Works standalone, no dependencies on other skills
+- `growth` — Enhanced by foundation skill outputs (e.g., better with voice profile)
+- `advanced` — Orchestrates multiple skills or requires significant brand context
+
+**Trigger best practices:**
+- Use natural language phrases the user would actually say
+- Include 3-5 triggers covering different phrasings
+- Include both action phrases ("write email sequence") and problem phrases
+  ("my emails aren't converting")

--- a/skills/create-skill/workflows/create-new-skill.md
+++ b/skills/create-skill/workflows/create-new-skill.md
@@ -1,0 +1,152 @@
+# Workflow: Create a New Marketing Skill
+
+Follow these steps to create a new skill for the mktg system.
+
+## Step 1: Gather Requirements
+
+**If the user provided context** (e.g., "build a skill for email onboarding"):
+- Analyze what's stated, what can be inferred, what's unclear
+- Skip to asking about genuine gaps only
+
+**If the user just invoked without context:**
+- Ask what marketing problem this skill solves
+
+### Questions to Resolve
+
+Answer these before proceeding — ask the user if unclear:
+
+1. **What does this skill do?** — One sentence: "This skill helps agents ___."
+2. **What triggers it?** — When should an agent activate this? What would a user say?
+3. **What does it produce?** — Specific output: a document, a file, a plan, analysis?
+4. **Where does output go?** — Does it write to `brand/`? To `marketing/`? Stdout only?
+5. **What brand context does it need?** — Which `brand/` files improve its output?
+6. **What category?** — brand, content, growth, analytics, or meta?
+7. **What tier?** — Does it work standalone (foundation), benefit from brand context
+   (growth), or orchestrate other skills (advanced)?
+
+### Decision Gate
+
+After gathering requirements, confirm with the user:
+"Here's what I'll build: [summary]. Ready to proceed?"
+
+## Step 2: Choose Structure
+
+**Simple skill** — Use when:
+- Single workflow, under 200 lines
+- No domain knowledge that needs separate reference files
+- One clear process from start to finish
+
+→ Create only `skills/{name}/SKILL.md`
+
+**Complex skill** — Use when:
+- Multiple distinct modes or workflows
+- Significant domain knowledge that would bloat SKILL.md
+- Templates needed for consistent output
+- Skill will likely grow over time
+
+→ Create the full directory:
+```
+skills/{name}/
+├── SKILL.md
+├── workflows/
+│   └── {workflow-name}.md
+├── references/
+│   └── {reference-name}.md
+└── templates/
+    └── {template-name}.md
+```
+
+Most marketing skills are simple. Only use complex structure when genuinely needed.
+
+## Step 3: Create the Skill
+
+### 3a: Write the Frontmatter
+
+```yaml
+---
+name: {skill-name}
+description: >
+  {What it does}. Use when {trigger conditions}.
+  Outputs {what it produces}. Dependencies: {deps or "none"}.
+  Reads: {brand files}. Writes: {brand files}.
+category: {brand | content | growth | analytics | meta}
+tier: {foundation | growth | advanced}
+reads:
+  - brand/{file}.md
+writes:
+  - brand/{file}.md
+triggers:
+  - {phrase 1}
+  - {phrase 2}
+  - {phrase 3}
+---
+```
+
+**Checklist for frontmatter:**
+- [ ] Name is lowercase-with-hyphens, matches directory name
+- [ ] Description includes WHAT it does and WHEN to use it
+- [ ] Category and tier are set correctly
+- [ ] Reads/writes accurately reflect brand file usage
+- [ ] 3-5 natural language triggers
+
+### 3b: Write the On Activation Section
+
+If the skill produces marketing content, include the brand context loader:
+
+```markdown
+## On Activation
+
+1. Check if `brand/` directory exists in the project root.
+2. If it does, read available files: `voice-profile.md`, `positioning.md`,
+   `audience.md`, `creative-kit.md`, `stack.md`, `learnings.md`.
+3. Apply any loaded brand context to enhance output quality.
+4. If `brand/` does not exist, proceed without it — this skill works standalone.
+```
+
+### 3c: Write the Body
+
+Use the template from `templates/marketing-skill.md`. Key sections:
+
+1. **Title + hook** — Why this skill exists (1-3 sentences)
+2. **Quick Start** — First 3-5 actions
+3. **Core Process** — Step-by-step with decision points
+4. **Output Format** — Exactly what the skill produces
+5. **Guidelines** — Rules and constraints
+6. **Success Criteria** — How to know it's done
+
+### 3d: Write Supporting Files (if complex)
+
+- **Workflows** — Step-by-step procedures. Include required reading at top.
+- **References** — Domain knowledge. Facts, patterns, examples.
+- **Templates** — Output structures to copy and fill.
+
+## Step 4: Validate
+
+Run through this checklist:
+
+- [ ] SKILL.md has valid YAML frontmatter
+- [ ] Name matches directory name
+- [ ] Description is specific (not "helps with marketing")
+- [ ] Category and tier are correct
+- [ ] Brand context loading is present (if content-producing)
+- [ ] Skill works without `brand/` directory (progressive enhancement)
+- [ ] All referenced files exist
+- [ ] SKILL.md is under 500 lines
+- [ ] Triggers use natural language the user would actually say
+- [ ] Output format is clearly specified
+- [ ] Success criteria are measurable
+
+## Step 5: Test
+
+1. Invoke the skill directly with `/skill-name`
+2. Test with zero brand context (no `brand/` directory)
+3. Test with full brand context
+4. Verify output matches the specified format
+5. Check that triggers would match reasonable user requests
+
+## Success Criteria
+
+Skill creation is complete when:
+- [ ] All validation checklist items pass
+- [ ] Skill tested with real invocation
+- [ ] User has confirmed the output meets their needs


### PR DESCRIPTION
## Summary

Closes #9

- Adds `skills/create-skill/` meta-skill ported from CE's `create-agent-skills` pattern, adapted for mktg conventions
- **SKILL.md** — Router with quick start, key principles (brand context pattern, progressive enhancement, frontmatter conventions), and navigation to supporting files
- **templates/marketing-skill.md** — Complete template with all mktg-specific fields (category, tier, reads, writes, triggers) and the brand context loading pattern
- **workflows/create-new-skill.md** — 5-step workflow: gather requirements, choose structure, create skill, validate, test
- **references/skill-structure.md** — Full format reference covering directory layout, frontmatter fields, body structure, description best practices, and anti-patterns

No existing skills or `src/` files were modified.

## Test plan

- [x] All 525 existing tests pass (`bun test`)
- [ ] Invoke `/create-skill` and verify it routes correctly
- [ ] Create a test skill using the template and validate it follows conventions
- [ ] Verify all internal file links resolve correctly