### PR TITLE
docs: research ASC CLI screenshots & analytics for mktg ideas

### DIFF
--- a/docs/ideas/marketing-analytics.md
+++ b/docs/ideas/marketing-analytics.md
@@ -1,0 +1,276 @@
+# Idea: Marketing Analytics for mktg
+
+> Inspired by the ASC CLI analytics system's snapshot → timeline → charts pipeline.
+
+## Problem
+
+mktg can generate marketing content and publish it, but has no way to track what's working. There's no feedback loop. The agent can't learn which content performs well, which channels drive traffic, or whether a launch campaign actually moved numbers. Without analytics, marketing decisions stay gut-feel instead of data-driven.
+
+## Concept
+
+A `mktg analytics` command that adapts the ASC CLI's download tracking pattern to marketing metrics:
+
+```
+mktg analytics snapshot   — Collect today's metrics from all connected sources
+mktg analytics timeline   — Show trend summary with deltas
+mktg analytics charts     — Generate visualization PNGs
+mktg analytics report     — Full analysis with insights (agent-generated)
+mktg analytics dashboard  — Open interactive HTML dashboard
+```
+
+## Architecture
+
+### Directory Structure
+
+```
+marketing/
+└── analytics/
+    ├── config.json                # Data source configuration
+    ├── data/
+    │   ├── YYYY-MM-DD.json       # Full daily snapshots
+    │   └── timeline.json         # Aggregated summary with deltas
+    ├── charts/                    # Generated visualizations
+    │   ├── traffic.png
+    │   ├── engagement.png
+    │   ├── conversion.png
+    │   └── dashboard.png
+    └── reports/
+        └── YYYY-MM-DD.md         # Agent-generated analysis
+```
+
+### Data Sources (Provider Pattern)
+
+Following the ASC CLI's `gh api` approach but for marketing data:
+
+```typescript
+interface AnalyticsProvider {
+  name: string
+  collect(config: ProviderConfig): Promise<MetricSnapshot>
+}
+```
+
+**Providers:**
+
+| Provider | What it collects | How |
+|----------|-----------------|-----|
+| `github` | Stars, traffic, clones, referrers | `gh api` (same as ASC CLI) |
+| `posthog` | Page views, events, funnels, feature flags | PostHog API / MCP |
+| `plausible` | Visitors, page views, sources, countries | Plausible API |
+| `gsc` | Search impressions, clicks, CTR, position | Google Search Console API |
+| `social` | Follower counts, post engagement | Platform APIs / scraping |
+| `email` | Open rates, click rates, subscriber count | Email provider API (gws) |
+| `stripe` | Revenue, conversion rate, MRR | Stripe API |
+
+Each provider independently collects its metrics. Missing providers degrade gracefully (return empty object, log warning) — same pattern as ASC CLI's defensive error handling.
+
+### Snapshot Format
+
+```json
+{
+  "date": "2026-03-12",
+  "timestamp": "2026-03-12T23:55:00.000Z",
+  "project": "ceo-app",
+  "sources": {
+    "github": {
+      "stars": 150,
+      "traffic": { "views": 89, "uniques": 34 },
+      "clones": { "count": 12, "uniques": 8 }
+    },
+    "posthog": {
+      "page_views": 1240,
+      "unique_visitors": 430,
+      "signups": 12,
+      "key_events": {
+        "started_trial": 8,
+        "completed_onboarding": 5
+      }
+    },
+    "gsc": {
+      "impressions": 3400,
+      "clicks": 210,
+      "ctr": 0.062,
+      "avg_position": 14.3
+    },
+    "email": {
+      "subscribers": 890,
+      "open_rate": 0.42,
+      "click_rate": 0.08
+    }
+  },
+  "totals": {
+    "total_visitors": 1670,
+    "total_signups": 12,
+    "total_revenue": 0
+  }
+}
+```
+
+### Timeline Format (Progressive Data Reduction)
+
+Adapted directly from ASC CLI's `timeline.json` pattern:
+
+```json
+[
+  {
+    "date": "2026-03-12",
+    "visitors": 1670,
+    "visitors_delta": 230,
+    "signups": 12,
+    "signups_delta": 4,
+    "revenue": 0,
+    "revenue_delta": 0,
+    "impressions": 3400,
+    "impressions_delta": 500,
+    "subscribers": 890,
+    "subscribers_delta": 15
+  }
+]
+```
+
+Key insight from ASC CLI: the timeline is a **lightweight aggregation layer** (1-2 KB) that enables fast trending without parsing full snapshots (50+ KB each). Deltas computed against previous entry.
+
+### Chart Generation
+
+Adapted from ASC CLI's matplotlib approach but using a TypeScript-native solution:
+
+**Charts generated:**
+
+1. **traffic.png** — Visitors over time (area chart + moving average)
+2. **engagement.png** — Signups, trial starts, onboarding completions (stacked bar)
+3. **conversion.png** — Funnel visualization (visitors → signups → trial → paid)
+4. **seo.png** — Search impressions, clicks, CTR, average position
+5. **dashboard.png** — 4-panel summary combining the above
+
+**Implementation options:**
+- **quickchart.io** — URL-based chart API, no dependencies, works anywhere
+- **Vega-Lite** — JSON-specified charts rendered to PNG via `vl2png`
+- **Playwright** — Render chart HTML pages, screenshot them (dogfooding the asset pipeline)
+
+Recommendation: Vega-Lite for static charts (declarative JSON specs, high quality), with Playwright screenshot as fallback for custom HTML dashboards.
+
+### Report Generation (Agent-Native)
+
+The agent reads `timeline.json` and generates a markdown report:
+
+```markdown
+# Marketing Report: 2026-03-12
+
+## Key Metrics
+- Visitors: 1,670 (+230, +16% vs yesterday)
+- Signups: 12 (+4, +50% vs yesterday)
+- Search impressions: 3,400 (+500, +17%)
+- Email subscribers: 890 (+15)
+
+## What's Working
+- Blog post "X" driving 40% of search traffic
+- Email sequence converting at 8% click rate (above 5% benchmark)
+
+## What Needs Attention
+- Landing page bounce rate elevated at 72%
+- Social referral traffic declining 3rd day in a row
+
+## Recommended Actions
+1. Run /page-cro on landing page to address bounce rate
+2. Run /content-atomizer on top blog post for social distribution
+3. A/B test email subject lines — current open rate plateauing
+```
+
+This is where mktg's agent-native design creates a feedback loop: analytics → insights → action via other mktg skills.
+
+## Implementation Sketch
+
+### Phase 1: Core Pipeline (MVP)
+
+1. **Config system** — `marketing/analytics/config.json` defining active providers + credentials
+2. **GitHub provider** — Adapt ASC CLI's `gh api` calls directly
+3. **PostHog provider** — Use PostHog MCP for event/pageview data
+4. **Snapshot command** — Collect from all active providers, write daily JSON
+5. **Timeline computation** — Aggregate snapshots, compute deltas
+6. **`mktg analytics snapshot`** + **`mktg analytics timeline`**
+
+### Phase 2: Visualization
+
+7. **Vega-Lite chart specs** — Define chart templates for each metric category
+8. **Chart generator** — Render specs to PNG using `vl2png` or quickchart.io
+9. **HTML dashboard** — Interactive page with embedded charts + tables
+10. **`mktg analytics charts`** + **`mktg analytics dashboard`**
+
+### Phase 3: Intelligence
+
+11. **Report generator** — Agent reads timeline, produces markdown analysis
+12. **Anomaly detection** — Flag metrics outside 2-sigma of rolling average
+13. **Skill recommendations** — Map metric problems to mktg skills (high bounce → /page-cro)
+14. **`mktg analytics report`**
+
+### Phase 4: Automation
+
+15. **CI scheduling** — GitHub Actions / cron for daily snapshots (same as ASC CLI)
+16. **Alerting** — Notify on significant changes (email via gws, Slack)
+17. **Campaign attribution** — Tag content with campaign IDs, track through funnel
+18. **A/B test tracking** — Compare variant performance over time
+
+## CLI Interface
+
+```bash
+# Collect today's data
+mktg analytics snapshot
+
+# View trends
+mktg analytics timeline
+mktg analytics timeline --metric visitors --days 30
+
+# Generate charts
+mktg analytics charts
+mktg analytics charts --metric traffic --output marketing/analytics/charts/
+
+# Full report
+mktg analytics report
+mktg analytics report --period weekly
+
+# Interactive dashboard
+mktg analytics dashboard
+
+# Configuration
+mktg analytics config                     # Show current config
+mktg analytics config --add posthog       # Add a provider
+mktg analytics schema                     # Show snapshot JSON schema
+```
+
+All commands output JSON with `--json` flag.
+
+## How This Connects to Existing mktg Skills
+
+| Skill | Analytics integration |
+|-------|---------------------|
+| `/seo-audit` | Feed GSC data into audit for data-backed recommendations |
+| `/page-cro` | Track conversion changes after CRO implementations |
+| `/keyword-research` | Correlate keyword targets with actual search performance |
+| `/content-atomizer` | Track which atomized variants perform best per platform |
+| `/email-sequences` | Track open/click rates to optimize sequence timing |
+| `/launch-strategy` | Post-launch analytics to measure launch effectiveness |
+| `/competitive-intel` | Benchmark your metrics against competitor estimates |
+| `/cmo` | Analytics feed into CMO's strategic decision-making |
+
+## Key Insight: The Feedback Loop
+
+The ASC CLI tracks downloads but doesn't act on the data — it's purely observational. For mktg, analytics should **close the loop**:
+
+```
+Generate content (mktg skills)
+    → Publish (mktg post / mktg email)
+    → Track performance (mktg analytics)
+    → Identify what works (mktg analytics report)
+    → Generate more of what works (mktg skills, informed by data)
+    → Repeat
+```
+
+This is the difference between a dashboard and a marketing engine. The analytics system isn't just tracking — it's feeding the agent's next decision.
+
+## Next Steps
+
+1. Define `AnalyticsConfig` and `MetricSnapshot` TypeScript types
+2. Implement GitHub provider (port ASC CLI's `gh api` calls to TypeScript)
+3. Implement PostHog provider using PostHog MCP
+4. Build snapshot + timeline commands
+5. Choose chart rendering approach (Vega-Lite vs quickchart.io)
+6. Test with CEO app project metrics

--- a/docs/ideas/marketing-asset-pipeline.md
+++ b/docs/ideas/marketing-asset-pipeline.md
@@ -1,0 +1,206 @@
+# Idea: Marketing Asset Pipeline for mktg
+
+> Inspired by the ASC CLI screenshots system's plan → capture → frame → review → watch workflow.
+
+## Problem
+
+Marketing requires generating many visual assets: landing page screenshots for A/B tests, social media post previews, email template renders, OG images, ad creatives. Today these are created manually or ad-hoc. There's no deterministic pipeline, no brand-consistent framing, no review workflow, and no way for an agent to orchestrate the full cycle.
+
+## Concept
+
+A `mktg assets` command that mirrors the ASC CLI screenshots workflow:
+
+```
+mktg assets plan      — Define what assets to generate (JSON plan)
+mktg assets capture   — Generate raw assets (screenshots, renders)
+mktg assets frame     — Apply brand treatment (overlays, device frames, templates)
+mktg assets review    — Generate HTML review page with approval flow
+mktg assets watch     — Watch for changes, auto-regenerate
+mktg assets run       — Execute full pipeline: plan → capture → frame → review
+```
+
+## Architecture
+
+### Directory Structure
+
+```
+marketing/
+└── assets/
+    ├── plans/                     # Asset generation plans (JSONC)
+    │   ├── landing-page-shots.json
+    │   ├── social-previews.json
+    │   └── email-templates.json
+    ├── raw/                       # Captured raw assets
+    │   └── {plan-name}/{variant}/{asset-id}.png
+    ├── framed/                    # Brand-treated output
+    │   └── {plan-name}/{variant}/{asset-id}.png
+    ├── templates/                 # Brand overlay templates
+    │   ├── social-post.json
+    │   ├── og-image.json
+    │   └── email-header.json
+    └── review/
+        ├── manifest.json          # Structured review metadata
+        ├── index.html             # Interactive HTML report
+        └── approved.json          # Approval tracking
+```
+
+### Plan Format
+
+```jsonc
+{
+  "version": 1,
+  "name": "landing-page-variants",
+  "description": "A/B test screenshots of landing page hero sections",
+  "capture": {
+    "provider": "playwright",      // or "browser", "url-to-image"
+    "targets": [
+      {
+        "id": "hero-v1",
+        "url": "http://localhost:3000?variant=1",
+        "viewport": { "width": 1440, "height": 900 },
+        "wait_for": ".hero-loaded",
+        "delay_ms": 500
+      },
+      {
+        "id": "hero-v2",
+        "url": "http://localhost:3000?variant=2",
+        "viewport": { "width": 1440, "height": 900 },
+        "wait_for": ".hero-loaded"
+      }
+    ],
+    "variants": ["desktop", "mobile"],  // viewport presets
+    "formats": ["png", "webp"]
+  },
+  "frame": {
+    "template": "og-image",
+    "brand_overlay": true,
+    "options": {
+      "logo_position": "top-left",
+      "gradient": "brand-primary"
+    }
+  }
+}
+```
+
+### Provider Abstraction
+
+Following the ASC CLI pattern of pluggable capture providers:
+
+```typescript
+interface AssetProvider {
+  capture(target: CaptureTarget): Promise<CaptureResult>
+}
+```
+
+**Providers:**
+
+| Provider | Use case | Implementation |
+|----------|----------|----------------|
+| `playwright` | Landing page screenshots, full-page captures | Playwright CLI (`ply` skill) |
+| `url-to-image` | Quick URL-to-PNG for any public page | Headless browser one-shot |
+| `template` | Generate from brand templates (OG images, social cards) | Canvas/SVG rendering |
+| `remotion` | Video thumbnails, animated previews | Remotion CLI |
+
+New providers plug in without touching orchestration — same pattern as ASC CLI's AXe/macOS providers.
+
+### Brand Framing
+
+The ASC CLI uses Koubou for device bezels. For mktg, "framing" means applying brand treatment:
+
+- **Logo overlay** — Position brand logo on assets
+- **Color treatment** — Apply brand gradient backgrounds
+- **Text overlays** — Headlines, CTAs, taglines from brand/ context
+- **Device mockups** — Wrap screenshots in phone/laptop frames for social posts
+- **Template composition** — Combine raw captures with brand templates
+
+Frame templates live in `marketing/assets/templates/` and reference `brand/` for colors, fonts, logos.
+
+### Review Workflow
+
+Directly adapted from ASC CLI's review system:
+
+1. **Manifest generation** — JSON manifest listing all assets with metadata (plan, variant, dimensions, status)
+2. **HTML report** — Interactive page showing all assets in grid, filterable by plan/variant
+3. **Approval tracking** — `approved.json` with selectors: by plan, variant, individual asset, or "all ready"
+4. **Status inference** — `ready`, `missing_raw`, `invalid_dimensions`, `needs_reframe`
+
+The agent can programmatically approve assets or flag them for human review.
+
+### Watch Mode
+
+File system monitoring adapted from ASC CLI:
+
+- Watch plan files + template files + brand/ directory
+- Debounce rapid changes (500ms)
+- Auto-regenerate affected assets on change
+- Coalesce pending work while generation runs
+- Optionally regenerate review HTML
+
+Use case: designer updates brand colors in `brand/visual-identity.md` → watch detects change → all framed assets regenerate with new colors → review page updates.
+
+## Implementation Sketch
+
+### Phase 1: Core Pipeline (MVP)
+
+1. **Plan loader** — Parse JSONC plans with validation (version, targets, provider)
+2. **Playwright provider** — Capture URLs with viewport/wait options via `ply`
+3. **Simple framing** — Logo overlay + gradient background using sharp/canvas
+4. **Review generator** — HTML report with image grid + manifest JSON
+5. **`mktg assets run`** — Execute plan → capture → frame → review
+
+### Phase 2: Multi-Provider + Templates
+
+6. **Template provider** — Generate OG images, social cards from JSON templates
+7. **Remotion provider** — Video thumbnail generation
+8. **Brand-aware framing** — Pull colors/fonts/logos from `brand/` automatically
+9. **Variant system** — Desktop/mobile/tablet viewport presets
+
+### Phase 3: Watch + Automation
+
+10. **File watcher** — Monitor plans, templates, brand/ for changes
+11. **Approval CLI** — `mktg assets approve --plan landing --variant desktop`
+12. **CI integration** — Generate assets on PR, post review link as comment
+13. **Diff mode** — Compare current vs. approved assets, highlight changes
+
+## CLI Interface
+
+```bash
+# Full pipeline
+mktg assets run --plan landing-page-shots
+
+# Individual steps
+mktg assets capture --plan social-previews --provider playwright
+mktg assets frame --plan social-previews --template og-image
+mktg assets review --plan social-previews
+mktg assets approve --plan social-previews --variant desktop
+
+# Watch mode
+mktg assets watch --plan landing-page-shots
+
+# List/inspect
+mktg assets list                          # Show all plans
+mktg assets list --plan landing-page-shots  # Show assets in plan
+mktg assets schema                        # Show plan JSON schema
+```
+
+All commands output JSON when `--json` flag is set (agent-native).
+
+## How This Connects to Existing mktg Skills
+
+| Skill | Asset pipeline integration |
+|-------|---------------------------|
+| `/page-cro` | Capture before/after screenshots for CRO analysis |
+| `/direct-response-copy` | Generate landing page → capture → frame for review |
+| `/content-atomizer` | Original content → social variants → capture previews |
+| `/email-sequences` | Render email templates → capture → review |
+| `/creative` | AI-generated images → frame with brand → review |
+| `/competitor-alternatives` | Capture competitor pages → side-by-side comparison |
+
+## Next Steps
+
+1. Define the `AssetPlan` TypeScript type and validation
+2. Implement Playwright capture provider using existing `ply` skill
+3. Build simple framing with sharp (logo + gradient overlay)
+4. Generate review HTML (adapt ASC CLI's template approach)
+5. Wire up `mktg assets run` command
+6. Test with a real project (CEO app landing page screenshots)

--- a/docs/research/asc-cli-screenshots-analytics.md
+++ b/docs/research/asc-cli-screenshots-analytics.md
@@ -1,0 +1,183 @@
+# Research: ASC CLI Screenshots & Analytics Systems
+
+## Overview
+
+The ASC CLI has two mature subsystems worth studying for mktg:
+
+1. **Screenshots system** — automated App Store screenshot capture, device framing, review, and file watching
+2. **Analytics system** — daily download/star tracking with chart generation
+
+Both follow patterns directly applicable to marketing automation: deterministic pipelines, provider abstractions, progressive data reduction, and automated review workflows.
+
+---
+
+## Part 1: Screenshots System
+
+### Architecture
+
+```
+internal/screenshots/
+├── types.go              # Type definitions + plan validation framework
+├── plan.go               # JSONC plan loading, parsing, validation
+├── capture.go            # Provider abstraction + capture orchestration
+├── frame.go              # Koubou YAML-based device framing (6 devices)
+├── review.go             # HTML/JSON manifest generation for review
+├── watch.go              # File system monitoring + auto-regeneration
+├── run.go                # Plan execution engine (step-by-step automation)
+├── provider_axe.go       # AXe CLI provider (iOS simulators)
+├── provider_macos.go     # Native macOS screencapture + Swift
+└── review_actions.go     # Approval flow utilities
+```
+
+### Core Workflow: Plan → Capture → Frame → Review → Watch
+
+**Plan phase** — Deterministic automation sequences defined in JSONC files. Version 1 enforced with strict validation. Six action types: `launch`, `tap`, `type`, `key_sequence`, `wait`, `wait_for`, `screenshot`. Configurable post-action delays. Structured validation errors with typed codes.
+
+**Capture phase** — Provider-agnostic capture via a `Provider` interface (`Capture(ctx, req) → pngPath`). Two implementations: AXe (iOS simulators via `xcrun simctl`) and macOS (native `screencapture` via embedded Swift). Provider selected by string constant. Post-capture image validation for dimensions and format.
+
+**Frame phase** — Raw screenshots wrapped in device bezels using Koubou (pinned v0.14.0). Two modes: input mode (raw → framed) and config mode (custom YAML). Supports 6 devices: `iphone-air`, `iphone-17-pro`, `iphone-17-pro-max`, `iphone-16e`, `iphone-17`, `mac`. Mac uses canvas mode with title/subtitle overlays instead of bezels.
+
+**Review phase** — Scans framed directory, generates `ReviewManifest` (JSON) + interactive HTML report. Infers locale/device from path structure (`{locale}/{device}/{screenshot_id}`). Approval tracking via `approved.json` with combinable selectors (by key, locale, device, or "all ready").
+
+**Watch phase** — Monitors config + asset directories for changes. 500ms debounce. Auto-regenerates framed screenshots and review HTML. Uses generation coalescer to queue pending work while generation runs.
+
+### Directory Structure
+
+```
+screenshots/
+├── raw/                           # Captured raw screenshots
+│   └── {locale}/{device}/{id}.png
+├── framed/                        # Device-framed output
+│   └── {locale}/{device}/{id}.png
+└── review/
+    ├── manifest.json              # Structured review metadata
+    ├── index.html                 # Interactive HTML report
+    └── approved.json              # Approval state
+```
+
+### Key Design Patterns
+
+| Pattern | How it works | Why it matters |
+|---------|-------------|----------------|
+| **Provider abstraction** | `Provider` interface with `Capture(ctx, req)` signature. AXe and macOS implementations. Selection by string constant. | New capture backends (browser, remote device) plug in without touching orchestration code. |
+| **Plan-driven automation** | JSONC files define step sequences. Validated on load with typed error codes. | Deterministic, reproducible runs. Plans are versionable, shareable, diffable. |
+| **Validation-first** | Every boundary validates: plan load, capture destination, image dimensions, Koubou version. | Failures surface early with actionable messages instead of cascading silently. |
+| **Context threading** | All operations accept `context.Context`. Custom `waitContext()` for delays. | Clean cancellation throughout the pipeline. |
+| **Type-safe enums** | `StepAction`, `FrameDevice` as string types with constants and parse functions. Normalization handles case/whitespace/hyphen. | Prevents typo bugs while keeping the API string-friendly for JSON plans. |
+| **Flexible approval** | Supports multiple JSON formats for approved.json. Selectors combinable (locale + device). | Approval workflows evolve without breaking existing data. |
+| **Watch + coalesce** | File watcher with debounce + generation coalescer. | Rapid saves don't trigger N rebuilds — queues work while generation runs. |
+
+### Koubou Template System
+
+Dynamic YAML generation for device framing:
+- **Project config**: name, output directory, device name, output size (named or explicit)
+- **Screenshot spec**: background (linear gradient or solid), content items (images, text)
+- **Canvas options**: title, subtitle, hex colors
+- **Named output sizes**: maps to App Store requirements (`iPhone6_9` → 1320x2868, `AppDesktop_2880` → 2880x1800)
+- **Display type auto-detection**: infers `APP_IPHONE_69`, `APP_DESKTOP` etc. from dimensions
+
+---
+
+## Part 2: Analytics System
+
+### Architecture
+
+```
+analytics/
+├── snapshot.py              # Daily data collection (GitHub API via gh CLI)
+├── generate_charts.py       # Matplotlib visualization (5 PNG outputs)
+└── data/
+    ├── YYYY-MM-DD.json     # Full daily snapshots (57-76 KB each)
+    └── timeline.json       # Lightweight aggregated summary (1.7 KB)
+```
+
+Automated via GitHub Actions daily at 23:55 UTC.
+
+### Data Collection (snapshot.py)
+
+Uses `gh api` to collect from GitHub:
+- **Stars**: current total stargazer count
+- **Traffic (14-day window)**: views, clones, unique counts, popular referrers, popular paths
+- **Release downloads**: all releases with per-asset download counts
+
+Daily snapshot structure:
+```json
+{
+  "date": "2026-03-12",
+  "timestamp": "2026-03-12T00:01:00.613554+00:00",
+  "stars": 2769,
+  "today": { "views": 0, "clones": 0, ... },
+  "traffic_14d": { "views": {...}, "clones": {...}, "referrers": {...}, "paths": {...} },
+  "total_downloads": 7624,
+  "releases": [{ "tag": "0.39.1", "assets": [...], "total_downloads": 92 }, ...]
+}
+```
+
+### Chart Generation (generate_charts.py)
+
+Produces 5 PNGs at 200 DPI:
+
+1. **stars_cumulative.png** — area chart with milestone annotations (100, 250, 500, 1000)
+2. **stars_per_day.png** — bar chart with intensity gradient + 3-day moving average
+3. **downloads_cumulative.png** — line chart with release markers
+4. **downloads_per_release.png** — bar chart (last 30 releases, intensity-scaled)
+5. **dashboard.png** — 4-panel summary for sponsors
+
+Styling: clean spines (top/right removed), grid with alpha=0.3, 200 DPI, tight layout.
+
+### Data Flow
+
+```
+GitHub API (via gh CLI)
+    ↓
+snapshot.py → analytics/data/YYYY-MM-DD.json (full)
+           → analytics/data/timeline.json (summary + deltas)
+    ↓
+generate_charts.py → 5 PNG charts
+    ↓
+GitHub Actions commit + push
+```
+
+### Key Design Patterns
+
+| Pattern | How it works | Why it matters |
+|---------|-------------|----------------|
+| **Progressive data reduction** | Full snapshots (76 KB) → timeline summary (1.7 KB) → PNG charts | Each layer serves a different consumer: raw for debugging, summary for trending, charts for stakeholders. |
+| **Delta computation** | Timeline entries include `stars_delta` and `downloads_delta` vs. previous snapshot | Momentum visible at a glance without post-processing. |
+| **Graceful degradation** | Missing API data returns empty object, not exception. Handles zero-download releases. | Pipeline never fails completely — partial data still captured. |
+| **Separation of concerns** | Collection (snapshot.py) fully separated from visualization (generate_charts.py) | Either can be replaced or run independently. |
+| **Automated via CI** | GitHub Actions runs daily, commits data, pushes | Zero human intervention for ongoing tracking. |
+
+---
+
+## Cross-System Observations
+
+### Shared Principles
+
+1. **Deterministic pipelines** — Both systems produce reproducible output from defined inputs. No hidden state.
+2. **Provider/adapter pattern** — Screenshots abstract capture providers; analytics abstract data sources (gh API).
+3. **File-based state** — JSON files as the source of truth. No database dependency. Git-trackable.
+4. **Progressive refinement** — Raw → processed → review-ready (screenshots). Raw → summary → charts (analytics).
+5. **Validation at boundaries** — Both validate inputs aggressively and fail early with structured errors.
+6. **Watch/automation** — Screenshots have file watching; analytics have cron-based GitHub Actions.
+
+### What Makes These Systems Work
+
+- **Low operational overhead**: JSON files + git commits. No servers, no databases, no dashboards to maintain.
+- **Composable steps**: Each phase (plan, capture, frame, review) is independently testable and replaceable.
+- **Agent-friendly**: Structured output (JSON manifests, typed errors) makes programmatic consumption easy.
+- **Self-contained**: No external services beyond GitHub API. Everything runs locally or in CI.
+
+---
+
+## Relevance to mktg
+
+The screenshots system's plan → capture → frame → review → watch workflow maps directly to a marketing content pipeline: plan content → generate assets → apply brand → review → watch for changes.
+
+The analytics system's snapshot → timeline → charts pipeline maps to campaign performance tracking: collect metrics → compute deltas → visualize trends.
+
+Both systems validate that file-based JSON state + CLI automation + CI/CD scheduling is a viable foundation for complex production workflows — exactly the approach mktg takes.
+
+See:
+- `docs/ideas/marketing-asset-pipeline.md` — concrete proposal inspired by screenshots system
+- `docs/ideas/marketing-analytics.md` — concrete proposal inspired by analytics system


### PR DESCRIPTION
## Summary

Closes #18

- Deep analysis of ASC CLI's screenshot system (plan → capture → frame → review → watch workflow) and analytics system (snapshot → timeline → charts pipeline)
- Concrete proposal for a `mktg assets` command — marketing asset pipeline with provider abstraction, brand framing, review workflow, and watch mode
- Concrete proposal for a `mktg analytics` command — multi-source metric collection, progressive data reduction, chart generation, and agent-generated reports with a feedback loop

## Files Added
- `docs/research/asc-cli-screenshots-analytics.md` — full analysis of both ASC CLI systems
- `docs/ideas/marketing-asset-pipeline.md` — actionable proposal with phased implementation plan
- `docs/ideas/marketing-analytics.md` — actionable proposal with provider pattern and feedback loop design

## Test plan
- [x] No src/ or skills/ files modified
- [x] All 525 existing tests pass
- [x] Each idea doc has clear next steps and implementation sketch