### PR TITLE
feat: add references/ and workflows/ to existing skills (CE pattern)

### DIFF
--- a/skills/brand-voice/references/tone-matrix.md
+++ b/skills/brand-voice/references/tone-matrix.md
@@ -1,0 +1,279 @@
+<overview>
+The tone matrix maps how voice adapts across different content situations while maintaining brand consistency. Voice is WHO you are (stable). Tone is HOW you say it in context (variable). This reference defines the situational tone shifts that make a brand feel human — celebrating wins differently than handling complaints, explaining features differently than announcing outages.
+</overview>
+
+<voice_vs_tone>
+## Voice vs. Tone: The Critical Distinction
+
+**Voice** = your brand's personality. It doesn't change.
+**Tone** = how that personality expresses itself in a specific situation. It always changes.
+
+Think of a person: your friend has the same personality whether they're giving a toast at a wedding or apologizing for being late. But their tone is completely different. Brands work the same way.
+
+**Example — same voice, different tone:**
+
+Voice: Confident, warm, direct
+
+| Situation | Tone | Example |
+|-----------|------|---------|
+| Feature announcement | Excited, proud | "We've been cooking. Here's what's new." |
+| Outage notification | Calm, accountable | "We're on it. Here's what happened and what we're doing." |
+| Onboarding welcome | Warm, guiding | "Welcome in. Let's get you set up — takes about 2 minutes." |
+| Pricing page | Clear, confident | "Simple pricing. No surprises. Pick the plan that fits." |
+| Churn save | Honest, empathetic | "We get it — not every tool is forever. Before you go, can we help?" |
+
+The voice (confident, warm, direct) is constant. The tone shifts to match the emotional context of each situation.
+</voice_vs_tone>
+
+<the_tone_matrix>
+## The Tone Matrix
+
+Map your brand's tone across these 12 common content situations:
+
+### Situation 1: Welcome / Onboarding
+**Emotional context:** User is excited but uncertain. First impression.
+**Tone goal:** Make them feel smart, not overwhelmed.
+
+| Attribute | Setting |
+|-----------|---------|
+| Warmth | High — they just chose you |
+| Pace | Slow — one step at a time |
+| Jargon | Zero — assume nothing |
+| Humor | Light — ease tension |
+| CTA energy | Gentle — "when you're ready" not "DO THIS NOW" |
+
+**Pattern:** Acknowledge → Orient → First win → Next step
+**Example:** "You're in! Let's start with the one thing that'll save you the most time. [Single action button]"
+
+### Situation 2: Feature Announcement
+**Emotional context:** You're proud. User needs to understand value quickly.
+**Tone goal:** Transfer your excitement without being salesy.
+
+| Attribute | Setting |
+|-----------|---------|
+| Warmth | Medium — professional enthusiasm |
+| Pace | Quick — lead with the benefit |
+| Jargon | Low — accessible to all users |
+| Humor | Optional — depends on feature gravity |
+| CTA energy | Medium — "try it now" |
+
+**Pattern:** Benefit headline → What it does → How to use it → What's next
+**Example:** "New: Schedule posts for the whole week in 5 minutes. Here's how."
+
+### Situation 3: Error / Failure State
+**Emotional context:** User is frustrated. Something went wrong.
+**Tone goal:** Defuse frustration, restore confidence, provide a path forward.
+
+| Attribute | Setting |
+|-----------|---------|
+| Warmth | High — acknowledge the frustration |
+| Pace | Immediate — don't make them read |
+| Jargon | Zero — "something went wrong" not "500 Internal Server Error" |
+| Humor | Very careful — only if error is minor and tone is already playful |
+| CTA energy | Clear — exactly what to do next |
+
+**Pattern:** Acknowledge → Explain (briefly) → Fix path → Assurance
+**Example:** "That didn't work — looks like the file was too large. Try one under 10MB, or drag it here to compress automatically."
+
+**Anti-pattern:** "Oops! Something went wrong 🙃" — Feels dismissive when the user just lost work. Match the tone to the severity.
+
+### Situation 4: Pricing / Sales
+**Emotional context:** User is evaluating. Trust is being tested.
+**Tone goal:** Be clear and confident, never pushy.
+
+| Attribute | Setting |
+|-----------|---------|
+| Warmth | Medium — professional, not salesy |
+| Pace | Scannable — they're comparing |
+| Jargon | None — "per seat/month" not "per provisioned user entity" |
+| Humor | Minimal — money is serious |
+| CTA energy | Confident — "Start free" not "BUY NOW" |
+
+**Pattern:** Value first → Price → What's included → FAQ → CTA
+**Example:** "Everything you need to launch. $29/mo. No setup fees, cancel anytime."
+
+### Situation 5: Support / Help
+**Emotional context:** User is stuck and potentially frustrated.
+**Tone goal:** Be the calm, competent friend who knows the answer.
+
+| Attribute | Setting |
+|-----------|---------|
+| Warmth | High — they need help |
+| Pace | Step-by-step — don't skip |
+| Jargon | Define everything — they're learning |
+| Humor | None — they want solutions |
+| CTA energy | Supportive — "let us know if that doesn't work" |
+
+**Pattern:** Empathize → Solution → Steps → Verify → Offer more help
+**Example:** "Frustrating, I know. Here's the fix: [steps]. Still stuck? Hit reply — we're here."
+
+### Situation 6: Success / Celebration
+**Emotional context:** User achieved something. Positive moment.
+**Tone goal:** Amplify their win. Make them feel good.
+
+| Attribute | Setting |
+|-----------|---------|
+| Warmth | Highest — share their joy |
+| Pace | Brief — don't over-explain a good moment |
+| Jargon | N/A |
+| Humor | Welcome — good vibes |
+| CTA energy | Gentle — suggest next goal, don't push |
+
+**Pattern:** Celebrate → Acknowledge effort → Suggest next step
+**Example:** "Your first campaign just hit 1,000 views. That's not luck — that's your strategy working. Ready to double it?"
+
+### Situation 7: Outage / Incident
+**Emotional context:** Users are worried. Trust is at risk.
+**Tone goal:** Be the calm, accountable adult in the room.
+
+| Attribute | Setting |
+|-----------|---------|
+| Warmth | Medium — professional, not sentimental |
+| Pace | Immediate — fast updates |
+| Jargon | Technical enough to show competence, plain enough to understand |
+| Humor | Absolutely none |
+| CTA energy | Informational — "we'll update you in 30 minutes" |
+
+**Pattern:** Status → Impact → Cause (if known) → Fix timeline → Next update
+**Example:** "We're experiencing slowdowns in email delivery. Some campaigns may be delayed up to 2 hours. Our team is actively working on this. Next update at 3pm ET."
+
+**Rule:** Never say "we're sorry for any inconvenience." Say specifically what happened and what you're doing. Generic apologies erode trust.
+
+### Situation 8: Asking for Feedback
+**Emotional context:** You need something from the user.
+**Tone goal:** Make it easy and make them feel valued.
+
+| Attribute | Setting |
+|-----------|---------|
+| Warmth | High — you're asking a favor |
+| Pace | Quick — respect their time |
+| Jargon | None |
+| Humor | Light — keep it conversational |
+| CTA energy | Low-pressure — "if you have 2 minutes" |
+
+**Pattern:** Why their input matters → Specific ask → Time estimate → Thank
+**Example:** "Quick question: what's the one feature you wish we had? (Takes 30 seconds.) Your answer directly shapes our roadmap."
+
+### Situation 9: Re-engagement / Win-back
+**Emotional context:** User has gone quiet. You miss them.
+**Tone goal:** Honest, zero guilt-trip, provide genuine value.
+
+| Attribute | Setting |
+|-----------|---------|
+| Warmth | High but not needy |
+| Pace | Brief — they haven't been paying attention |
+| Jargon | None — re-orient them |
+| Humor | Can work well — self-deprecating |
+| CTA energy | Low — open door, don't push |
+
+**Pattern:** Acknowledge absence (lightly) → What's new (one thing) → Easy re-entry
+**Example:** "It's been a while. We've shipped some things you might like — [one specific feature]. Your account is right where you left it."
+
+**Anti-pattern:** "We miss you! 😢 Come back!" — Desperation is never a good tone. Neither is guilt: "You haven't logged in for 47 days."
+
+### Situation 10: Upsell / Upgrade
+**Emotional context:** User is on a lower tier. You want them to upgrade.
+**Tone goal:** Show value, never pressure.
+
+| Attribute | Setting |
+|-----------|---------|
+| Warmth | Medium |
+| Pace | Contextual — trigger when they hit a limit |
+| Jargon | Feature-specific |
+| Humor | None — money decision |
+| CTA energy | Medium — "see plans" not "UPGRADE NOW" |
+
+**Pattern:** Show what they're missing → Concrete benefit → Easy comparison → No urgency
+**Example:** "You've sent 950 of 1,000 emails this month. Need more? Pro gives you unlimited sends + analytics. See plans →"
+
+### Situation 11: Educational Content
+**Emotional context:** User wants to learn. They trust you as a source.
+**Tone goal:** Be the expert teacher, not the textbook.
+
+| Attribute | Setting |
+|-----------|---------|
+| Warmth | Medium-high — approachable expert |
+| Pace | Thorough but not dense |
+| Jargon | Define on first use |
+| Humor | Occasional — keeps attention |
+| CTA energy | Learning-focused — "try this" not "buy this" |
+
+**Pattern:** Hook → Context → Teaching → Example → Practice → Next
+**Example:** "Most SEO guides overcomplicate this. Here's the one thing that actually moves the needle for pages under 6 months old: [specific actionable insight]."
+
+### Situation 12: Social Media
+**Emotional context:** Casual, mixed attention, high competition for attention.
+**Tone goal:** Be the follow worth keeping. Value or personality in every post.
+
+| Attribute | Setting |
+|-----------|---------|
+| Warmth | Platform-dependent (Twitter: direct, LinkedIn: professional, IG: visual) |
+| Pace | Maximum brevity — earn every word |
+| Jargon | Minimal — broad audience |
+| Humor | Higher than other channels — personality differentiates |
+| CTA energy | Soft — engagement over conversion |
+
+**Pattern:** Hook (first line) → Value or insight → Engagement ask (optional)
+**Example (Twitter):** "Hot take: your launch strategy doesn't need 47 steps. It needs 3 things: a list, a landing page, and something worth talking about. Thread 🧵"
+</the_tone_matrix>
+
+<building_your_matrix>
+## How to Build Your Brand's Tone Matrix
+
+### Step 1: Define Your Voice Constants
+These never change regardless of situation:
+- Core personality traits (3-4 adjectives with definitions)
+- Vocabulary rules (words you always/never use)
+- Structural patterns (sentence length, paragraph length)
+- POV rules (first person, reader address)
+
+### Step 2: Score Each Situation
+For each of the 12 situations above, define:
+- Which voice constants stay at baseline
+- Which attributes shift and by how much
+- One "do this" example
+- One "not this" example
+
+### Step 3: Create the Quick-Reference Matrix
+
+```markdown
+| Situation | Warmth | Pace | Humor | Energy | CTA |
+|-----------|--------|------|-------|--------|-----|
+| Welcome | ↑↑ | Slow | Light | Gentle | Soft |
+| Feature | ↑ | Quick | Optional | Medium | Medium |
+| Error | ↑↑ | Immediate | None* | Clear | Direct |
+| Pricing | → | Scannable | None | Confident | Strong |
+| Support | ↑↑ | Step-by-step | None | Supportive | Helpful |
+| Success | ↑↑↑ | Brief | Welcome | High | Gentle |
+| Outage | → | Immediate | NEVER | Calm | Informational |
+| Feedback | ↑ | Quick | Light | Low-pressure | Soft |
+| Win-back | ↑ | Brief | Can work | Low | Open door |
+| Upsell | → | Contextual | None | Medium | Medium |
+| Education | ↑ | Thorough | Occasional | Motivating | Learning |
+| Social | Varies | Maximum brevity | Higher | Punchy | Soft |
+```
+
+*Error humor: only if your brand is 7+ on the humor dimension AND the error is minor (e.g., 404 page, not data loss).
+
+### Step 4: Write Sample Copy
+For each situation, write one real example in your brand's voice. These become the reference standard — when in doubt, match the sample.
+
+### Step 5: Validate
+Test each sample with the question: "If a customer saw this, would they feel [intended emotion]?" If not, adjust.
+</building_your_matrix>
+
+<anti_patterns>
+## Tone Anti-Patterns
+
+**The Robot:** Same tone in every situation. No emotional range. Feels like talking to a corporate FAQ.
+
+**The Chameleon:** Tone shifts so dramatically between channels that it doesn't feel like the same brand. Twitter is Gen-Z slang, LinkedIn is corporate speak, emails are academic.
+
+**The Overcompensator:** Crisis happens → brand tries to be funny to deflect. Error loses user data → "Oops! Our bad 😅." Severity mismatch destroys trust.
+
+**The Guilt-Tripper:** Win-back emails that make users feel bad: "We noticed you haven't been around... did we do something wrong? 😢" Manipulation ≠ tone.
+
+**The Hype Machine:** Every feature announcement is "GAME-CHANGING" and "REVOLUTIONARY." When everything is exciting, nothing is. Save high energy for genuinely big moments.
+
+**The Template Voice:** Copy-pasting the same structure with different nouns. "Introducing [Feature]! [Feature] helps you [verb] your [noun]. Get started with [Feature] today!" Users can smell templates.
+</anti_patterns>

--- a/skills/brand-voice/references/voice-dimensions.md
+++ b/skills/brand-voice/references/voice-dimensions.md
@@ -1,0 +1,188 @@
+<overview>
+Deep reference on the measurable dimensions that define a brand voice. Goes beyond "we're friendly and professional" into specific, actionable voice attributes that can be consistently applied across content, copy, and conversation. Each dimension is a spectrum — the skill is choosing WHERE on each spectrum your brand sits and staying there.
+</overview>
+
+<why_dimensions_matter>
+## Why Voice Dimensions > Adjectives
+
+Most brand voice guides say things like "our voice is friendly, professional, and innovative." This is useless because:
+
+1. **Everyone says this.** "Friendly and professional" describes 95% of brands. It differentiates nothing.
+2. **It's not actionable.** A writer can't take "innovative" and produce consistent copy.
+3. **It's not measurable.** How do you review content against "friendly"? What's friendly to one person is annoying to another.
+
+**Dimensions solve this** by defining voice as specific positions on measurable spectrums. Instead of "friendly," you get: "Casual tone (7/10 on formal-casual spectrum), uses contractions, first-person plural, addresses reader as 'you,' opens emails with conversational hooks not corporate greetings."
+
+A new writer, a freelancer, or an AI agent can take dimensional definitions and produce consistent output on the first try.
+</why_dimensions_matter>
+
+<core_dimensions>
+## The 7 Core Voice Dimensions
+
+### Dimension 1: Formality Spectrum
+**Range:** Corporate ← → Conversational
+
+| Score | Sounds Like | Example |
+|-------|------------|---------|
+| 1 | Legal document | "Users shall be notified of modifications to the service terms." |
+| 3 | Business report | "We will notify all users of any changes to our terms of service." |
+| 5 | Professional blog | "We'll let you know if anything changes in our terms." |
+| 7 | Friendly email | "Heads up — we're updating our terms. Here's what changed." |
+| 9 | Text to a friend | "yo we changed some stuff in the fine print, nothing major" |
+
+**What to define:**
+- Contractions: always / sometimes / never
+- Sentence openers: "Furthermore" vs "Plus" vs "Oh, and"
+- Greetings: "Dear valued customer" vs "Hey [name]" vs no greeting
+- Sign-offs: "Best regards" vs "Cheers" vs "— [name]"
+
+### Dimension 2: Authority Spectrum
+**Range:** Peer ← → Expert
+
+| Score | Sounds Like | Example |
+|-------|------------|---------|
+| 1 | Fellow learner | "I'm figuring this out too, but here's what's working for me..." |
+| 3 | Experienced peer | "I've tried a lot of approaches — here's what actually works." |
+| 5 | Trusted advisor | "Based on hundreds of launches, here's the framework that works." |
+| 7 | Industry expert | "The data across 10,000 launches shows three clear patterns." |
+| 9 | Academic authority | "Our longitudinal analysis of product launch outcomes reveals..." |
+
+**What to define:**
+- Qualifier usage: "I think" vs "In my experience" vs "The data shows"
+- Source citation style: anecdotal vs data-driven vs research-cited
+- Confidence level: hedging ("might work") vs assertive ("this works")
+- Teaching style: collaborative discovery vs authoritative instruction
+
+### Dimension 3: Humor Spectrum
+**Range:** Serious ← → Playful
+
+| Score | Sounds Like | Example |
+|-------|------------|---------|
+| 1 | No humor | "Email marketing drives 4,200% ROI on average." |
+| 3 | Dry wit | "Email marketing drives 4,200% ROI. Yes, that number is real. No, we didn't add a zero." |
+| 5 | Lighthearted | "Email marketing's ROI is frankly absurd — 4,200%. Your email list is your best friend." |
+| 7 | Regularly funny | "Email marketing ROI: 4,200%. That's not a typo. Your email list is basically a money printer." |
+| 9 | Comedy-first | "Plot twist: the most valuable marketing channel is the one your CEO hasn't checked since 2019. It's email. Email absolutely slaps." |
+
+**What to define:**
+- Humor frequency: never / occasional / regular / constant
+- Humor type: wordplay / self-deprecation / absurdist / observational
+- Where humor is OK: headlines / body / CTAs / error messages / all
+- Where humor is NOT OK: pricing / legal / security / crisis comms
+
+### Dimension 4: Complexity Spectrum
+**Range:** Simple ← → Sophisticated
+
+| Score | Sounds Like | Example |
+|-------|------------|---------|
+| 1 | ELI5 | "SEO means making Google find your website." |
+| 3 | Beginner-friendly | "SEO is the practice of optimizing your content so search engines rank it higher." |
+| 5 | Educated generalist | "SEO combines technical optimization, content strategy, and link building to improve organic search visibility." |
+| 7 | Industry professional | "On-page SEO encompasses entity optimization, semantic topical coverage, and structured data implementation." |
+| 9 | Technical specialist | "Leveraging TF-IDF analysis alongside BERT-informed entity salience scoring for topical authority modeling." |
+
+**What to define:**
+- Jargon policy: avoid / define on first use / use freely
+- Acronym policy: always expand / expand on first use / use freely
+- Assumed knowledge: zero / basic digital literacy / industry familiarity / technical expertise
+- Explanation depth: surface / practical / comprehensive / exhaustive
+
+### Dimension 5: Warmth Spectrum
+**Range:** Detached ← → Empathetic
+
+| Score | Sounds Like | Example |
+|-------|------------|---------|
+| 1 | Clinical | "Users who fail to convert may retry the onboarding flow." |
+| 3 | Neutral | "If signup didn't work, you can try again." |
+| 5 | Supportive | "Having trouble signing up? No worries — let's get you in." |
+| 7 | Encouraging | "Signup hiccup? Happens to everyone. Let's sort this out together." |
+| 9 | Emotionally expressive | "Ugh, signup issues are the worst! We're SO sorry. Let's fix this right now." |
+
+**What to define:**
+- Emotional acknowledgment: ignore / note / validate / mirror
+- Apology style: never / when at fault / proactively / frequently
+- Encouragement frequency: never / at milestones / regularly / constantly
+- Reader address: impersonal / "you" / "you and me" / "we together"
+
+### Dimension 6: Energy Spectrum
+**Range:** Calm ← → Urgent
+
+| Score | Sounds Like | Example |
+|-------|------------|---------|
+| 1 | Zen | "When you're ready, you might consider exploring our launch guide." |
+| 3 | Steady | "Our launch guide can help you plan your next release." |
+| 5 | Motivating | "Ready to launch? Our guide has everything you need to make it happen." |
+| 7 | Energetic | "It's launch time! Grab our guide and let's get your product out there." |
+| 9 | Hyperbolic | "🚀 THIS CHANGES EVERYTHING!!! Our INSANE launch guide will BLOW YOUR MIND!!!" |
+
+**What to define:**
+- Exclamation marks: never / rare / occasional / frequent
+- Superlatives: banned / rare / common
+- Urgency language: "when you're ready" vs "start now" vs "don't wait"
+- CTA energy: soft ("learn more") / medium ("get started") / strong ("start free today")
+
+### Dimension 7: Originality Spectrum
+**Range:** Conventional ← → Distinctive
+
+| Score | Sounds Like | Example |
+|-------|------------|---------|
+| 1 | Industry standard | "We help businesses grow with proven marketing strategies." |
+| 3 | Slightly differentiated | "We help businesses grow — without the marketing BS." |
+| 5 | Noticeably different | "Marketing doesn't have to feel like marketing. We build growth systems that don't make you cringe." |
+| 7 | Strongly distinctive | "We're the anti-marketing marketing tool. No funnels. No hacks. Just stuff that works." |
+| 9 | Unmistakable | "Everyone's selling you 'growth hacks.' We're selling you a nap. Automate your marketing, reclaim your weekends." |
+
+**What to define:**
+- Metaphor usage: none / occasional / signature metaphors
+- Coined terms: none / a few internal terms / signature vocabulary
+- Category convention: follow / bend / break
+- Cliché policy: unavoidable / minimize / actively replace with fresh language
+</core_dimensions>
+
+<dimension_profile_template>
+## How to Create a Dimension Profile
+
+Score each dimension 1-10, then document the implications:
+
+```markdown
+## Voice Dimension Profile
+
+| Dimension | Score | Anchor |
+|-----------|-------|--------|
+| Formality | 6 | Professional but uses contractions, first names |
+| Authority | 7 | Expert with data, but admits uncertainty |
+| Humor | 4 | Dry wit, never slapstick, rare in headlines |
+| Complexity | 5 | Educated generalist, define jargon on first use |
+| Warmth | 6 | Supportive, acknowledges frustration, not gushy |
+| Energy | 5 | Motivating but not breathless, rare exclamation marks |
+| Originality | 6 | Breaks some conventions, avoids clichés, few coined terms |
+
+### Implications for Content
+
+**Sentence starters:** "Here's the thing:" ✅ "Let us explore:" ❌
+**Contractions:** Always ✅ "Do not" sounds robotic for us ❌
+**Addressing reader:** "you" always, "we" for company, "I" for founder's posts
+**Paragraph openers to avoid:** "In today's fast-paced world..." / "It goes without saying..." / "As we all know..."
+**Paragraph openers to use:** "The short answer:" / "Here's what works:" / "Most guides miss this:"
+```
+
+**Validation test:** Give the dimension profile to three different writers (or agents). Have them each write the same 200-word product description. If the outputs feel like the same brand, the profile works. If they diverge, the profile needs more specificity.
+</dimension_profile_template>
+
+<platform_adjustments>
+## Dimension Shifts by Platform
+
+Voice dimensions aren't static — they shift by platform. Define the baseline, then document adjustments:
+
+| Dimension | Baseline | Email | Twitter/X | LinkedIn | Landing Page | Docs |
+|-----------|----------|-------|-----------|----------|--------------|------|
+| Formality | 6 | 7 (warmer) | 5 (looser) | 6 (same) | 5 (direct) | 7 (precise) |
+| Authority | 7 | 6 (peer) | 7 (opinionated) | 8 (thought leader) | 7 (expert) | 9 (reference) |
+| Humor | 4 | 5 (more personal) | 6 (punchier) | 3 (restrained) | 2 (focused) | 1 (none) |
+| Complexity | 5 | 4 (simpler) | 3 (shortest) | 5 (same) | 4 (scannable) | 7 (thorough) |
+| Warmth | 6 | 7 (personal) | 5 (direct) | 5 (professional) | 6 (empathetic) | 3 (factual) |
+| Energy | 5 | 6 (action-oriented) | 7 (punchy) | 5 (steady) | 7 (motivating) | 3 (calm) |
+| Originality | 6 | 5 (familiar) | 8 (distinctive) | 5 (professional) | 7 (memorable) | 2 (standard) |
+
+**Rule:** Never shift any dimension more than ±2 from baseline on any platform. Larger shifts make the brand feel inconsistent — like a different company is speaking on each channel.
+</platform_adjustments>

--- a/skills/launch-strategy/references/launch-checklist.md
+++ b/skills/launch-strategy/references/launch-checklist.md
@@ -1,0 +1,207 @@
+<overview>
+Exhaustive pre-launch, launch-day, and post-launch checklists organized by channel. Every item is a concrete action — not a vague reminder. Use this as the single source of truth for launch readiness. Nothing ships until every required item is checked.
+</overview>
+
+<pre_launch_checklist>
+## Pre-Launch Checklist (Complete Before Launch Day)
+
+### Product Readiness
+- [ ] Core user flow works end-to-end without errors
+- [ ] Onboarding sequence tested with 3+ new users who had zero prior context
+- [ ] Error states have helpful messages (not stack traces or generic errors)
+- [ ] Loading states exist for every async operation
+- [ ] Mobile responsive (if web) or device-tested (if native)
+- [ ] Analytics tracking confirmed: signup, activation, key feature usage
+- [ ] Billing/pricing page live and tested with real payment method
+- [ ] Support channel defined and monitored (email, chat, or community)
+
+### Landing Page
+- [ ] Hero headline matches validated positioning (customer language, not founder language)
+- [ ] Social proof visible above the fold (testimonials, logos, metrics)
+- [ ] Single clear CTA — no competing actions
+- [ ] Page loads in under 3 seconds on mobile
+- [ ] Meta title and description optimized for target keyword
+- [ ] Open Graph image set (shows correctly when shared on Twitter/LinkedIn)
+- [ ] Favicon and site title set
+- [ ] All links work (zero 404s)
+- [ ] Cookie consent / privacy policy if required by jurisdiction
+
+### Email
+- [ ] Welcome sequence (3-5 emails) written, tested, and active
+- [ ] Launch announcement email drafted and approved
+- [ ] Email sender reputation warmed (if new domain, send 50+ emails over 2 weeks first)
+- [ ] Unsubscribe link works
+- [ ] Email renders correctly in Gmail, Apple Mail, Outlook
+- [ ] Merge tags tested (first name, etc.)
+- [ ] Reply-to address monitored by a human
+
+### Content
+- [ ] At least 1 long-form piece published and indexed (blog post, guide, or tutorial)
+- [ ] 3+ comparison/alternative pages published (if applicable)
+- [ ] FAQ page or section with 10+ real questions from beta users
+- [ ] All content reviewed for brand voice consistency
+
+### Social
+- [ ] Twitter/X thread drafted (10+ tweets telling the story)
+- [ ] LinkedIn post drafted (long-form, personal narrative)
+- [ ] All social profiles updated with product link in bio
+- [ ] Social images/videos created and sized for each platform
+- [ ] 10+ supporters briefed and ready to share/comment on launch day
+
+### Product Hunt (if applicable)
+- [ ] Listing complete: name, tagline (60 chars max), description, topics
+- [ ] 5+ high-quality screenshots or GIF demos
+- [ ] Maker video recorded (60-90 seconds, authentic, not polished)
+- [ ] First comment drafted (the "maker comment" — personal story + what you're building)
+- [ ] Hunter confirmed (if using one) — ideally someone with 1000+ followers on PH
+- [ ] Launch date confirmed (Tuesday-Thursday, avoid holidays and major tech events)
+- [ ] "Coming soon" page has 100+ followers
+
+### Legal / Compliance
+- [ ] Terms of service published
+- [ ] Privacy policy published
+- [ ] GDPR/CCPA compliance verified (if applicable)
+- [ ] Trademark search done for product name
+- [ ] Domain and social handles secured
+</pre_launch_checklist>
+
+<launch_day_checklist>
+## Launch Day Checklist
+
+### Hour-by-Hour Execution
+
+**T-12 hours (night before):**
+- [ ] Final check: all links, pages, and flows work
+- [ ] Social posts scheduled (or ready to manually post)
+- [ ] Team Slack/Discord channel set up for real-time coordination
+- [ ] Coffee stocked, schedule cleared for the day
+
+**T-0 (launch moment):**
+- [ ] Product Hunt listing goes live (if applicable — aim for 12:01am PT)
+- [ ] Landing page switched from "coming soon" to launch version
+- [ ] Pricing page activated
+
+**T+1 hour:**
+- [ ] Launch email sent to full waitlist
+- [ ] Twitter/X thread posted
+- [ ] LinkedIn post published
+- [ ] Product Hunt maker comment posted
+- [ ] Personal messages sent to 20 closest supporters asking for shares/upvotes
+
+**T+2-4 hours:**
+- [ ] Respond to every Product Hunt comment (within 30 min of each)
+- [ ] Engage with every social mention (like, reply, repost)
+- [ ] Monitor for and fix any broken flows
+- [ ] Post in relevant communities (Reddit, Discord, Slack groups) — only where you're already an active member
+
+**T+6-12 hours:**
+- [ ] Second wave of social posts (different angle, different platform)
+- [ ] Send personal thank-you DMs to everyone who shared
+- [ ] Check analytics: signups, activation rate, any drop-off points
+- [ ] Collect screenshots of social mentions for future social proof
+
+**End of day:**
+- [ ] Document total signups, PH ranking, social metrics
+- [ ] Note every piece of user feedback received
+- [ ] Identify top 3 issues to fix tomorrow
+- [ ] Post an update thread thanking supporters
+</launch_day_checklist>
+
+<post_launch_checklist>
+## Post-Launch Checklist (Days +1 to +30)
+
+### Week 1 (Days +1-7)
+- [ ] Thank-you email to early supporters and sharers
+- [ ] Publish launch retrospective (blog post or social thread)
+- [ ] Fix top 3 issues identified on launch day
+- [ ] Reach out to every user who signed up but didn't activate
+- [ ] Collect 5+ new testimonials from launch-day users
+- [ ] Update landing page with launch metrics ("500+ signups in 24 hours")
+
+### Week 2 (Days +8-14)
+- [ ] Publish first piece of post-launch content (tutorial, case study, or update)
+- [ ] Begin second-wave outreach: press, podcasts, newsletters
+- [ ] Set up automated onboarding email sequence for new signups
+- [ ] Analyze launch funnel: where did people come from? Where did they drop off?
+- [ ] A/B test landing page headline based on launch learnings
+
+### Week 3 (Days +15-21)
+- [ ] Publish detailed case study from an early user
+- [ ] Create comparison pages for top 3 competitors (if not done pre-launch)
+- [ ] Begin regular content cadence (1-2 pieces per week)
+- [ ] Set up referral program or word-of-mouth mechanism
+- [ ] Review and respond to all Product Hunt reviews
+
+### Week 4 (Days +22-30)
+- [ ] 30-day retrospective: metrics, learnings, what worked, what didn't
+- [ ] Update positioning based on real user language (not assumed language)
+- [ ] Plan next launch moment (feature launch, milestone, or partnership)
+- [ ] Set monthly marketing OKRs based on launch data
+- [ ] Archive launch assets for reuse in future launches
+</post_launch_checklist>
+
+<channel_specific_checklists>
+## Channel-Specific Deep Checklists
+
+### Email Launch Checklist
+- [ ] Subject line A/B test planned (send to 10% of list, wait 2 hours, send winner to 90%)
+- [ ] Preview text set (not just first line of email body)
+- [ ] Single CTA button (not multiple competing links)
+- [ ] PS line with social proof or urgency
+- [ ] Plain text version checked (some readers strip HTML)
+- [ ] Send time optimized: Tuesday-Thursday, 10am recipient's timezone
+
+### Product Hunt Checklist
+- [ ] Tagline under 60 characters, benefit-focused
+- [ ] Description uses "you" language, not "we" language
+- [ ] Screenshots show the product in use, not empty states
+- [ ] Topics selected (max 3, most relevant first)
+- [ ] Maker comment tells a personal story: problem → journey → solution
+- [ ] Respond to first 10 comments with substantive replies (not just "thanks!")
+
+### Twitter/X Launch Checklist
+- [ ] Thread starts with hook (not "Excited to announce...")
+- [ ] Each tweet is self-contained (can be retweeted alone)
+- [ ] Include at least 1 image/GIF per 3 tweets
+- [ ] End with clear CTA and link
+- [ ] Thread is 7-15 tweets (sweet spot for engagement)
+- [ ] Pin thread to profile
+
+### LinkedIn Launch Checklist
+- [ ] Post starts with a personal story or insight (not product announcement)
+- [ ] Line breaks after every 1-2 sentences (LinkedIn formatting)
+- [ ] Tag 3-5 relevant people who helped or inspired the product
+- [ ] Include image or carousel
+- [ ] End with a question to drive comments
+- [ ] Reply to every comment within 24 hours
+</channel_specific_checklists>
+
+<readiness_scoring>
+## Launch Readiness Scoring
+
+Rate each category 1-5. Launch when total score is 35+.
+
+| Category | Score (1-5) | Weight | Notes |
+|----------|-------------|--------|-------|
+| Product stability | ___ | 2x | Crashes or data loss = hard stop |
+| Landing page conversion | ___ | 2x | Below 15% = not ready |
+| Email list size | ___ | 1x | 100 minimum, 500+ ideal |
+| Social proof | ___ | 1x | 5+ testimonials minimum |
+| Content published | ___ | 1x | 1 piece minimum, 5+ ideal |
+| Launch assets ready | ___ | 1x | All platform-specific assets |
+| Team availability | ___ | 1x | Full team available launch day |
+| Support readiness | ___ | 1x | Response SLA defined |
+
+**Scoring guide:**
+- 1 = Not started
+- 2 = In progress, major gaps
+- 3 = Functional but not optimized
+- 4 = Good, minor improvements possible
+- 5 = Excellent, fully optimized
+
+**Hard stops (cannot launch regardless of total score):**
+- Product stability below 3
+- Landing page conversion below 2
+- Zero social proof
+- No email list
+</readiness_scoring>

--- a/skills/launch-strategy/references/launch-timeline.md
+++ b/skills/launch-strategy/references/launch-timeline.md
@@ -1,0 +1,195 @@
+<overview>
+Master timeline for product launches across all five phases. This reference maps every critical activity to its optimal timing window, dependencies, and ownership. Use this to build phase-specific calendars and avoid the #1 launch killer: doing things in the wrong order.
+</overview>
+
+<timeline_philosophy>
+## Why Timing Matters More Than Tactics
+
+Most launches fail not because the tactics are wrong, but because they happen in the wrong sequence. You can't build buzz before you have a waitlist to capture it. You can't send a launch email before you've warmed the list. Every activity has a dependency chain — this reference maps them.
+
+**The 90-Day Mental Model:**
+- **Days -90 to -60:** Foundation (brand, positioning, assets)
+- **Days -60 to -30:** Audience building (waitlist, community, relationships)
+- **Days -30 to -7:** Pre-launch momentum (content, teasers, outreach)
+- **Days -7 to 0:** Launch execution (final checks, coordinated push)
+- **Days +1 to +30:** Post-launch compounding (follow-up, iteration, amplification)
+</timeline_philosophy>
+
+<phase_1_internal>
+## Phase 1: Internal Launch (Days -90 to -75)
+
+**Goal:** Validate core value prop with friendly users before any public presence.
+
+| Day | Activity | Dependency | Owner |
+|-----|----------|------------|-------|
+| -90 | Finalize positioning document | Brand voice defined | Founder |
+| -88 | Create internal demo/prototype | Working product | Engineering |
+| -85 | Recruit 5-10 friendly testers | Personal network | Founder |
+| -82 | Run structured feedback sessions | Testers onboarded | Product |
+| -78 | Synthesize feedback into launch brief | Feedback collected | Marketing |
+| -75 | Go/no-go decision on public launch | Launch brief reviewed | Founder |
+
+**Key outputs:**
+- Validated value proposition (in customer language, not yours)
+- 3-5 testimonial quotes from internal testers
+- List of objections and how to address them
+- Refined elevator pitch (under 15 words)
+
+**Anti-pattern:** Skipping internal launch because "we already know our audience." You don't — internal launch reveals language gaps between how you describe your product and how users describe their problem.
+</phase_1_internal>
+
+<phase_2_alpha>
+## Phase 2: Alpha Launch (Days -75 to -50)
+
+**Goal:** First external users in controlled setting. Landing page live, waitlist growing.
+
+| Day | Activity | Dependency | Owner |
+|-----|----------|------------|-------|
+| -75 | Build landing page with waitlist | Positioning finalized | Marketing |
+| -72 | Set up email capture + welcome sequence | Landing page live | Marketing |
+| -70 | Create "coming soon" social posts | Landing page live | Content |
+| -68 | Begin daily social sharing (value-first) | Social accounts active | Founder |
+| -65 | Reach out to 20 potential beta users | Landing page live | Founder |
+| -60 | First 100 waitlist signups milestone | All channels active | Team |
+| -55 | Publish first long-form content piece | SEO strategy defined | Content |
+| -50 | Alpha retrospective + phase gate | Metrics reviewed | Team |
+
+**Key outputs:**
+- Live landing page with proven conversion rate
+- Working email capture + 3-email welcome sequence
+- Initial waitlist (target: 100-500 depending on niche)
+- First content piece published and indexed
+
+**Milestone metrics:**
+- Landing page conversion rate > 25% (from targeted traffic)
+- Email open rate > 50% (welcome sequence)
+- At least 3 organic signups (not from direct outreach)
+</phase_2_alpha>
+
+<phase_3_beta>
+## Phase 3: Beta Launch (Days -50 to -20)
+
+**Goal:** Scale early access while generating external social proof.
+
+| Day | Activity | Dependency | Owner |
+|-----|----------|------------|-------|
+| -50 | Open beta invitations (batch 1) | Alpha feedback incorporated | Product |
+| -48 | Publish 3 comparison/alternative pages | SEO keywords researched | Content |
+| -45 | Guest post / podcast outreach begins | Content pieces published | Marketing |
+| -40 | Collect and publish first case study | Beta users active 2+ weeks | Marketing |
+| -35 | Create Product Hunt "coming soon" page | Case study ready | Marketing |
+| -30 | Begin Product Hunt community engagement | PH page live | Founder |
+| -25 | Publish "building in public" thread | Product milestones achieved | Founder |
+| -20 | Beta retrospective + launch readiness check | All metrics reviewed | Team |
+
+**Key outputs:**
+- 3+ published case studies or testimonials
+- Guest content on 2-3 external platforms
+- Product Hunt "coming soon" page with 100+ followers
+- Comparison pages ranking for "[competitor] alternative" keywords
+
+**Social proof targets:**
+- 10+ public testimonials
+- 1+ case study with quantified results
+- Active community thread (Twitter, Reddit, or Discord)
+</phase_3_beta>
+
+<phase_4_early_access>
+## Phase 4: Early Access (Days -20 to -3)
+
+**Goal:** Shift from testing to controlled expansion. Build launch-day momentum.
+
+| Day | Activity | Dependency | Owner |
+|-----|----------|------------|-------|
+| -20 | Final product polish sprint | Beta feedback synthesized | Engineering |
+| -18 | Create all launch-day assets | Brand kit finalized | Design |
+| -15 | Write launch announcement (all channels) | Assets ready | Marketing |
+| -12 | Queue email blast to full waitlist | Announcement drafted | Marketing |
+| -10 | Brief launch partners / allies | Announcement finalized | Founder |
+| -8 | Schedule all social posts | Content calendar done | Marketing |
+| -5 | Final landing page update (launch version) | All assets ready | Marketing |
+| -3 | Dry run: test every link, flow, integration | Everything staged | Team |
+
+**Launch-day asset checklist:**
+- [ ] Launch announcement email (full waitlist)
+- [ ] Twitter/X thread (10+ tweets)
+- [ ] LinkedIn post (long-form)
+- [ ] Product Hunt listing (title, tagline, description, images, video)
+- [ ] Blog post / changelog
+- [ ] In-app announcement
+- [ ] Partner/affiliate notification email
+</phase_4_early_access>
+
+<phase_5_full_launch>
+## Phase 5: Full Launch (Day 0 to +30)
+
+**Goal:** Coordinated push across all channels. Maximum reach in 48-hour window.
+
+| Day | Activity | Dependency | Owner |
+|-----|----------|------------|-------|
+| 0 (6am) | Product Hunt goes live | Listing approved | Founder |
+| 0 (7am) | Email blast to full waitlist | PH live | Marketing |
+| 0 (8am) | All social posts go live | Email sent | Marketing |
+| 0 (9am) | Personal outreach to top supporters | Social live | Founder |
+| 0 (ongoing) | Respond to every PH comment | PH live | Founder |
+| +1 | Thank-you email to early supporters | Launch day complete | Marketing |
+| +3 | Publish launch retrospective | Metrics collected | Founder |
+| +7 | First post-launch content piece | Retro complete | Content |
+| +14 | Comparison page updates with launch data | 2 weeks of data | Content |
+| +21 | Second wave outreach (press, podcasts) | Launch data + case studies | Marketing |
+| +30 | 30-day retrospective + next phase planning | Full month of data | Team |
+
+**Launch day rules:**
+1. Everyone on the team is online and responsive 6am-10pm
+2. Respond to every Product Hunt comment within 30 minutes
+3. No feature changes on launch day — only critical bug fixes
+4. Document every piece of feedback in a single running thread
+5. Send personal thank-you to every person who shares/upvotes
+</phase_5_full_launch>
+
+<compressed_timelines>
+## Compressed Timeline Variants
+
+### 30-Day Sprint (Skip internal + alpha)
+For products with existing audience or validated MVP:
+- Days -30 to -20: Beta launch (existing users)
+- Days -20 to -7: Early access + asset creation
+- Days -7 to 0: Launch prep
+- Day 0+: Full launch
+
+### 14-Day Blitz (Emergency launch)
+For time-sensitive opportunities:
+- Days -14 to -7: Landing page + waitlist + announcement draft
+- Days -7 to -3: Asset creation + partner briefs
+- Days -3 to 0: Final prep + scheduling
+- Day 0+: Launch
+
+### Continuous Launch (SaaS model)
+For products that launch features, not the product:
+- Weekly: Ship + announce one feature
+- Monthly: Themed launch around feature bundle
+- Quarterly: Major version launch (full 90-day cycle)
+
+**Warning:** Compressed timelines sacrifice audience building. Only compress if you already have distribution (existing email list, social following, or partner channels).
+</compressed_timelines>
+
+<dependencies_map>
+## Critical Dependency Chains
+
+```
+Positioning → Landing Page → Waitlist → Email Sequence → Launch Email
+     ↓              ↓            ↓
+Brand Voice → Content → SEO Rankings (takes 30-90 days)
+     ↓
+Case Studies → Social Proof → Conversion Rate
+     ↓
+Product Hunt "Coming Soon" → PH Community → Launch Day Ranking
+```
+
+**The three longest lead-time items:**
+1. **SEO content** — Takes 30-90 days to rank. Start in Phase 2.
+2. **Product Hunt relationships** — Genuine engagement takes 30+ days. Start in Phase 3.
+3. **Case studies with results** — Need 2-4 weeks of user data. Start collecting in Phase 2.
+
+Never shortcut these. They cannot be parallelized or rushed.
+</dependencies_map>

--- a/skills/launch-strategy/workflows/plan-launch.md
+++ b/skills/launch-strategy/workflows/plan-launch.md
@@ -1,0 +1,224 @@
+# Workflow: Plan a Product Launch
+
+<objective>
+Build a complete, phased launch plan for any product — from internal validation through full public launch. Produces a timeline, channel strategy, asset checklist, and success metrics tailored to the specific product and audience.
+</objective>
+
+<required_reading>
+**Read these reference files NOW:**
+1. references/launch-timeline.md — Master timeline across all five phases
+2. references/launch-checklist.md — Exhaustive checklists by phase and channel
+</required_reading>
+
+<process>
+## Step 1: Gather Launch Context
+
+Collect these inputs before planning. Check `brand/` directory for existing files first.
+
+**Required inputs:**
+- What is being launched? (new product, feature, version, pivot)
+- Who is the target audience? (load `brand/audience.md` if exists)
+- What channels does the founder already own? (email list size, social followers, community)
+- What is the timeline? (ideal launch date, or "as soon as possible")
+- Has anything been launched before? (prior experience level)
+- Is Product Hunt part of the strategy? (yes/no)
+
+**Optional inputs (load from brand/ if available):**
+- `brand/voice-profile.md` — For consistent messaging across all launch assets
+- `brand/positioning.md` — For validated value proposition
+- `brand/audience.md` — For audience segmentation
+
+If critical files are missing, note which skills should run first:
+- No voice profile → run `/brand-voice` first
+- No positioning → run `/positioning-angles` first
+- No audience research → run `/audience-research` first
+
+## Step 2: Assess Current State
+
+Map the founder's current assets to launch readiness:
+
+```
+Distribution:
+- Email list: [size] subscribers
+- Twitter/X: [count] followers
+- LinkedIn: [count] connections
+- Other channels: [list]
+
+Content:
+- Published pieces: [count]
+- SEO rankings: [any existing rankings?]
+
+Social Proof:
+- Testimonials: [count]
+- Case studies: [count]
+- Beta users: [count]
+
+Product:
+- Stage: [idea / prototype / alpha / beta / production]
+- Onboarding: [exists? tested?]
+- Pricing: [defined? page built?]
+```
+
+## Step 3: Select Timeline Template
+
+Based on context, choose the right timeline:
+
+**90-Day Full Launch** — Choose when:
+- New product with no existing audience
+- Founder wants maximum impact
+- Product Hunt is a priority
+
+**30-Day Sprint** — Choose when:
+- Existing audience (500+ email subscribers)
+- Product already validated with users
+- Time-sensitive opportunity
+
+**14-Day Blitz** — Choose when:
+- Large existing audience (5000+ email or social)
+- Product is ready and tested
+- Competitive pressure requires speed
+
+**Continuous Launch** — Choose when:
+- SaaS product shipping features regularly
+- Existing user base to announce to
+- Focus is on feature adoption, not awareness
+
+## Step 4: Build the Phase Plan
+
+For each phase in the selected timeline, create:
+
+```markdown
+## Phase [N]: [Name] (Days [X] to [Y])
+
+**Goal:** [One sentence]
+
+**Key Activities:**
+1. [Activity] — Owner: [who] — Due: [date]
+2. [Activity] — Owner: [who] — Due: [date]
+...
+
+**Deliverables:**
+- [ ] [Concrete output]
+- [ ] [Concrete output]
+
+**Phase Gate (must be true to proceed):**
+- [ ] [Metric or condition]
+- [ ] [Metric or condition]
+```
+
+## Step 5: Define Channel Strategy
+
+For each owned, rented, and borrowed channel:
+
+**Owned channels** (you control these — invest the most):
+- Email: Welcome sequence, launch blast, post-launch nurture
+- Blog/SEO: Long-form content, comparison pages, tutorials
+- Community: Discord/Slack if applicable
+
+**Rented channels** (you have presence, platform controls reach):
+- Twitter/X: Thread strategy, daily engagement
+- LinkedIn: Personal narrative posts
+- Product Hunt: Listing, community engagement
+- Reddit: Only if already an active member
+
+**Borrowed channels** (someone else's audience):
+- Guest posts on relevant blogs
+- Podcast appearances
+- Newsletter sponsorships or features
+- Partner cross-promotions
+
+For each channel, specify:
+- Content format and cadence
+- Key messages (adapted to platform voice)
+- Success metric
+- Owner
+
+## Step 6: Create Asset List
+
+Generate a complete list of assets needed, organized by phase:
+
+For each asset:
+```
+- [Asset name]
+  - Format: [email / social post / landing page / etc.]
+  - Due: [date]
+  - Skill to generate: [/direct-response-copy, /email-sequences, /seo-content, etc.]
+  - Dependencies: [what must exist first]
+```
+
+## Step 7: Define Success Metrics
+
+Set metrics for three timeframes:
+
+**Launch Day (Day 0):**
+- Signups: [target]
+- Product Hunt ranking: [target if applicable]
+- Social shares: [target]
+
+**First Week (Days +1-7):**
+- Total signups: [target]
+- Activation rate: [target %]
+- Email open rate: [target %]
+
+**First Month (Days +1-30):**
+- Total users: [target]
+- Retention (week 2): [target %]
+- Revenue (if applicable): [target]
+- Content pieces published: [target]
+- Backlinks earned: [target]
+
+## Step 8: Save the Plan
+
+Save the complete launch plan to `marketing/launch/plan.md` with this structure:
+
+```markdown
+---
+product: [name]
+launch_date: [YYYY-MM-DD]
+timeline: [90-day / 30-day / 14-day / continuous]
+created: [YYYY-MM-DD]
+---
+
+# Launch Plan: [Product Name]
+
+## Overview
+[2-3 sentence summary of launch strategy]
+
+## Timeline
+[Phase-by-phase plan from Step 4]
+
+## Channel Strategy
+[From Step 5]
+
+## Asset Checklist
+[From Step 6]
+
+## Success Metrics
+[From Step 7]
+
+## Launch Readiness Score
+[Score card from launch-checklist.md reference]
+```
+
+Also save the checklist to `marketing/launch/checklist.md` — pull the relevant items from references/launch-checklist.md based on the selected channels and timeline.
+</process>
+
+<anti_patterns>
+## What NOT To Do
+
+- **Don't launch without distribution.** If email list is 0 and social following is 0, the priority is audience building, not launch planning. Redirect to `/audience-research` and `/email-sequences` first.
+- **Don't plan every channel.** Pick 2-3 channels max for launch, do them well. Trying to launch on Twitter, LinkedIn, Product Hunt, Reddit, HackerNews, and 5 communities simultaneously means doing all of them poorly.
+- **Don't skip phase gates.** Each phase has exit criteria. Moving to the next phase without meeting them compounds problems.
+- **Don't write launch copy without voice profile.** Generic launch copy converts 2-5x worse than voiced copy. Run `/brand-voice` first if `brand/voice-profile.md` doesn't exist.
+- **Don't set vanity metrics.** "Go viral" is not a success metric. "200 signups from Product Hunt" is.
+</anti_patterns>
+
+<success_criteria>
+- Complete launch plan saved to `marketing/launch/plan.md`
+- Checklist saved to `marketing/launch/checklist.md`
+- Every phase has concrete deliverables with dates and owners
+- Channel strategy covers owned + rented + borrowed
+- Asset list maps each asset to the skill that generates it
+- Success metrics are specific numbers, not vague goals
+- Plan accounts for the founder's actual distribution (not assumed)
+</success_criteria>

--- a/skills/seo-content/references/content-structure.md
+++ b/skills/seo-content/references/content-structure.md
@@ -1,0 +1,231 @@
+<overview>
+Deep reference on how to structure content for both search engines and human readers. Goes beyond templates — covers the psychology of content structure, how Google evaluates content quality, and the specific structural patterns that win featured snippets and drive engagement. Complements content-structures.md (templates) with the WHY behind each structural decision.
+</overview>
+
+<structure_psychology>
+## Why Structure Matters More Than Writing Quality
+
+A perfectly written 3,000-word article with no structure will lose to a mediocre 2,000-word article with great structure. Here's why:
+
+**For readers:**
+- 79% of web readers scan, not read (Nielsen Norman Group)
+- Average time on page is 52 seconds — they're looking for their specific answer
+- Scannable structure = they find their answer = they stay = they trust you = they convert
+
+**For Google:**
+- Structured content is easier to parse for featured snippets
+- Clear heading hierarchy helps Google understand topic relationships
+- Well-structured pages get more internal passage ranking (Google ranks specific passages, not just pages)
+
+**For agents:**
+- AI-powered search (Perplexity, ChatGPT Search, Google AI Overview) pulls structured answers
+- Clear hierarchies make it easy to cite specific sections
+- Structured data (schema) makes content machine-readable
+
+**The paradox:** The best-structured content looks effortless to read. The effort goes into the structure so the reader doesn't have to work.
+</structure_psychology>
+
+<inverted_pyramid>
+## The Inverted Pyramid for SEO Content
+
+Journalism's inverted pyramid works perfectly for SEO. Lead with the answer, then provide depth.
+
+```
+┌─────────────────────────────────────┐
+│ ANSWER (first 100 words)            │ ← Featured snippet zone
+│ Direct answer to the search query   │    Google pulls from here
+├─────────────────────────────────────┤
+│ CONTEXT (next 200-300 words)        │ ← Why this matters
+│ Why, who, when this applies         │    Reader decides to stay
+├─────────────────────────────────────┤
+│ DEPTH (body sections)               │ ← Full treatment
+│ Step-by-step, examples, nuance      │    Reader gets value
+├─────────────────────────────────────┤
+│ SUPPORT (end sections)              │ ← FAQ, related content
+│ FAQ, resources, next steps          │    Reader converts
+└─────────────────────────────────────┘
+```
+
+**Anti-pattern:** Academic structure (intro → background → methodology → findings → conclusion). The reader doesn't need 500 words of background before getting to the point. Web readers have zero patience for throat-clearing.
+</inverted_pyramid>
+
+<section_anatomy>
+## Anatomy of a Perfect Content Section
+
+Every H2 section should follow this micro-structure:
+
+```
+H2: [Question or promise]
+├── Opening line: Direct answer or key takeaway (1-2 sentences)
+├── Supporting detail: Evidence, data, or reasoning (2-3 sentences)
+├── Example or illustration: Concrete, specific (code block, table, or story)
+├── Actionable insight: What the reader should do with this info (1-2 sentences)
+└── Transition: Bridge to the next section (1 sentence)
+```
+
+**Word count per section:** 200-400 words. Under 200 feels thin. Over 400 should be split into subsections (H3s).
+
+**Paragraph length:** 1-3 sentences max. Single-sentence paragraphs are power moves in web writing — use them for emphasis.
+
+**Key principle:** Every section earns the right to exist. If a section doesn't answer a question the reader has, cut it. The reader is not reading your article — they're scanning it for their specific answer.
+</section_anatomy>
+
+<content_flow_patterns>
+## Content Flow Patterns
+
+### Pattern 1: Problem-Agitate-Solve (PAS)
+**Best for:** How-to content, tutorials
+```
+H2: [Problem statement]
+  - Describe the pain
+  - Agitate: why existing solutions fail
+  - Solve: your approach
+
+H2: [Step 1]
+H2: [Step 2]
+...
+H2: [Common Mistakes]
+H2: [FAQ]
+```
+
+### Pattern 2: What-Why-How
+**Best for:** Explanatory content, guides
+```
+H2: What is [concept]?
+  - Definition + quick answer
+  - Featured snippet target
+
+H2: Why [concept] matters
+  - Data, trends, consequences
+
+H2: How to [apply concept]
+  - Step-by-step implementation
+
+H2: [Concept] examples
+  - Real-world applications
+
+H2: FAQ
+```
+
+### Pattern 3: Comparison Framework
+**Best for:** "X vs Y" or "best X" content
+```
+H2: Quick Verdict (who should choose what)
+  - TL;DR recommendation
+  - "Choose X if... Choose Y if..."
+
+H2: Comparison Table
+  - Side-by-side on key factors
+
+H2: [Option A] Deep Dive
+H2: [Option B] Deep Dive
+H2: When to Choose [A] Over [B]
+H2: FAQ
+```
+
+### Pattern 4: Listicle with Depth
+**Best for:** "N best X" or "N tips for Y"
+```
+H2: [Tip 1]: [Descriptive name]
+  - Why it works
+  - How to implement
+  - Example
+
+H2: [Tip 2]: [Descriptive name]
+...
+
+H2: How to Choose the Right [Approach]
+H2: FAQ
+```
+</content_flow_patterns>
+
+<engagement_hooks>
+## Structural Elements That Drive Engagement
+
+### Open Loops
+Place "I'll show you how in section 3" references to keep readers scrolling. Works especially well in long-form content.
+
+### Pattern Interrupts
+Break up text walls every 300-400 words with:
+- A pull quote or callout box
+- An image, diagram, or screenshot
+- A comparison table
+- A code block or template
+- A bulleted list (but not too many — wall-of-bullets is as bad as wall-of-text)
+
+### Bucket Brigades
+Short transitional phrases that keep the reader moving:
+- "Here's the thing:"
+- "But it gets better."
+- "Now, here's where it gets interesting."
+- "Let me explain."
+
+Use sparingly — 2-3 per article. Overuse makes writing feel breathless and clickbaity.
+
+### TL;DR Boxes
+For long articles (2,000+ words), include a summary box near the top:
+```
+**TL;DR:**
+- [Key takeaway 1]
+- [Key takeaway 2]
+- [Key takeaway 3]
+- [Skip to section: [link to most actionable section]]
+```
+
+This paradoxically increases time-on-page because it builds trust — the reader knows the article respects their time, so they're more willing to read deeply.
+
+### Table of Contents
+For articles over 1,500 words:
+- Anchor-linked ToC below the intro
+- Use descriptive labels, not just heading text
+- Keep to H2 level only (H3s clutter the ToC)
+</engagement_hooks>
+
+<content_length_guidance>
+## Content Length by Intent
+
+Content length should match search intent, not an arbitrary word count.
+
+| Search Intent | Optimal Length | Example Query |
+|---------------|---------------|---------------|
+| Quick answer | 300-800 words | "what is a meta description" |
+| How-to | 1,500-2,500 words | "how to write a landing page" |
+| Complete guide | 3,000-5,000 words | "complete guide to product launches" |
+| Comparison | 2,000-3,500 words | "Mailchimp vs ConvertKit" |
+| Listicle | 1,500-3,000 words | "15 best email subject lines" |
+| Case study | 1,000-2,000 words | "how Superhuman launched" |
+| Pillar page | 5,000-8,000 words | "content marketing strategy" |
+
+**The real rule:** Be as long as necessary and as short as possible. If you can answer the query in 800 words, don't pad to 2,000. If the topic genuinely requires 5,000 words, don't truncate to 2,000.
+
+**How to check:** Look at the top 5 results for your keyword. Average their word counts. Be within 20% of that average, but only if every word earns its place.
+</content_length_guidance>
+
+<readability_rules>
+## Readability Rules for Web Content
+
+### Sentence Structure
+- Average sentence length: 15-20 words
+- Mix short (5-8 words) and medium (15-25 words) sentences
+- Limit complex sentences (30+ words) to 1 per paragraph
+- Front-load the subject: "Google uses mobile-first indexing" not "When it comes to how Google indexes pages, they use a mobile-first approach"
+
+### Paragraph Structure
+- 1-3 sentences per paragraph (web standard)
+- One idea per paragraph
+- First sentence carries the point — if the reader only reads first sentences, they should get the gist
+
+### Formatting That Aids Scanning
+- **Bold** key phrases the scanner is looking for (2-3 per section)
+- Use bullet lists for 3+ related items
+- Use numbered lists for sequential steps
+- Use tables for comparisons (3+ items, 3+ attributes)
+- Use code blocks for templates, formulas, or technical content
+- Use blockquotes for definitions or important callouts
+
+### Reading Level
+- Target 8th-grade reading level for general audiences
+- Use the Flesch-Kincaid readability score as a guide (aim for 60-70)
+- Prefer common words: "use" over "utilize," "start" over "commence," "help" over "facilitate"
+- Define jargon on first use, or avoid it entirely
+</readability_rules>

--- a/skills/seo-content/references/on-page-seo.md
+++ b/skills/seo-content/references/on-page-seo.md
@@ -1,0 +1,264 @@
+<overview>
+Complete on-page SEO reference for creating content that ranks. Covers every optimization factor from title tags to internal linking, with specific implementation guidance. This is the technical counterpart to the creative content workflow — apply these after the content is written, not during.
+</overview>
+
+<title_tag_optimization>
+## Title Tag Optimization
+
+The title tag is the single highest-impact on-page factor. Get this wrong and nothing else matters.
+
+**Formula:** `[Primary Keyword] — [Benefit or Modifier] | [Brand]`
+
+**Rules:**
+- 50-60 characters max (Google truncates at ~60)
+- Primary keyword in the first 3 words
+- Include a power word: ultimate, complete, proven, essential, definitive
+- Year modifier for time-sensitive content: "Best X in 2026"
+- Never keyword-stuff: one primary keyword, one secondary max
+
+**Examples (good):**
+- "Product Launch Checklist: 47 Steps to a Successful Launch | Mktg"
+- "How to Write Landing Page Copy That Converts (2026 Guide)"
+- "SEO Content Strategy: The Complete Playbook for Startups"
+
+**Examples (bad):**
+- "Launch Checklist — Launch Strategy — Product Launch Tips — Best Launches" (keyword stuffing)
+- "Our Amazing Guide to Everything You Need to Know About Launching" (no keyword, too vague)
+- "Chapter 1: Introduction to Launching Products Successfully in Today's Market" (too long, keyword buried)
+
+**Title tag ≠ H1.** The H1 can be longer and more descriptive. The title tag is for search results.
+</title_tag_optimization>
+
+<meta_description>
+## Meta Description
+
+Doesn't directly affect rankings but controls click-through rate from SERPs.
+
+**Formula:** `[Problem/Question] + [Promise of answer] + [Proof element] + [CTA]`
+
+**Rules:**
+- 150-160 characters max
+- Include primary keyword naturally (Google bolds matching terms)
+- Include a number or specific detail (specificity builds trust)
+- End with implied CTA or curiosity gap
+- Never duplicate across pages
+
+**Template:**
+```
+[Struggling with X?] Learn [specific technique] that [proof/result]. [Curiosity hook].
+```
+
+**Examples:**
+- "Struggling to get your first 1,000 users? This 5-phase launch framework helped 200+ startups hit their signup goals. See the full timeline inside."
+- "On-page SEO isn't about keywords anymore. These 12 ranking factors matter most in 2026 — and #7 is what most guides miss."
+</meta_description>
+
+<heading_structure>
+## Heading Structure (H1-H6)
+
+Headings are both a ranking signal and a UX signal. They tell Google what the page is about and tell readers where to find what they need.
+
+**H1 Rules:**
+- Exactly one H1 per page
+- Contains primary keyword
+- Matches search intent (if searcher asks "how to X," H1 should promise to show how to X)
+- Can be longer than title tag
+
+**H2 Rules:**
+- One H2 per major section (3-7 per article)
+- Include keyword variations and related terms
+- Use question format for sections targeting PAA (People Also Ask)
+- Each H2 should be understandable without reading the full article
+
+**H3-H4 Rules:**
+- Use for subsections within an H2
+- Include long-tail keyword variations
+- Keep hierarchical (never H4 without a parent H3)
+
+**Example structure:**
+```
+H1: How to Launch a Product: The Complete 5-Phase Framework
+  H2: What Makes a Product Launch Successful?
+    H3: The ORB Framework (Owned, Rented, Borrowed)
+    H3: Why Most Launches Fail
+  H2: Phase 1: Internal Launch (Days -90 to -75)
+    H3: How to Recruit Your First Testers
+    H3: Running Structured Feedback Sessions
+  H2: How Long Does a Product Launch Take?    ← PAA question
+  H2: Product Launch Checklist (47 Items)
+  H2: Frequently Asked Questions
+```
+
+**Anti-pattern:** Using headings for visual styling. If you want bigger text, use CSS — headings are semantic, not decorative.
+</heading_structure>
+
+<keyword_placement>
+## Strategic Keyword Placement
+
+Keyword placement matters, but density does not. Google uses semantic understanding — mentioning "product launch" 50 times won't help. Mentioning it in the right places will.
+
+**High-impact placement locations (in priority order):**
+1. **Title tag** — First 3 words ideally
+2. **H1** — Natural inclusion
+3. **First 100 words** — Confirms topic to Google immediately
+4. **H2 headings** — Keyword variations, not exact match repeated
+5. **Image alt text** — Describe what's in the image, include keyword if natural
+6. **URL slug** — Short, keyword-rich: `/product-launch-checklist` not `/the-complete-guide-to-everything-about-launching`
+7. **Last 100 words** — Reinforces topic
+
+**Keyword variations to include (semantic field):**
+- Synonyms: "launch" / "release" / "ship" / "go live"
+- Related entities: "Product Hunt" / "landing page" / "waitlist"
+- Long-tail variations: "how to launch a product with no audience"
+- Question forms: "how long does a product launch take?"
+
+**Density guidance:** If you're counting keyword density, you're doing it wrong. Write naturally. If the keyword appears 3-8 times in a 2,000 word article, that's normal. If you have to force it in, the content probably doesn't match the keyword's intent.
+</keyword_placement>
+
+<internal_linking>
+## Internal Linking Strategy
+
+Internal links are the most underused SEO lever. They pass authority between pages, help Google discover content, and keep users on your site longer.
+
+**Rules:**
+- Every new page should link to 3-5 existing related pages
+- Every new page should receive links from 2-3 existing pages (go back and add them)
+- Anchor text should be descriptive, not "click here" or "read more"
+- Link to your most important pages from your most authoritative pages
+- Don't link to the same page twice from the same article
+
+**Internal linking patterns:**
+
+| Pattern | When to Use | Example |
+|---------|------------|---------|
+| Hub and spoke | Pillar content with subtopic articles | "Product Launch Guide" links to "Launch Checklist," "Product Hunt Strategy," etc. |
+| Sequential | Step-by-step series | "Step 1: Brand Voice" → "Step 2: Positioning" → "Step 3: Launch" |
+| Contextual | Natural mention within content | "...using the [ORB framework](/blog/orb-framework) for channel strategy..." |
+| Related posts | End-of-article suggestions | "You might also like: [3 related articles]" |
+
+**Anchor text distribution:**
+- 50% descriptive keyword anchors: "product launch checklist"
+- 30% partial match: "this launch framework" or "checklist we use"
+- 20% branded or generic: "our guide" or "learn more about this"
+
+**Never:** All exact-match anchors (looks manipulative), broken internal links (check quarterly), orphan pages (no internal links pointing to them).
+</internal_linking>
+
+<url_structure>
+## URL Structure
+
+**Rules:**
+- Short and keyword-rich: `/launch-checklist` not `/blog/2026/03/the-complete-product-launch-checklist-for-startups`
+- Hyphens between words (not underscores)
+- Lowercase only
+- No stop words unless needed for readability
+- No dates in URL (makes content feel outdated)
+- No file extensions (.html, .php)
+- Flat hierarchy preferred: `/launch-checklist` over `/blog/marketing/launches/checklist`
+
+**URL must never change after publishing.** If you must change it, set up a 301 redirect from old → new. Broken URLs lose all accumulated authority.
+</url_structure>
+
+<image_optimization>
+## Image Optimization
+
+Images affect page speed, accessibility, and can rank in Google Images (a non-trivial traffic source).
+
+**File optimization:**
+- WebP format (30-50% smaller than JPEG at same quality)
+- Compress to under 200KB per image (use TinyPNG, ImageOptim, or Squoosh)
+- Serve responsive sizes: `srcset` for different viewports
+- Lazy-load images below the fold
+
+**SEO optimization:**
+- **Alt text:** Describe the image as if explaining it to someone who can't see it. Include keyword only if the image is actually about that keyword.
+- **File name:** `product-launch-timeline.webp` not `IMG_4832.webp`
+- **Caption:** Optional but helps with context. Users read captions more than body text.
+- **Surrounding text:** The paragraph before/after the image should relate to what the image shows.
+
+**Alt text examples:**
+- Good: "Five-phase product launch timeline showing activities from day -90 to day +30"
+- Bad: "product launch product launch strategy launch plan" (keyword stuffing)
+- Bad: "image" or "photo" or "" (empty — accessibility violation)
+</image_optimization>
+
+<featured_snippet_optimization>
+## Featured Snippet Optimization
+
+Featured snippets (position zero) get 30-40% of clicks for their query. Three main types:
+
+### Paragraph Snippet
+**Target queries:** "What is X" / "Why does X" / "How does X work"
+**How to win:**
+- Place a 40-60 word answer directly below the H2 that matches the query
+- Start with the definition/answer, then elaborate
+- Use the exact question as an H2
+
+### List Snippet
+**Target queries:** "How to X" / "Steps to X" / "Best X"
+**How to win:**
+- Use an H2 with the query
+- Immediately follow with an ordered or unordered list
+- 5-8 items is the sweet spot
+- Each item should be one concise line
+
+### Table Snippet
+**Target queries:** "X vs Y" / "X pricing" / "comparison of X"
+**How to win:**
+- Use an HTML table (not a screenshot of a table)
+- Include a descriptive H2 above the table
+- Keep columns to 3-5
+- Include clear column headers
+
+**Pro tip:** Check "People Also Ask" for your target keyword. Each PAA question is a featured snippet opportunity — create an H2 for each and answer it directly.
+</featured_snippet_optimization>
+
+<technical_on_page>
+## Technical On-Page Factors
+
+### Page Speed
+- Core Web Vitals: LCP < 2.5s, INP < 200ms, CLS < 0.1
+- Minimize render-blocking JavaScript
+- Use a CDN for static assets
+- Preload critical fonts and hero images
+
+### Schema Markup
+- Article schema for blog posts (author, date, publisher)
+- FAQ schema for FAQ sections (eligible for rich results)
+- HowTo schema for step-by-step guides
+- BreadcrumbList for navigation context
+- See `references/schema-templates.md` for ready-to-use JSON-LD
+
+### Mobile Optimization
+- Google uses mobile-first indexing — mobile version IS the version they rank
+- Tap targets minimum 48x48px
+- No horizontal scrolling
+- Font size minimum 16px for body text
+- No interstitial popups that block content on mobile
+
+### Content Freshness Signals
+- Update date visible on page (not just publish date)
+- Regular content updates (quarterly for evergreen, monthly for fast-moving topics)
+- Updated year in title for time-sensitive content
+- Remove outdated information rather than leaving it with a "this is outdated" note
+</technical_on_page>
+
+<on_page_audit_checklist>
+## Quick On-Page SEO Audit Checklist
+
+Run this after every piece of content is written:
+
+- [ ] Title tag: under 60 chars, keyword in first 3 words
+- [ ] Meta description: under 160 chars, includes keyword, has CTA
+- [ ] URL: short, keyword-rich, no dates
+- [ ] H1: one per page, contains keyword, matches intent
+- [ ] H2s: 3-7 per article, include keyword variations
+- [ ] First 100 words: keyword mentioned naturally
+- [ ] Images: alt text set, files compressed, WebP format
+- [ ] Internal links: 3-5 outgoing, anchor text descriptive
+- [ ] External links: 1-3 to authoritative sources (not competitors)
+- [ ] Schema markup: Article + FAQ (if applicable)
+- [ ] Mobile: renders correctly, no horizontal scroll
+- [ ] Page speed: under 3 seconds on mobile
+- [ ] Featured snippet: at least one H2 matches a PAA question with direct answer below
+</on_page_audit_checklist>


### PR DESCRIPTION
Closes #3

## Summary
- Adds `references/` and `workflows/` subdirectories to 3 existing mktg skills, following compound-engineering's pattern of XML-structured deep knowledge files
- **launch-strategy**: `references/launch-timeline.md`, `references/launch-checklist.md`, `workflows/plan-launch.md`
- **seo-content**: `references/on-page-seo.md`, `references/content-structure.md`
- **brand-voice**: `references/voice-dimensions.md`, `references/tone-matrix.md`

## What's in the files
- **References** contain substantive marketing domain knowledge — timelines, checklists, SEO optimization factors, voice dimension spectrums, tone matrices
- **Workflows** are step-by-step procedures with `<required_reading>`, `<process>`, `<anti_patterns>`, and `<success_criteria>` sections
- Format matches CE's reference/workflow pattern: XML semantic tags with markdown content inside

## Test plan
- [x] All 525 existing tests pass (`bun test`)
- [x] No existing SKILL.md files modified
- [x] No src/ files modified
- [x] References contain substantive marketing knowledge (not stubs)
- [x] Workflow is actionable step-by-step procedure
- [x] Format matches CE's reference/workflow pattern