### PR TITLE
feat: add workflow skills (cmo:plan, cmo:work, cmo:review, cmo:compound)

### DIFF
--- a/skills/cmo-compound/SKILL.md
+++ b/skills/cmo-compound/SKILL.md
@@ -1,0 +1,285 @@
+---
+name: cmo:compound
+description: "Document marketing campaign learnings to compound knowledge over time. Use after a campaign ships, a review completes, or the user says 'what did we learn', 'document this', 'campaign retrospective', 'what worked', or any request to capture marketing insights for future use."
+argument-hint: "[optional: campaign name or brief context about what to document]"
+metadata:
+  version: 1.0.0
+category: workflow
+tier: orchestration
+reads:
+  - marketing/plans/
+  - marketing/reviews/
+  - marketing/content/
+  - brand/learnings.md
+writes:
+  - marketing/learnings/
+  - brand/learnings.md
+triggers:
+  - what did we learn
+  - campaign retrospective
+  - document learnings
+  - what worked
+  - compound marketing
+---
+
+# /cmo:compound — Marketing Knowledge Compounding
+
+Capture marketing campaign learnings while context is fresh. Each documented insight compounds your marketing intelligence — what worked, what didn't, and why.
+
+## Purpose
+
+Captures campaign insights, content performance data, and strategic learnings in `marketing/learnings/` for future reference. The first time you run a campaign type takes full research. Document the results, and the next campaign of that type takes half the effort.
+
+**Why "compound"?** Each documented campaign compounds your marketing knowledge. First launch campaign: full research. Document what worked, and the next launch starts from proven patterns. Knowledge compounds.
+
+This is step 4 of the marketing workflow cycle: **plan** -> **work** -> **review** -> **compound**.
+
+## Usage
+
+```bash
+/cmo:compound                         # Document the most recent campaign
+/cmo:compound [campaign name/context]  # Document specific campaign
+```
+
+## Execution Workflow
+
+### Phase 1: Gather Context
+
+1. **Find the campaign to document**
+
+   If no specific campaign is mentioned, find the most recent:
+
+   ```bash
+   ls -lt marketing/plans/*.md 2>/dev/null | head -5
+   ls -lt marketing/reviews/*.md 2>/dev/null | head -5
+   ```
+
+   Read:
+   - The campaign plan (`marketing/plans/`)
+   - The review report (`marketing/reviews/`) if it exists
+   - Key content outputs (`marketing/content/`, `marketing/social/`, `marketing/email/`)
+
+2. **Extract key data points**
+
+   From the plan:
+   - Original objective and success metrics
+   - Target audience and channels used
+   - Skills invoked and in what order
+   - Timeline planned vs. actual
+
+   From the review:
+   - P1/P2/P3 findings and how they were resolved
+   - Brand voice consistency score
+   - Conversion effectiveness assessment
+
+   From the conversation:
+   - What the user said worked or didn't
+   - Any pivots made during execution
+   - Unexpected discoveries
+
+### Phase 2: Analyze and Classify
+
+Determine the learning categories:
+
+**What Worked:**
+- Which content types performed best?
+- Which channels showed the most promise?
+- Which skills produced the strongest output?
+- What brand voice decisions resonated?
+
+**What Didn't Work:**
+- Where did the plan need adjustment?
+- What content needed heavy revision?
+- Which channels underperformed expectations?
+- What assumptions proved wrong?
+
+**Patterns Identified:**
+- Reusable templates or structures
+- Effective skill invocation sequences
+- Audience insights that apply beyond this campaign
+- Competitive insights worth remembering
+
+**Process Learnings:**
+- Was the plan the right level of detail?
+- Did the execution order make sense?
+- Were brand files sufficient or did gaps appear?
+- How long did each phase actually take?
+
+### Phase 3: Write Learning Document
+
+```bash
+mkdir -p marketing/learnings/
+```
+
+Classify the learning and write to `marketing/learnings/`:
+
+```markdown
+---
+title: "[Campaign Type]: [Key Insight]"
+date: YYYY-MM-DD
+campaign: marketing/plans/[associated plan filename]
+type: [launch|content|growth|retention|seo|email|social]
+audience: [audience segment]
+channels: [channels used]
+tags: [relevant tags for future search]
+outcome: [success|partial|failed|pivot]
+---
+
+# [Campaign Type]: [Key Insight]
+
+## Campaign Summary
+
+[1-2 sentence overview of what was done and why]
+
+## What Worked
+
+[Specific tactics, content types, or approaches that produced results]
+
+### Evidence
+[Concrete examples — content that converted, emails that got opens, copy that resonated]
+
+## What Didn't Work
+
+[What underperformed and why]
+
+### Root Cause
+[Why it didn't work — wrong audience, wrong channel, wrong timing, weak copy]
+
+## Key Learnings
+
+1. **[Learning 1]** — [Why it matters for future campaigns]
+2. **[Learning 2]** — [Why it matters]
+3. **[Learning 3]** — [Why it matters]
+
+## Reusable Patterns
+
+[Templates, structures, skill sequences, or approaches worth reusing]
+
+```markdown
+# Example: effective [content type] structure
+[Template or pattern here]
+```
+
+## Brand Voice Notes
+
+[Any voice or tone discoveries — what resonated with the audience, what fell flat]
+
+## Recommendations for Next Time
+
+- [ ] [Specific actionable recommendation]
+- [ ] [Specific actionable recommendation]
+- [ ] [Specific actionable recommendation]
+
+## Skills Used
+
+| Skill | Effectiveness | Notes |
+|-------|--------------|-------|
+| [skill name] | [high/medium/low] | [what worked or didn't] |
+
+## Related Learnings
+
+[Links to other learning documents that connect to this one]
+```
+
+### Phase 4: Update Brand Learnings
+
+If the campaign surfaced insights that apply broadly (not just this campaign):
+
+1. Read `brand/learnings.md` (create if it doesn't exist)
+2. Append new cross-campaign learnings:
+
+```markdown
+## [Date] — [Learning Source]
+
+- **Insight:** [What we learned]
+- **Evidence:** [From which campaign]
+- **Application:** [How to apply in future campaigns]
+```
+
+Only add learnings that are:
+- Applicable across campaigns (not one-off observations)
+- Specific enough to be actionable
+- Backed by evidence from this campaign
+
+### Phase 5: Summary
+
+Present to the user:
+
+```markdown
+## Campaign Learning Documented
+
+**File created:** marketing/learnings/[filename]
+**Campaign:** [campaign name]
+**Key insight:** [one-line summary]
+
+### Learnings Captured
+- [count] things that worked
+- [count] things that didn't
+- [count] reusable patterns
+- [count] brand voice notes
+
+### Brand Learnings Updated
+[Yes/No — what was added to brand/learnings.md]
+```
+
+Use the **AskUserQuestion tool**:
+
+**Question:** "Learning documented. What would you like to do next?"
+
+**Options:**
+1. **Plan next campaign** — Start `/cmo:plan` informed by these learnings
+2. **View all learnings** — Browse `marketing/learnings/` for patterns
+3. **Update brand files** — Refine voice, positioning, or audience based on insights
+4. **Done** — Wrap up this workflow cycle
+
+## The Compounding Philosophy
+
+This creates a compounding marketing intelligence system:
+
+1. First launch campaign -> Full research, trial and error (days)
+2. Document the learnings -> `marketing/learnings/launch-what-worked.md` (minutes)
+3. Next launch campaign -> `/cmo:plan` reads learnings, starts from proven patterns (hours, not days)
+4. Knowledge compounds -> Each campaign gets smarter
+
+The feedback loop:
+
+```
+Plan -> Work -> Review -> Compound -> Plan (informed) -> Work (faster) -> ...
+  ^                                                                       |
+  └───────────────────────────────────────────────────────────────────────┘
+```
+
+**Each marketing campaign should make subsequent campaigns easier — not harder.**
+
+## When to Compound
+
+- After any campaign ships (even partially)
+- After a review reveals surprising findings
+- When the user says "that worked" or "that bombed"
+- After A/B test results come in
+- After any marketing experiment, successful or not
+
+## What NOT to Document
+
+- Obvious things (e.g., "emails need subject lines")
+- Things already in brand files (don't duplicate)
+- Temporary tactical details (e.g., "posted at 2pm on Tuesday")
+- Anything without evidence (gut feelings without data)
+
+## Categories for Learning Files
+
+Auto-detect from campaign type:
+- `launch/` — Product and feature launch insights
+- `content/` — Content creation and SEO learnings
+- `email/` — Email marketing insights
+- `social/` — Social media learnings
+- `conversion/` — CRO and conversion insights
+- `growth/` — Growth loop and referral learnings
+- `brand/` — Brand voice and positioning discoveries
+
+## Related Commands
+
+- `/cmo:plan` — Plan next campaign informed by learnings (start of next cycle)
+- `/cmo:work` — Execute a marketing plan
+- `/cmo:review` — Review marketing output quality (previous step)
+- `/cmo` — Full CMO orchestration

--- a/skills/cmo-plan/SKILL.md
+++ b/skills/cmo-plan/SKILL.md
@@ -1,0 +1,318 @@
+---
+name: cmo:plan
+description: "Plan a marketing campaign, content strategy, or growth initiative. Use when the user wants to plan marketing work — campaigns, content calendars, launch sequences, channel strategies, or any marketing initiative that needs structure before execution."
+argument-hint: "[campaign idea, marketing goal, or initiative description]"
+metadata:
+  version: 1.0.0
+category: workflow
+tier: orchestration
+reads:
+  - brand/voice-profile.md
+  - brand/positioning.md
+  - brand/audience.md
+  - brand/competitors.md
+  - marketing/learnings/
+writes:
+  - marketing/plans/
+triggers:
+  - plan campaign
+  - marketing plan
+  - content strategy
+  - plan launch
+  - campaign plan
+---
+
+# /cmo:plan — Marketing Campaign Planning
+
+Plan marketing campaigns, content strategies, and growth initiatives into structured, actionable documents.
+
+## Introduction
+
+Transform marketing ideas into well-structured campaign plans. This is the starting point of the marketing workflow cycle: **plan** -> **work** -> **review** -> **compound**.
+
+## Campaign Description
+
+<campaign_description> #$ARGUMENTS </campaign_description>
+
+**If the campaign description above is empty, ask the user:** "What marketing initiative would you like to plan? Describe the campaign, content strategy, or growth goal you have in mind."
+
+Do not proceed until you have a clear description from the user.
+
+### 0. Idea Refinement
+
+**Check for existing marketing context first:**
+
+Before asking questions, check what brand context exists:
+
+```bash
+mktg status --json
+```
+
+Also look for recent marketing plans or brainstorms:
+
+```bash
+ls -la marketing/plans/*.md 2>/dev/null | head -10
+ls -la marketing/learnings/*.md 2>/dev/null | head -10
+```
+
+**If relevant brand context exists:**
+1. Read available brand files (`brand/voice-profile.md`, `brand/positioning.md`, `brand/audience.md`, `brand/competitors.md`)
+2. Announce: "Found existing brand context. Using as foundation for planning."
+3. Extract and carry forward positioning, audience segments, voice guidelines, and competitive landscape
+4. **Skip basic brand questions** — the brand files already answered WHO and WHY
+
+**If no brand context found:**
+1. Note the gap. Suggest running `/cmo` first to build foundation.
+2. Proceed with what you have — ask targeted questions about the marketing goal.
+
+**Run idea refinement (if needed):**
+
+Refine the idea through collaborative dialogue using the **AskUserQuestion tool**:
+
+- Ask questions one at a time to understand the initiative
+- Prefer multiple choice questions when natural options exist
+- Focus on: objective, target audience, channels, budget constraints, timeline, success metrics
+- Continue until the initiative is clear OR user says "proceed"
+
+**Skip option:** If the description is already detailed, offer:
+"Your description is clear. Should I proceed with research, or would you like to refine it further?"
+
+## Main Tasks
+
+### 1. Marketing Research (Parallel)
+
+Run these research tasks **in parallel** to gather context:
+
+**Internal research:**
+- Scan `marketing/learnings/` for past campaign insights that might apply
+- Check `brand/` files for positioning, audience, and competitive context
+- Look at `marketing/` for existing content and campaigns to build on
+
+**External research (conditional):**
+- If the campaign involves SEO: research keyword opportunities
+- If the campaign involves competitors: check competitive landscape
+- If the campaign involves a new channel: research channel best practices
+
+### 2. Campaign Planning & Structure
+
+**Title & Categorization:**
+
+- [ ] Draft clear campaign title (e.g., `Q2 Product Launch Campaign`, `SEO Content Blitz`, `Email Nurture Sequence`)
+- [ ] Determine campaign type: launch, content, growth, retention, brand-awareness
+- [ ] Convert to filename: date prefix, sequence number, kebab-case, `-plan` suffix
+  - Scan `marketing/plans/` for files matching today's date pattern
+  - Example: `2026-03-12-001-launch-ceo-app-campaign-plan.md`
+
+**Audience Analysis:**
+
+- [ ] Define primary audience segment (from `brand/audience.md` or new research)
+- [ ] Identify audience pain points this campaign addresses
+- [ ] Map audience to channels where they're active
+
+**Channel Strategy:**
+
+- [ ] Select channels based on audience + objective (use ORB framework from `launch-strategy`)
+  - **Owned:** Email, blog, podcast, community
+  - **Rented:** Social platforms, marketplaces, app stores
+  - **Borrowed:** Guest content, partnerships, influencer outreach
+- [ ] Define channel-specific tactics
+- [ ] Set content volume per channel
+
+### 3. Choose Detail Level
+
+Select how comprehensive the plan should be:
+
+#### MINIMAL (Quick Campaign)
+
+**Best for:** Single-channel pushes, content pieces, simple promotions
+
+```markdown
+---
+title: [Campaign Title]
+type: [launch|content|growth|retention|awareness]
+status: active
+date: YYYY-MM-DD
+audience: [primary segment]
+channels: [channel list]
+---
+
+# [Campaign Title]
+
+[Brief campaign description and objective]
+
+## Target Audience
+
+[Who and why]
+
+## Tactics
+
+- [ ] Tactic 1
+- [ ] Tactic 2
+
+## Success Metrics
+
+[How we measure success]
+
+## Skills Needed
+
+[Which mktg skills to invoke during /cmo:work]
+```
+
+#### STANDARD (Most Campaigns)
+
+**Best for:** Multi-channel campaigns, content strategies, launch sequences
+
+```markdown
+---
+title: [Campaign Title]
+type: [launch|content|growth|retention|awareness]
+status: active
+date: YYYY-MM-DD
+audience: [primary segment]
+channels: [channel list]
+duration: [timeframe]
+---
+
+# [Campaign Title]
+
+## Objective
+
+[What we're trying to achieve and why]
+
+## Target Audience
+
+[Detailed segment description, pain points, where they are]
+
+## Channel Strategy
+
+### Owned Channels
+[Tactics for email, blog, etc.]
+
+### Rented Channels
+[Tactics for social, marketplaces, etc.]
+
+### Borrowed Channels
+[Partnerships, guest content, etc.]
+
+## Content Plan
+
+| Asset | Skill | Channel | Timeline |
+|-------|-------|---------|----------|
+| [asset] | [mktg skill] | [channel] | [when] |
+
+## Execution Phases
+
+### Phase 1: [Foundation]
+- [ ] Tasks and deliverables
+
+### Phase 2: [Launch/Distribution]
+- [ ] Tasks and deliverables
+
+### Phase 3: [Optimization]
+- [ ] Tasks and deliverables
+
+## Success Metrics
+
+[KPIs and measurement methods]
+
+## Skills Needed
+
+[Which mktg skills to invoke during /cmo:work, in order]
+
+## Dependencies & Risks
+
+[What could block or complicate this]
+```
+
+#### COMPREHENSIVE (Major Initiatives)
+
+**Best for:** Product launches, rebrand campaigns, multi-month strategies
+
+Includes everything from STANDARD plus:
+- Detailed competitive positioning
+- Budget allocation across channels
+- A/B testing plan
+- Attribution and tracking setup
+- Team/resource requirements
+- Content calendar with specific dates
+- Fallback strategies per channel
+
+### 4. Plan Validation
+
+Before writing, validate the plan:
+
+- [ ] Every tactic maps to a measurable outcome
+- [ ] Skills needed are realistic (check with `mktg list --json`)
+- [ ] Timeline accounts for content creation time (not just publishing dates)
+- [ ] Budget is allocated (even if $0 — document it)
+- [ ] Brand voice and positioning are consistent throughout
+
+### 5. Write Plan File
+
+**REQUIRED: Write the plan file to disk.**
+
+```bash
+mkdir -p marketing/plans/
+```
+
+Use the Write tool to save the complete plan to `marketing/plans/YYYY-MM-DD-NNN-<type>-<descriptive-name>-plan.md`.
+
+Confirm: "Plan written to marketing/plans/[filename]"
+
+## Output Format
+
+```
+marketing/plans/YYYY-MM-DD-NNN-<type>-<descriptive-name>-plan.md
+```
+
+Examples:
+- `marketing/plans/2026-03-12-001-launch-ceo-app-campaign-plan.md`
+- `marketing/plans/2026-03-15-001-content-seo-blitz-q2-plan.md`
+- `marketing/plans/2026-04-01-001-growth-referral-program-plan.md`
+
+## Post-Generation Options
+
+After writing the plan file, use the **AskUserQuestion tool** to present these options:
+
+**Question:** "Plan ready at `marketing/plans/[filename]`. What would you like to do next?"
+
+**Options:**
+1. **Review and refine** — Improve the plan through self-review
+2. **Start `/cmo:work`** — Begin executing this marketing plan
+3. **Create GitHub Issue** — Track this campaign as an issue
+4. **Adjust scope** — Change detail level or add/remove sections
+
+Based on selection:
+- **Review and refine** -> Re-read and improve the plan
+- **`/cmo:work`** -> Call the /cmo:work command with the plan file path
+- **Create Issue** -> `gh issue create --title "<type>: <title>" --body-file <plan_path>`
+- **Adjust scope** -> Accept feedback and regenerate
+
+## Key Principles
+
+### Marketing Plans Are Living Documents
+- Plans get checked off as `/cmo:work` executes them
+- Update the plan when strategy shifts mid-campaign
+- Plans reference specific mktg skills for each tactic
+
+### Brand Context Is Your Advantage
+- Always load brand files before planning
+- Positioning and audience data make plans sharper
+- Past learnings prevent repeated mistakes
+
+### 30/70 Rule
+- Plan 30% content creation, 70% distribution
+- Most campaigns under-distribute and over-create
+- Every content asset should have 3+ distribution channels mapped
+
+### Skills Are Your Execution Layer
+- Map every tactic to a specific mktg skill
+- `/cmo:work` will invoke these skills in order
+- If no skill exists for a tactic, note it as manual work
+
+## Related Commands
+
+- `/cmo:work` — Execute this plan (next step)
+- `/cmo:review` — Review marketing output quality (after work)
+- `/cmo:compound` — Document campaign learnings (after review)
+- `/cmo` — Full CMO orchestration (routes to the right skill)

--- a/skills/cmo-review/SKILL.md
+++ b/skills/cmo-review/SKILL.md
@@ -1,0 +1,277 @@
+---
+name: cmo:review
+description: "Review marketing output for quality, brand consistency, and conversion effectiveness. Use when the user wants to evaluate marketing content, audit campaign assets, or quality-check deliverables before publishing. Triggers on 'review the content', 'check the copy', 'audit the campaign', 'is this ready to publish', or any request to evaluate marketing quality."
+argument-hint: "[file path, directory, or 'latest' to review most recent campaign output]"
+metadata:
+  version: 1.0.0
+category: workflow
+tier: orchestration
+reads:
+  - brand/voice-profile.md
+  - brand/positioning.md
+  - brand/audience.md
+  - marketing/content/
+  - marketing/social/
+  - marketing/email/
+writes:
+  - marketing/reviews/
+triggers:
+  - review content
+  - check copy
+  - audit campaign
+  - ready to publish
+  - quality check
+---
+
+# /cmo:review — Marketing Quality Review
+
+Review marketing output for brand consistency, conversion effectiveness, audience alignment, and publish-readiness.
+
+## Introduction
+
+Perform thorough quality reviews of marketing content and campaign assets. This catches issues before they reach your audience — off-brand messaging, weak CTAs, misaligned positioning, or inconsistent tone.
+
+This is step 3 of the marketing workflow cycle: **plan** -> **work** -> **review** -> **compound**.
+
+## Review Target
+
+<review_target> #$ARGUMENTS </review_target>
+
+## Main Tasks
+
+### 1. Determine Review Scope
+
+**If a specific file/directory is provided:**
+- Read the file(s) and identify the content type (copy, email, social, SEO, etc.)
+
+**If "latest" or empty:**
+- Check recent campaign output:
+  ```bash
+  mktg status --json
+  ls -lt marketing/content/ marketing/social/ marketing/email/ 2>/dev/null | head -20
+  ```
+- Find the most recent plan and its associated output:
+  ```bash
+  ls -lt marketing/plans/*.md 2>/dev/null | head -5
+  ```
+- Identify all files produced by the most recent `/cmo:work` execution
+
+**Load brand context (required):**
+- Read `brand/voice-profile.md` — voice guidelines are the review baseline
+- Read `brand/positioning.md` — positioning frames what claims are valid
+- Read `brand/audience.md` — audience determines if messaging resonates
+
+### 2. Brand Voice Audit
+
+Review every piece of content against `brand/voice-profile.md`:
+
+| Check | What to Look For |
+|-------|-----------------|
+| **Tone** | Does it match the brand's tone attributes? (e.g., confident but not arrogant) |
+| **Vocabulary** | Uses brand-approved terminology? Avoids banned words? |
+| **Personality** | Reads like the brand would speak, not generic marketing? |
+| **Consistency** | Same voice across all pieces? No jarring shifts? |
+
+**Severity:**
+- Tone mismatch across multiple pieces = P1 (blocks publish)
+- Occasional off-brand phrasing = P2 (should fix)
+- Minor style inconsistencies = P3 (nice to fix)
+
+### 3. Conversion Effectiveness Review
+
+Evaluate each content piece for marketing effectiveness:
+
+**For landing pages / sales copy:**
+- [ ] Clear value proposition above the fold
+- [ ] Specific benefits, not vague claims
+- [ ] Social proof present (testimonials, logos, numbers)
+- [ ] Single clear CTA per section
+- [ ] Objection handling present
+- [ ] Urgency or scarcity elements (if appropriate)
+- [ ] Mobile-friendly structure (short paragraphs, scannable)
+
+**For email sequences:**
+- [ ] Subject lines are specific and curiosity-driven (not clickbait)
+- [ ] Each email has one clear goal
+- [ ] Sequence builds progressive trust
+- [ ] Unsubscribe path is clear
+- [ ] Personalization tokens used correctly
+- [ ] CTA placement is prominent
+
+**For SEO content:**
+- [ ] Target keyword in title, H1, and first paragraph
+- [ ] Search intent matches content type (informational, commercial, transactional)
+- [ ] Comprehensive coverage of the topic
+- [ ] Internal links to related content
+- [ ] Meta description is compelling and includes keyword
+- [ ] Content is better than current top 3 results for the keyword
+
+**For social content:**
+- [ ] Hook in first line (stops the scroll)
+- [ ] Platform-native format (not copy-pasted across platforms)
+- [ ] Clear CTA or engagement prompt
+- [ ] Hashtags/mentions are relevant (not spammy)
+- [ ] Visual description or alt text included
+
+### 4. Audience Alignment Check
+
+Cross-reference all content against `brand/audience.md`:
+
+- [ ] Speaks to the audience's pain points (not the product's features)
+- [ ] Uses language the audience uses (not industry jargon they wouldn't know)
+- [ ] Addresses the audience's stage in the buyer journey
+- [ ] Emotional resonance appropriate for the segment
+- [ ] Examples and analogies are relevant to the audience's world
+
+### 5. Positioning Accuracy Check
+
+Cross-reference against `brand/positioning.md`:
+
+- [ ] Claims are consistent with stated positioning
+- [ ] Competitive differentiation is accurate (no outdated competitor info)
+- [ ] Value propositions match what the product actually delivers
+- [ ] No positioning contradictions across content pieces
+- [ ] Category language is consistent
+
+### 6. Technical Quality Check
+
+- [ ] No placeholder text or TODO markers
+- [ ] YAML front-matter present and correct on all files
+- [ ] Links are valid (no broken references)
+- [ ] Images/visuals referenced exist or have clear descriptions
+- [ ] Formatting is clean (no double spaces, orphaned bullets, etc.)
+- [ ] Content length matches the channel (not a blog post in a tweet)
+
+### 7. Findings Synthesis
+
+Categorize all findings:
+
+**P1 — Blocks Publish (must fix):**
+- Brand voice violations across multiple pieces
+- Factually incorrect claims
+- Missing or broken CTAs
+- Content that could damage brand reputation
+- Legal or compliance issues
+
+**P2 — Should Fix (important):**
+- Weak conversion elements
+- Audience misalignment
+- Positioning inconsistencies
+- Missing social proof or objection handling
+- SEO gaps
+
+**P3 — Nice to Fix (enhancement):**
+- Minor style inconsistencies
+- Additional social proof opportunities
+- Formatting improvements
+- Additional internal link opportunities
+
+### 8. Write Review Report
+
+Save the review to `marketing/reviews/`:
+
+```bash
+mkdir -p marketing/reviews/
+```
+
+Write to `marketing/reviews/YYYY-MM-DD-review-<campaign-name>.md`:
+
+```markdown
+---
+title: "Review: [Campaign Name]"
+date: YYYY-MM-DD
+plan: marketing/plans/[associated plan]
+status: [pass|needs-fixes|blocked]
+p1_count: [number]
+p2_count: [number]
+p3_count: [number]
+---
+
+# Marketing Review: [Campaign Name]
+
+## Summary
+- **Overall:** [PASS / NEEDS FIXES / BLOCKED]
+- **Brand Voice:** [Consistent / Minor Issues / Major Issues]
+- **Conversion:** [Strong / Adequate / Weak]
+- **Audience Fit:** [Aligned / Partially / Misaligned]
+
+## P1 Findings (Blocks Publish)
+[Detailed findings with file paths and specific text to fix]
+
+## P2 Findings (Should Fix)
+[Findings with suggestions]
+
+## P3 Findings (Enhancements)
+[Nice-to-have improvements]
+
+## Content Scorecard
+
+| Asset | Voice | Conversion | Audience | Overall |
+|-------|-------|------------|----------|---------|
+| [file] | [score] | [score] | [score] | [score] |
+
+## Recommended Actions
+1. [Specific action items in priority order]
+```
+
+### 9. Present Results
+
+Show the user a summary:
+
+```markdown
+## Marketing Review Complete
+
+**Status:** [PASS / NEEDS FIXES / BLOCKED]
+
+**Findings:**
+- P1 (Blocks Publish): [count]
+- P2 (Should Fix): [count]
+- P3 (Enhancements): [count]
+
+**Review saved to:** marketing/reviews/[filename]
+```
+
+Use the **AskUserQuestion tool**:
+
+**Question:** "Review complete. What would you like to do?"
+
+**Options:**
+1. **Fix P1 issues** — Address blocking issues immediately
+2. **Fix all issues** — Address P1 + P2 findings
+3. **Publish as-is** — Accept current state (only if no P1s)
+4. **Run `/cmo:compound`** — Document learnings from this campaign
+5. **Re-run `/cmo:work`** — Regenerate specific deliverables
+
+Based on selection:
+- **Fix P1/all** -> Apply fixes using the Edit tool, re-run affected checks
+- **Publish** -> Confirm with `mktg post --dry-run` then proceed
+- **`/cmo:compound`** -> Call /cmo:compound with campaign context
+- **Re-run work** -> Call /cmo:work for specific deliverables
+
+## Key Principles
+
+### Voice Is the First Filter
+- If it doesn't sound like the brand, nothing else matters.
+- Brand voice issues are always P1 if they're systemic.
+
+### Review Before Publish, Always
+- No content goes live without a review pass.
+- Even a quick scan catches embarrassing mistakes.
+- `/cmo:review` is not optional — it's the quality gate.
+
+### Conversion Is Measurable
+- Don't just check if copy "sounds good."
+- Check if it has the structural elements that drive action.
+- Every page needs a clear CTA. Every email needs a goal.
+
+### Audience > Product
+- Great marketing talks about the audience's problems, not the product's features.
+- If content is feature-heavy, flag it.
+- The audience file is your empathy guide.
+
+## Related Commands
+
+- `/cmo:work` — Execute the plan (previous step)
+- `/cmo:compound` — Document learnings (next step)
+- `/cmo:plan` — Plan a campaign (start of cycle)
+- `/cmo` — Full CMO orchestration

--- a/skills/cmo-work/SKILL.md
+++ b/skills/cmo-work/SKILL.md
@@ -1,0 +1,254 @@
+---
+name: cmo:work
+description: "Execute a marketing plan efficiently — generate content, build assets, and distribute across channels. Use when the user has a marketing plan and wants to start producing. Triggers on 'execute the plan', 'start the campaign', 'build the content', 'run the marketing', or any request to produce marketing deliverables from a plan."
+argument-hint: "[plan file path, campaign description, or content brief]"
+metadata:
+  version: 1.0.0
+category: workflow
+tier: orchestration
+reads:
+  - brand/voice-profile.md
+  - brand/positioning.md
+  - brand/audience.md
+  - marketing/plans/
+writes:
+  - marketing/content/
+  - marketing/social/
+  - marketing/email/
+triggers:
+  - execute plan
+  - start campaign
+  - build content
+  - run marketing
+  - produce assets
+---
+
+# /cmo:work — Marketing Plan Execution
+
+Execute a marketing plan by invoking the right skills in the right order, producing all deliverables, and tracking progress.
+
+## Introduction
+
+This command takes a marketing plan (from `/cmo:plan` or a brief) and executes it systematically. The focus is on **shipping complete marketing** — producing all content, building all assets, and setting up distribution.
+
+This is step 2 of the marketing workflow cycle: **plan** -> **work** -> **review** -> **compound**.
+
+## Input Document
+
+<input_document> #$ARGUMENTS </input_document>
+
+## Execution Workflow
+
+### Phase 1: Quick Start
+
+1. **Read Plan and Clarify**
+
+   - Read the work document completely
+   - Check `mktg status --json` for current brand state
+   - Load brand context: `brand/voice-profile.md`, `brand/positioning.md`, `brand/audience.md`
+   - If anything is unclear or ambiguous, ask clarifying questions now
+   - Get user approval to proceed
+   - **Do not skip this** — better to ask now than produce off-brand content
+
+2. **Check Prerequisites**
+
+   ```bash
+   mktg doctor
+   ```
+
+   Verify:
+   - Brand files exist that the plan references
+   - Required skills are installed (`mktg list --json`)
+   - Any external tools needed are available (playwright-cli, gws, etc.)
+
+   If brand files are missing:
+   - For voice: suggest running `brand-voice` first
+   - For audience: suggest running `audience-research` first
+   - For positioning: suggest running `positioning-angles` first
+   - Or proceed with defaults if the user wants speed
+
+3. **Build Task List**
+
+   Parse the plan's execution phases and content table into actionable tasks:
+   - Break each content asset into: research -> draft -> refine -> distribute
+   - Include dependencies (e.g., landing page copy before email sequence)
+   - Prioritize based on the plan's phase structure
+   - Include quality check tasks between phases
+
+### Phase 2: Execute
+
+1. **Skill Execution Loop**
+
+   For each content asset or tactic in the plan:
+
+   ```
+   while (tasks remain):
+     - Mark task as in_progress
+     - Load relevant brand context for this skill
+     - Invoke the mapped mktg skill (see Skill Routing below)
+     - Write output to the correct directory
+     - Mark task as completed
+     - Check off the corresponding item in the plan file ([ ] -> [x])
+   ```
+
+   **IMPORTANT**: Always update the plan document by checking off completed items. Use the Edit tool to change `- [ ]` to `- [x]` for each deliverable you finish.
+
+2. **Skill Routing**
+
+   Map plan tactics to skills:
+
+   | Plan Says | Invoke | Output Directory |
+   |-----------|--------|-----------------|
+   | Landing page / sales copy | `direct-response-copy` | `marketing/content/` |
+   | SEO article / blog post | `seo-content` | `marketing/content/` |
+   | Email sequence | `email-sequences` | `marketing/email/` |
+   | Social posts | `content-atomizer` | `marketing/social/` |
+   | Lead magnet | `lead-magnet` | `marketing/content/` |
+   | Newsletter | `newsletter` | `marketing/email/` |
+   | Comparison page | `competitor-alternatives` | `marketing/content/` |
+   | Visual assets | `creative` | `marketing/creative/` |
+   | SEO audit | `seo-audit` | `marketing/audits/` |
+   | CRO audit | `page-cro` | `marketing/audits/` |
+   | Pricing page | `pricing-strategy` | `marketing/content/` |
+   | Referral program | `referral-program` | `marketing/growth/` |
+   | Free tool | `free-tool-strategy` | `marketing/growth/` |
+
+3. **Content Production Rules**
+
+   - Every piece of content MUST use brand voice from `brand/voice-profile.md`
+   - Every piece MUST target the audience segment from the plan
+   - Apply `marketing-psychology` principles where the plan specifies
+   - Use `--dry-run` before any external publishing actions
+   - Write all outputs with YAML front-matter for structured handoffs
+
+4. **Progressive Output**
+
+   After each major deliverable:
+   - Announce what was produced and where it was saved
+   - Show a brief preview (first few lines or key headline)
+   - Continue to next task without waiting for approval (unless the plan specifies checkpoints)
+
+5. **Distribution Setup**
+
+   When the plan includes distribution:
+   - Generate platform-specific content via `content-atomizer`
+   - Prepare email sends (draft only — never send without `--dry-run` confirmation)
+   - Queue social posts (draft to files, not posted)
+   - Flag any actions that require manual steps (e.g., paid ads, partnerships)
+
+### Phase 3: Quality Check
+
+1. **Content Quality Scan**
+
+   Review all produced content for:
+   - [ ] Brand voice consistency (matches `brand/voice-profile.md`)
+   - [ ] Audience alignment (speaks to the right segment)
+   - [ ] Positioning accuracy (reflects `brand/positioning.md`)
+   - [ ] No placeholder text or TODO markers left
+   - [ ] YAML front-matter present on all files
+   - [ ] Cross-links between related content pieces
+
+2. **Completeness Check**
+
+   - [ ] All plan items checked off (`- [x]`)
+   - [ ] All content files written to correct directories
+   - [ ] Distribution content generated for each channel in the plan
+   - [ ] No orphaned content (everything maps to a distribution channel)
+
+3. **CLI Validation**
+
+   ```bash
+   mktg status --json
+   ```
+
+   Verify content counts match what the plan specified.
+
+### Phase 4: Ship It
+
+1. **Commit Marketing Assets**
+
+   ```bash
+   git add marketing/
+   git status
+   git commit -m "feat(marketing): [campaign name] — [what was produced]"
+   ```
+
+2. **Summary Report**
+
+   Present to the user:
+
+   ```markdown
+   ## Campaign Execution Complete
+
+   **Plan:** marketing/plans/[filename]
+   **Assets produced:** [count]
+
+   ### Deliverables
+   | Asset | Location | Status |
+   |-------|----------|--------|
+   | [name] | [path] | Done |
+
+   ### Distribution Ready
+   | Channel | Content | Status |
+   |---------|---------|--------|
+   | [channel] | [content] | Draft ready |
+
+   ### Next Steps
+   1. Run `/cmo:review` to quality-check all output
+   2. Review drafts before publishing
+   3. Use `mktg post --dry-run` to preview distribution
+   ```
+
+3. **Offer Next Steps**
+
+   Use the **AskUserQuestion tool**:
+
+   **Question:** "Marketing assets complete. What would you like to do next?"
+
+   **Options:**
+   1. **Run `/cmo:review`** — Quality review of all produced content
+   2. **Preview distribution** — `mktg post --dry-run` to see what would be published
+   3. **Adjust content** — Revise specific deliverables
+   4. **Push to remote** — `git push` to share with team
+
+## Key Principles
+
+### Execute, Don't Deliberate
+- The plan already made the decisions. Execute them.
+- If something is unclear, check the plan first, then ask.
+- Speed matters — marketing has a shelf life.
+
+### Brand Voice Is Non-Negotiable
+- Every word must sound like the brand.
+- Load `brand/voice-profile.md` before every content skill invocation.
+- If voice feels off, stop and recalibrate before producing more.
+
+### Skills Are Your Toolkit
+- Each content type maps to a specific mktg skill.
+- Skills read brand context and write structured output.
+- You orchestrate the skills — skills don't call each other.
+
+### Track Progress in the Plan
+- Check off items as you complete them.
+- The plan is the single source of truth for campaign progress.
+- Anyone should be able to open the plan and see what's done vs. remaining.
+
+### Distribution > Creation
+- Apply the 30/70 rule: 30% creation, 70% distribution.
+- Every content piece should appear on 3+ channels.
+- Use `content-atomizer` aggressively — one asset becomes many.
+
+## Common Pitfalls to Avoid
+
+- **Skipping brand context** — Content without brand voice is generic content
+- **Producing without a plan** — Use `/cmo:plan` first to avoid wasted work
+- **Forgetting distribution** — Great content nobody sees is wasted content
+- **Publishing without review** — Always run `/cmo:review` before going live
+- **Over-creating** — Produce what the plan says, not more
+
+## Related Commands
+
+- `/cmo:plan` — Create the plan (previous step)
+- `/cmo:review` — Review output quality (next step)
+- `/cmo:compound` — Document campaign learnings (after review)
+- `/cmo` — Full CMO orchestration


### PR DESCRIPTION
## Summary

Port compound-engineering's workflow cycle (`ce:plan` → `ce:work` → `ce:review` → `ce:compound`) into marketing equivalents for mktg.

- **`cmo:plan`** — Plan marketing campaigns with brand context, audience analysis, channel strategy, and structured plan documents in `marketing/plans/`
- **`cmo:work`** — Execute marketing plans by invoking the right skills in order, producing all content deliverables, and tracking progress
- **`cmo:review`** — Review marketing output for brand voice consistency, conversion effectiveness, audience alignment, and positioning accuracy
- **`cmo:compound`** — Document campaign learnings to compound marketing intelligence over time in `marketing/learnings/`

## Design Decisions

- Each skill follows CE's SKILL.md format (frontmatter with metadata, reads/writes, triggers)
- Skills reference each other forming a complete cycle: plan → work → review → compound → plan (informed)
- All skills integrate with `mktg` CLI commands (`mktg status --json`, `mktg doctor`, `mktg list --json`)
- Brand context loading is built into every skill (reads `brand/voice-profile.md`, `brand/positioning.md`, `brand/audience.md`)
- Marketing-domain specific patterns: ORB framework, 30/70 creation/distribution rule, brand voice as P1 quality gate

## Test plan

- [x] All 525 existing tests pass
- [ ] Verify each SKILL.md has valid YAML frontmatter
- [ ] Verify skills cross-reference each other correctly
- [ ] Verify no existing skills were modified

Closes #2