### PR TITLE
feat(skills): first-class Exa agent-skills (search, contents, company, leads)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "marketing-cli",
-      "description": "Agent-native marketing playbook CLI: 58 skills, 5 research/review agents, brand memory, and /cmo orchestration.",
+      "description": "Agent-native marketing playbook CLI: 63 skills, 5 research/review agents, brand memory, and /cmo orchestration.",
       "version": "0.6.0",
       "source": "./",
       "homepage": "https://github.com/MoizIbnYousaf/marketing-cli",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "marketing-cli",
   "version": "0.6.0",
-  "description": "Agent-native marketing playbook CLI: 58 skills, 5 research/review agents, brand memory, and /cmo orchestration.",
+  "description": "Agent-native marketing playbook CLI: 63 skills, 5 research/review agents, brand memory, and /cmo orchestration.",
   "author": {
     "name": "Moiz Ibn Yousaf",
     "url": "https://github.com/MoizIbnYousaf/marketing-cli"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "marketing-cli",
   "version": "0.6.0",
-  "description": "Agent-native marketing playbook CLI: 58 skills, 5 research/review agents, brand memory, and /cmo orchestration.",
+  "description": "Agent-native marketing playbook CLI: 63 skills, 5 research/review agents, brand memory, and /cmo orchestration.",
   "author": {
     "name": "Moiz Ibn Yousaf",
     "url": "https://github.com/MoizIbnYousaf/marketing-cli"
@@ -21,7 +21,7 @@
   "interface": {
     "displayName": "Marketing CLI",
     "shortDescription": "A CMO for your agent.",
-    "longDescription": "Install one CLI and give your agent 57 marketing skills, 5 research/review agents, persistent brand memory, native publishing workflows, and a local marketing studio.",
+    "longDescription": "Install one CLI and give your agent 62 marketing skills, 5 research/review agents, persistent brand memory, native publishing workflows, and a local marketing studio.",
     "developerName": "Moiz Ibn Yousaf",
     "category": "Productivity",
     "capabilities": [

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "exa": {
+      "type": "http",
+      "url": "https://mcp.exa.ai/mcp?tools=web_search_exa,web_fetch_exa,web_search_advanced_exa,agent_tools",
+      "headers": {
+        "x-api-key": "${EXA_API_KEY}"
+      }
+    }
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -285,7 +285,8 @@ Studio auth: bearer token at `~/.mktg/.runtime/studio-token`. Open `http://127.0
 2. **`mktg verify` / `mktg ship-check` suite reachability**: those commands resolve suites as `<mktgmonoRoot>/marketing-cli` and `.../mktg-studio`. In a bare `/workspace` checkout they mark suites unreachable. Symlink `sudo ln -sfn /workspace /marketing-cli` (or check out as `.../mktgmono/marketing-cli`) if you need those orchestration tests green.
 3. **Studio lint**: `bun --cwd studio run lint` expects an ESLint flat config (`eslint.config.*`) that is not present yet — typecheck via `bun --cwd studio run typecheck` instead.
 4. **Optional integrations**: Postiz / Typefully / Resend / Firecrawl / Exa are BYO. Exa is first-class via skills `exa-search`, `exa-contents`, `company-research`, `lead-generation`, `build-with-exa` + root `.mcp.json`. Set `EXA_API_KEY`; `mktg doctor` surfaces `integration-EXA_API_KEY`.
-5. **Tests**: root `bun test` (CLI); studio `bun run --cwd studio test`. No mocks — real temp-dir I/O.
+5. **Tests**: root `bun test` (CLI); studio `bun run --cwd studio test` (or `bun run test` inside `studio/`). Do **not** run bare `bun test` in `studio/` — that also picks up `tests/e2e/perf` (Lighthouse fixtures) and fails without a prior `bun run tests/e2e/perf/run-lighthouse.ts`. No mocks — real temp-dir I/O.
+6. **Studio UI vs API in cloud VMs**: Bun API on `:3001` is the source of truth. The Next dashboard on `:3000` rewrites `/api/*` → Bun; that proxy can hang (`socket hang up` / HTTP 000) while direct `:3001` curls stay healthy. If the UI stays on skeletons, verify with `curl -H "Authorization: Bearer $(cat ~/.mktg/.runtime/studio-token)" http://127.0.0.1:3001/api/skills` and restart via `mktg studio --no-open` with `MKTG_PROJECT_ROOT` set to the checkout root. Do not start `bun run server.ts` alone without that root — native publish / brand paths will miss `/workspace/.mktg`.
 
 ### Standard commands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -284,7 +284,7 @@ Studio auth: bearer token at `~/.mktg/.runtime/studio-token`. Open `http://127.0
 1. **Project root**: Studio must share `brand/` and `.mktg/native-publish/` with the CLI. The launcher now defaults `MKTG_PROJECT_ROOT` to the marketing-cli parent when `studio/` is a workspace member. Still override with `MKTG_PROJECT_ROOT=/path` when pointing at an external project.
 2. **`mktg verify` / `mktg ship-check` suite reachability**: those commands resolve suites as `<mktgmonoRoot>/marketing-cli` and `.../mktg-studio`. In a bare `/workspace` checkout they mark suites unreachable. Symlink `sudo ln -sfn /workspace /marketing-cli` (or check out as `.../mktgmono/marketing-cli`) if you need those orchestration tests green.
 3. **Studio lint**: `bun --cwd studio run lint` expects an ESLint flat config (`eslint.config.*`) that is not present yet — typecheck via `bun --cwd studio run typecheck` instead.
-4. **Optional integrations**: Postiz / Typefully / Resend / Firecrawl / Exa are BYO. `mktg doctor` warns when unset; core CLI + Studio work without them.
+4. **Optional integrations**: Postiz / Typefully / Resend / Firecrawl / Exa are BYO. Exa is first-class via skills `exa-search`, `exa-contents`, `company-research`, `lead-generation`, `build-with-exa` + root `.mcp.json`. Set `EXA_API_KEY`; `mktg doctor` surfaces `integration-EXA_API_KEY`.
 5. **Tests**: root `bun test` (CLI); studio `bun run --cwd studio test`. No mocks — real temp-dir I/O.
 
 ### Standard commands

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+### feat
+
+- Port [exa-labs/agent-skills](https://github.com/exa-labs/agent-skills) as first-class mktg skills: `exa-search`, `exa-contents`, `company-research`, `lead-generation`, `build-with-exa` (with `build-with-exa/references/`).
+- Ship root `.mcp.json` for Exa MCP (search + fetch + advanced + agent tools); `EXA_API_KEY` on skill manifest surfaces via `mktg doctor`.
+- Wire Exa into `/cmo` routing + disambiguation, ecosystem/recency/safety rules, and all research/review agents.
+
+### counts
+
+- 58 → 63 skills (1 orchestrator + 62 playbook skills).
+
 ## v0.6.0
 
 ### feat

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,14 +10,14 @@
 
 ## What This Is
 
-A TypeScript/Bun agent-native marketing playbook CLI. 58 marketing skills, 5 agents, 20 commands, 1 upstream catalog. The Studio dashboard (Next.js + Bun API) ships inside the same tarball and is launched via `mktg studio`.
+A TypeScript/Bun agent-native marketing playbook CLI. 63 skills (62 playbook + `/cmo`), 5 agents, 20 commands, 1 upstream catalog. The Studio dashboard (Next.js + Bun API) ships inside the same tarball and is launched via `mktg studio`.
 
 | Component | Count | Purpose |
 |---|---|---|
 | `mktg` CLI | 20 commands | Infrastructure: setup, health, skill management, catalog registry, verification, and orchestration |
 | `/cmo` skill | 1 orchestrator | Routes every marketing request to the right skill |
 | `brand/` directory | 10 memory files (+ SCHEMA.md) | Persistent marketing memory, compounds across sessions |
-| Marketing skills | 57 | The playbook, installed to `~/.claude/skills/` |
+| Marketing skills | 62 | The playbook, installed to `~/.claude/skills/` |
 | Marketing agents | 6 | Parallel sub-agents for research + review, installed to `~/.claude/agents/` |
 | Upstream catalogs | 1 | External OSS projects mktg builds on (postiz = 30+ social providers via REST API, AGPL-firewalled) |
 | Studio dashboard | 1 | Next.js + Bun API workspace member at `studio/`, bundled in the tarball, launched via `mktg studio` |
@@ -225,7 +225,7 @@ mktg orchestrates external tools but does not bundle them. `mktg doctor` detects
 | [`summarize`](https://github.com/steipete/summarize) | Text compression | `npm i -g @steipete/summarize` |
 | [`higgsfield`](https://higgsfield.ai/cli) | AI image + video generation (30+ models, Marketing Studio, Soul Characters) | `npm i -g @higgsfield/cli && higgsfield auth login` (paid platform — optional) |
 
-**MCP:** Exa MCP for parallel deep web research (wired via `.mcp.json`).
+**MCP + Exa skills:** Exa MCP for deep web research (wired via `.mcp.json`) plus first-class skills ported from [exa-labs/agent-skills](https://github.com/exa-labs/agent-skills): `exa-search`, `exa-contents`, `company-research`, `lead-generation`, `build-with-exa`. Requires `EXA_API_KEY` (surfaced by `mktg doctor`).
 
 ### Adding a new chained tool
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@
 
 ## What This Is
 
-A TypeScript/Bun agent-native marketing playbook CLI. 63 skills (62 playbook + `/cmo`), 5 agents, 20 commands, 1 upstream catalog. The Studio dashboard (Next.js + Bun API) ships inside the same tarball and is launched via `mktg studio`.
+A TypeScript/Bun agent-native marketing playbook CLI. 63 marketing skills (62 playbook + `/cmo`), 6 agents, 20 commands, 1 upstream catalog. The Studio dashboard (Next.js + Bun API) ships inside the same tarball and is launched via `mktg studio`.
 
 | Component | Count | Purpose |
 |---|---|---|
@@ -46,9 +46,9 @@ src/
 │   ├── skill-add.ts    # External skill chaining (mktg skill add)
 │   ├── agents.ts       # Agent registry, install to ~/.claude/agents/
 │   └── transcribe.ts   # whisper.cpp + yt-dlp + ffmpeg pipeline
-skills/                  # 52 SKILL.md files installed to ~/.claude/skills/
+skills/                  # 63 SKILL.md files installed to ~/.claude/skills/
 skills-manifest.json     # Definitive skill list with metadata
-agents/                  # 5 agent .md files installed to ~/.claude/agents/
+agents/                  # 6 agent .md files installed to ~/.claude/agents/
 agents-manifest.json     # Definitive agent list with metadata
 catalogs-manifest.json   # Upstream catalog registry (postiz v1; parallel to skills/agents)
 studio/                  # Studio dashboard workspace member (ships inside the tarball)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p align="center">
   <a href="https://github.com/MoizIbnYousaf/marketing-cli/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-10b981" alt="MIT License"></a>
-  <img src="https://img.shields.io/badge/skills-58-10b981" alt="58 Skills">
+  <img src="https://img.shields.io/badge/skills-63-10b981" alt="63 Skills">
   <img src="https://img.shields.io/badge/agents-5-10b981" alt="5 Agents">
   <a href="https://www.npmjs.com/package/marketing-cli"><img src="https://img.shields.io/npm/v/marketing-cli?color=10b981" alt="npm"></a>
   <img src="https://img.shields.io/badge/tests-2,624-10b981" alt="2,624 tests">
@@ -12,7 +12,7 @@
 </p>
 
 <p align="center">
-  <b>One package. One install. CLI for the agent, Studio for the human. 58 skills, 6 research agents, brand memory that compounds.</b>
+  <b>One package. One install. CLI for the agent, Studio for the human. 63 skills, 6 research agents, brand memory that compounds.</b>
 </p>
 
 ---
@@ -25,7 +25,7 @@ One npm package, two surfaces. The CLI is the agent surface, the Studio dashboar
 
 | Surface | What it is | Path |
 |---|---|---|
-| `mktg` CLI | 58 skills, 6 agents, brand memory, `/cmo` orchestration | (root) |
+| `mktg` CLI | 63 skills, 6 agents, brand memory, `/cmo` orchestration | (root) |
 | Studio dashboard | Local Next.js + Bun API: pulse, signals, brand visualizer, publish queue | [`studio/`](studio/) |
 
 `npm i -g marketing-cli` installs both. The repo uses a bun workspace because Studio is a Next.js app with its own build, but at install time it is one package, one tarball.
@@ -34,7 +34,7 @@ One npm package, two surfaces. The CLI is the agent surface, the Studio dashboar
 
 You ask your agent for marketing help. It writes generic copy and forgets your audience by tomorrow. The skills it would use aren't installed; the brand files don't exist; the agent learns this halfway through, when something fails mid-execution. Every session is the first session.
 
-`marketing-cli` fixes that. Install once and your agent inherits 58 skills, 6 research agents, and a brand memory that compounds. Session 10 starts where session 9 ended. Every conversation builds on the last.
+`marketing-cli` fixes that. Install once and your agent inherits 63 skills, 6 research agents, and a brand memory that compounds. Session 10 starts where session 9 ended. Every conversation builds on the last.
 
 ---
 
@@ -57,7 +57,7 @@ You ask your agent for marketing help. It writes generic copy and forgets your a
 | | |
 |---|---|
 | **`mktg` CLI** | 20 commands, 21/21 Agent DX score, JSON-by-default |
-| **58 marketing skills** | The playbook, copied to `~/.claude/skills/` |
+| **63 marketing skills** | The playbook, copied to `~/.claude/skills/` |
 | **5 research + review agents** | Parallel sub-agents in `~/.claude/agents/` |
 | **10 brand memory files** | Persistent marketing memory in your project's `brand/` (10 templates plus `SCHEMA.md`), created by `mktg init` |
 | **`/cmo` orchestrator** | The brain that routes every request to the right skill |
@@ -77,7 +77,7 @@ Not bundled. These are external binaries the skills know how to drive. `mktg doc
 | `whisper-cli` | Speech-to-text via whisper.cpp | `brew install whisper-cpp` |
 | `yt-dlp` | Media download from YouTube/TikTok/podcasts | `brew install yt-dlp` |
 | [`summarize`](https://github.com/steipete/summarize) | Text compression: TL;DR, digest, key points | `npm i -g @steipete/summarize` |
-| Exa MCP | Parallel deep research (default for agent web queries) | MCP config in `.mcp.json` |
+| Exa MCP + skills | Semantic search, company research, lead gen (`exa-search`, `company-research`, …) | `.mcp.json` + `EXA_API_KEY` |
 
 ### Best-practices skills (how to use a tool, written down)
 
@@ -97,7 +97,7 @@ mktg orchestrates; it doesn't reimplement. When a good tool already exists, we c
 npm i -g marketing-cli
 ```
 
-That's it. The global npm install copies the 58 skills into `~/.claude/skills/` and the 5 agents into `~/.claude/agents/`. No second install command, no `mktg init` to remember.
+That's it. The global npm install copies the 63 skills into `~/.claude/skills/` and the 5 agents into `~/.claude/agents/`. No second install command, no `mktg init` to remember.
 
 Then open Claude Code in your project and run:
 
@@ -232,7 +232,7 @@ Organized by marketing layer. Foundation builds up to distribution.
 
 | Skill | What it does |
 |-------|-------------|
-| **cmo** | Orchestrates all 58 skills. Routing table, disambiguation, guardrails. |
+| **cmo** | Orchestrates all 63 skills. Routing table, disambiguation, guardrails. |
 | **brand-voice** | Define or extract brand voice from existing content |
 | **audience-research** | Build buyer personas with parallel web research |
 | **competitive-intel** | Analyze competitors with real-time web intelligence |
@@ -301,7 +301,7 @@ Organized by marketing layer. Foundation builds up to distribution.
 </details>
 
 <details>
-<summary><b>Adapters & best-practices (9 skills)</b>: Tool wrappers, ecosystem connectors, advanced workflows</summary>
+<summary><b>Adapters & best-practices (14 skills)</b>: Tool wrappers, ecosystem connectors, advanced workflows</summary>
 
 | Skill | What it does |
 |-------|-------------|
@@ -314,6 +314,11 @@ Organized by marketing layer. Foundation builds up to distribution.
 | **firecrawl** | Best-practices wrapper for the Firecrawl CLI |
 | **summarize** | Best-practices wrapper for @steipete/summarize |
 | **mktg-x** | Authenticated Twitter/X reader for tweets, threads, bookmarks |
+| **exa-search** | Exa semantic web search (MCP or `POST /search`) |
+| **exa-contents** | Exa known-URL extraction (MCP or `POST /contents`) |
+| **company-research** | Exa Agent company deep dives and company lists |
+| **lead-generation** | Exa Agent ICP prospect lists with CSV output |
+| **build-with-exa** | Exa API/SDK cookbook (`exa-js` / `exa-py`, Agent, websets) |
 
 </details>
 
@@ -342,7 +347,7 @@ The 3 research agents run **in parallel**. Results write back to `brand/` so eve
 | `mktg init` | Scaffold `brand/` plus install skills plus install agents |
 | `mktg status` | Project marketing state snapshot |
 | `mktg doctor` | Health checks: brand files, skills, agents, CLI tools, integrations |
-| `mktg list` | Show all 58 skills with install status and metadata |
+| `mktg list` | Show all 63 skills with install status and metadata |
 | `mktg update` | Re-install skills from latest package version |
 | `mktg schema` | Introspect all commands, flags, and output shapes |
 | `mktg skill` | Inspect, validate, register, analyze, and chain external skills |
@@ -400,7 +405,7 @@ src/
 ├── commands/           # 20 top-level commands (init, doctor, status, list, update, schema, skill, brand, run, transcribe, context, plan, publish, compete, dashboard, catalog, studio, verify, ship-check, cmo)
 └── core/               # Shared modules (output, errors, brand, skills, agents, integrations)
 
-skills/                 # 58 SKILL.md files installed via ai-agent-skills or directly
+skills/                 # 63 SKILL.md files installed via ai-agent-skills or directly
 ├── cmo/                # Orchestrator with rules/ and references/
 ├── brand-voice/
 ├── direct-response-copy/
@@ -440,7 +445,7 @@ bun run build         # Build
 ### Project Structure
 
 - `src/`: CLI source (TypeScript, ~15,500 lines)
-- `skills/`: 58 SKILL.md files (manifest-backed)
+- `skills/`: 63 SKILL.md files (manifest-backed)
 - `agents/`: 5 agent definitions
 - `tests/`: 2,599 tests across 96 files (real file I/O, no mocks)
 - `docs/`: Reference docs (`EXIT_CODES.md`, `skill-contract.md`)
@@ -466,7 +471,7 @@ Contributions welcome. The fastest ways to help:
 
 ## Acknowledgments
 
-- [Corey Haines' Marketing Skills](https://github.com/coreyhaines31/marketingskills): the breadth skill collection that inspired many of mktg's 58 skills
+- [Corey Haines' Marketing Skills](https://github.com/coreyhaines31/marketingskills): the breadth skill collection that inspired many of mktg's 63 skills
 - [Postiz](https://github.com/gitroomhq/postiz-app) by [@gitroomhq](https://github.com/gitroomhq): the upstream catalog for 30+ social provider integrations (LinkedIn, Reddit, Bluesky, Mastodon, Threads, Instagram, TikTok, YouTube, Pinterest, Discord, Slack, etc.). mktg connects via REST API; license stays firewalled.
 - [last30days-skill](https://github.com/mvanhorn/last30days-skill) by [@mvanhorn](https://github.com/mvanhorn): live research across Reddit, X, YouTube, Hacker News, GitHub, and the web. `/cmo` chains it before any market claim, so the playbook stays grounded in what's actually happening this month, not training-data folklore.
 - [`@steipete/summarize`](https://github.com/steipete/summarize) by [@steipete](https://github.com/steipete): the text-compression CLI that mktg's `summarize` skill wraps with rules and budgets.

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ mktg orchestrates; it doesn't reimplement. When a good tool already exists, we c
 npm i -g marketing-cli
 ```
 
-That's it. The global npm install copies the 63 skills into `~/.claude/skills/` and the 5 agents into `~/.claude/agents/`. No second install command, no `mktg init` to remember.
+That's it. The global npm install copies the 63 skills into `~/.claude/skills/` and the 6 agents into `~/.claude/agents/`. No second install command, no `mktg init` to remember.
 
 Then open Claude Code in your project and run:
 
@@ -324,7 +324,7 @@ Organized by marketing layer. Foundation builds up to distribution.
 
 ---
 
-## Agents (5)
+## Agents (6)
 
 Parallel sub-agents for research and review. `/cmo` spawns them during foundation building:
 
@@ -411,7 +411,7 @@ skills/                 # 63 SKILL.md files installed via ai-agent-skills or dir
 ├── direct-response-copy/
 └── ...
 
-agents/                 # 5 agent .md files installed to ~/.claude/agents/
+agents/                 # 6 agent .md files installed to ~/.claude/agents/
 ├── research/           # brand-researcher, audience-researcher, competitive-scanner
 └── review/             # content-reviewer, seo-analyst
 
@@ -446,7 +446,7 @@ bun run build         # Build
 
 - `src/`: CLI source (TypeScript, ~15,500 lines)
 - `skills/`: 63 SKILL.md files (manifest-backed)
-- `agents/`: 5 agent definitions
+- `agents/`: 6 agent definitions
 - `tests/`: 2,599 tests across 96 files (real file I/O, no mocks)
 - `docs/`: Reference docs (`EXIT_CODES.md`, `skill-contract.md`)
 

--- a/agents/research/audience-researcher.md
+++ b/agents/research/audience-researcher.md
@@ -1,6 +1,6 @@
 ---
 name: mktg-audience-researcher
-description: "Audience research agent. Uses Exa MCP to find communities, build buyer personas, and map watering holes. Writes brand/audience.md. Spawned by /cmo during parallel foundation building."
+description: "Audience research agent. Uses `exa-search` / Exa MCP to find communities, build buyer personas, and map watering holes. Writes brand/audience.md. Spawned by /cmo during parallel foundation building."
 model: opus
 ---
 
@@ -12,7 +12,7 @@ You do NOT ask questions. You research, analyze, and write.
 
 1. **Check for existing audience.md** — if `brand/audience.md` already exists, read it. Build on what's there rather than starting from scratch. Add depth, verify claims, fill gaps. Only overwrite sections where you find stronger data.
 2. **Read project context** — README.md, package.json, any existing brand/ files (voice-profile.md, positioning.md, competitors.md). These tell you what the product does and who it's for.
-3. **Assess your tools** — if Exa MCP is available, you're in deep research mode. If not, build from local context and be upfront about limitations.
+3. **Assess your tools** — if `exa-search` / Exa MCP is available, you're in deep research mode. If not, build from local context and be upfront about limitations.
 
 ## Research Process
 
@@ -42,7 +42,7 @@ For each distinct audience segment (1-2 max — specificity beats breadth), buil
 
 ### Step 3: Find watering holes
 
-Where does this audience already gather? Use Exa MCP when available:
+Where does this audience already gather? Use `exa-search` / Exa MCP when available:
 1. Search "[problem/topic] + reddit/forum/community" to find communities
 2. Search "[job title/role] + newsletter/podcast/blog" to find content they consume
 3. Search "[competitor name] + reviews/alternatives" to find real user language
@@ -136,7 +136,7 @@ primary_persona: [name]
 
 ## Tools
 
-- **Exa MCP** — web search for communities, forums, social discussions, reviews. This is your primary research tool.
+- **`exa-search` / Exa MCP** — web search for communities, forums, social discussions, reviews. This is your primary research tool.
 - **Read** — analyze local project files for context (README.md, package.json, brand/ files)
 - **Write** — write brand/audience.md
 - **Glob/Grep** — find relevant content in the project
@@ -145,7 +145,7 @@ primary_persona: [name]
 
 - Never fabricate quotes — downstream skills use language mines as real customer voice in copy. Fabricated quotes produce inauthentic messaging that erodes trust. Mark paraphrased language as "representative."
 - Never assume demographics without evidence — persona decisions drive targeting, pricing, and channel strategy. Wrong demographics cascade into wrong marketing.
-- If Exa MCP is unavailable, build from local context (README, package.json, existing brand files) and note the limitation clearly at the top of the output: "Research based on local project context only. Validate with web research when available."
+- If `exa-search` / Exa MCP is unavailable, build from local context (README, package.json, existing brand files) and note the limitation clearly at the top of the output: "Research based on local project context only. Validate with web research when available."
 - Write the file even with limited context — a working persona beats no persona. Every downstream skill needs audience.md to function well.
 - Focus on 1-2 personas max. Specificity beats breadth because generic personas produce generic copy.
 - If audience.md already exists, preserve what's there and add depth. Don't delete existing research unless you have stronger evidence.

--- a/agents/research/backlink-prospector.md
+++ b/agents/research/backlink-prospector.md
@@ -1,6 +1,6 @@
 ---
 name: mktg-backlink-prospector
-description: "Backlink prospecting research agent. Uses Exa MCP (mktg default) or Ahrefs MCP (if connected) to surface directory + listicle + guest-post candidates from competitor referring-domains. Writes the consolidated target list to the project's .seo/backlink-targets.json (project path, NOT a brand file). Spawned by /cmo via the off-page-seo skill or when the user asks for outreach targets."
+description: "Backlink prospecting research agent. Uses `exa-search` / Exa MCP (mktg default) or Ahrefs MCP (if connected) to surface directory + listicle + guest-post candidates from competitor referring-domains. Writes the consolidated target list to the project's .seo/backlink-targets.json (project path, NOT a brand file). Spawned by /cmo via the off-page-seo skill or when the user asks for outreach targets."
 model: opus
 ---
 

--- a/agents/research/brand-researcher.md
+++ b/agents/research/brand-researcher.md
@@ -28,13 +28,13 @@ Before researching, check for existing brand context that should inform the voic
 ## Research Process
 
 1. **Read project context** — README.md, package.json, any existing docs/, marketing/, or content files. Use Glob to find relevant files.
-2. **If a URL was provided** — use Exa MCP to search for and analyze the website:
+2. **If a URL was provided** — use `exa-search` / Exa MCP to search for and analyze the website:
    - Homepage copy, about page, social bios
    - Blog posts, landing pages, email signup copy
    - Social media presence and tone
    - Podcast appearances, interviews, guest posts
-3. **If no URL** — use Exa MCP to search for the project/brand name online
-4. **If Exa MCP unavailable** — work with local files only. Note the limitation in the profile but still produce a complete profile from whatever is available.
+3. **If no URL** — use `exa-search` / Exa MCP to search for the project/brand name online
+4. **If Exa unavailable** — work with local files only. Note the limitation in the profile but still produce a complete profile from whatever is available.
 5. **Analyze all content for voice patterns across 6 dimensions:**
    - Tone patterns (formal↔casual, serious↔playful, reserved↔bold, distant↔intimate)
    - Vocabulary patterns (jargon level, signature words, words to avoid)

--- a/agents/research/competitive-scanner.md
+++ b/agents/research/competitive-scanner.md
@@ -1,6 +1,6 @@
 ---
 name: mktg-competitive-scanner
-description: "Competitive intelligence agent. Uses Exa MCP to research competitors, analyze positioning, and find market gaps. Writes brand/competitors.md. Spawned by /cmo during parallel foundation building."
+description: "Competitive intelligence agent. Uses `company-research` / `exa-search` (Exa MCP) to research competitors, analyze positioning, and find market gaps. Writes brand/competitors.md. Spawned by /cmo during parallel foundation building."
 model: opus
 ---
 
@@ -27,7 +27,7 @@ Run in **Deep Teardown** mode — the spawning agent needs comprehensive competi
 
 ## Research Process
 
-1. **Identify competitors using Exa MCP:**
+1. **Identify competitors using `exa-search` / `company-research` (Exa MCP):**
    - Search "[product category] alternatives" and "[product name] alternatives"
    - Search "[product type] vs" to find comparison content
    - Search product category on Product Hunt, G2, and Reddit
@@ -111,7 +111,7 @@ primary_gap: "{one-line summary of biggest opportunity}"
 
 ## Tools
 
-- **Exa MCP** — web search for competitor websites, pricing pages, reviews, social presence
+- **`exa-search` / `company-research`** - web search for competitor websites, pricing pages, reviews, social presence
 - **Read** — analyze local project files for context
 - **Write** — write brand/competitors.md
 - **Glob/Grep** — find relevant content in the project
@@ -119,7 +119,7 @@ primary_gap: "{one-line summary of biggest opportunity}"
 ## Edge Cases
 
 - **No direct competitors found:** The product may be genuinely novel. Search for adjacent categories and indirect competitors (different solution, same problem). Note that the competitive landscape is emerging rather than established.
-- **Exa MCP unavailable:** Work with whatever local context is available (README, existing brand files, package.json). Produce a skeleton competitors.md with what you can infer, and clearly mark all entries as "needs verification with web research."
+- **Exa unavailable (`EXA_API_KEY` / MCP):** Work with whatever local context is available (README, existing brand files, package.json). Produce a skeleton competitors.md with what you can infer, and clearly mark all entries as "needs verification with web research."
 - **Very thin results:** If search returns minimal data for a competitor (no pricing page, no clear positioning), note what's unknown rather than guessing. Partial data with honest gaps is more useful than fabricated completeness.
 - **Competitor has pivoted or shut down:** Note the status change. A competitor shutting down can signal market problems or opportunity.
 

--- a/agents/review/seo-analyst.md
+++ b/agents/review/seo-analyst.md
@@ -138,7 +138,7 @@ TOP 3 FIXES:
 
 ## Tools
 
-- **Exa MCP** — research what currently ranks for target keywords
+- **`exa-search`** - research what currently ranks for target keywords
 - **Read** — analyze local content files and brand context
 - **Bash** — curl pages for meta tag analysis if needed
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "marketing-cli",
   "version": "0.6.0",
-  "description": "Agent-native marketing playbook CLI: 58 skills, 5 research/review agents, brand memory, and /cmo orchestration."
+  "description": "Agent-native marketing playbook CLI: 63 skills, 5 research/review agents, brand memory, and /cmo orchestration."
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "marketing-cli",
   "version": "0.6.0",
-  "description": "Agent-native marketing playbook: 58 skills, 5 research agents, brand memory that compounds, plus a local Studio dashboard (beta). One install, then /cmo in Claude Code walks you through a 4-question setup wizard. CLI for the agent, Studio for the human.",
+  "description": "Agent-native marketing playbook: 63 skills, 5 research agents, brand memory that compounds, plus a local Studio dashboard (beta). One install, then /cmo in Claude Code walks you through a 4-question setup wizard. CLI for the agent, Studio for the human.",
   "type": "module",
   "workspaces": [
     "studio"
@@ -16,6 +16,7 @@
     "agents",
     "agents-manifest.json",
     "catalogs-manifest.json",
+    ".mcp.json",
     ".claude-plugin",
     ".codex-plugin",
     "gemini-extension.json",

--- a/scripts/postinstall.cjs
+++ b/scripts/postinstall.cjs
@@ -248,6 +248,7 @@ try {
     }
   }
 
+  log("mktg postinstall: for Exa web research skills, set EXA_API_KEY (https://dashboard.exa.ai/api-keys); repo ships `.mcp.json`.");
   log("mktg postinstall: run `mktg init` inside a project to scaffold brand memory.");
 } catch (error) {
   log(`mktg postinstall: skipped Claude skill install (${error && error.message ? error.message : String(error)}).`);

--- a/skills-manifest.json
+++ b/skills-manifest.json
@@ -780,7 +780,6 @@
         "competitive-intel"
       ],
       "triggers": [
-
         "build organic traffic",
         "rank in google",
         "alternatives pages",
@@ -1843,6 +1842,183 @@
       ],
       "review_interval_days": 30,
       "version": "0.3.0"
+    },
+    "exa-search": {
+      "source": "new",
+      "upstream": {
+        "primary": {
+          "repo": "exa-labs/agent-skills",
+          "path": "skills/exa-search",
+          "snapshot_sha": "390ffee2d7e1d0dce2ed8efe4994c2b3c1c0173b",
+          "snapshot_at": "2026-07-15T17:11:29Z"
+        }
+      },
+      "category": "knowledge",
+      "layer": "foundation",
+      "tier": "nice-to-have",
+      "reads": [
+        "positioning.md",
+        "competitors.md",
+        "landscape.md"
+      ],
+      "writes": [],
+      "depends_on": [],
+      "triggers": [
+        "exa search",
+        "exa-search",
+        "semantic web search",
+        "search the web with exa",
+        "find sources with exa",
+        "web_search_exa",
+        "open-ended web research",
+        "discover competitors online",
+        "find recent news about"
+      ],
+      "review_interval_days": 30,
+      "version": "0.1.0",
+      "env_vars": [
+        "EXA_API_KEY"
+      ]
+    },
+    "exa-contents": {
+      "source": "new",
+      "upstream": {
+        "primary": {
+          "repo": "exa-labs/agent-skills",
+          "path": "skills/exa-contents",
+          "snapshot_sha": "390ffee2d7e1d0dce2ed8efe4994c2b3c1c0173b",
+          "snapshot_at": "2026-07-15T17:11:29Z"
+        }
+      },
+      "category": "knowledge",
+      "layer": "foundation",
+      "tier": "nice-to-have",
+      "reads": [
+        "competitors.md",
+        "landscape.md"
+      ],
+      "writes": [],
+      "depends_on": [],
+      "triggers": [
+        "exa contents",
+        "exa-contents",
+        "extract url with exa",
+        "web_fetch_exa",
+        "exa crawl url",
+        "fetch page via exa",
+        "exa highlights from url"
+      ],
+      "review_interval_days": 30,
+      "version": "0.1.0",
+      "env_vars": [
+        "EXA_API_KEY"
+      ]
+    },
+    "build-with-exa": {
+      "source": "new",
+      "upstream": {
+        "primary": {
+          "repo": "exa-labs/agent-skills",
+          "path": "skills/build-with-exa",
+          "snapshot_sha": "390ffee2d7e1d0dce2ed8efe4994c2b3c1c0173b",
+          "snapshot_at": "2026-07-15T17:11:29Z"
+        }
+      },
+      "category": "knowledge",
+      "layer": "execution",
+      "tier": "nice-to-have",
+      "reads": [],
+      "writes": [],
+      "depends_on": [],
+      "triggers": [
+        "build with exa",
+        "exa api",
+        "exa-js",
+        "exa-py",
+        "integrate exa",
+        "exa agent api",
+        "exa websets",
+        "exa monitors",
+        "exa sdk"
+      ],
+      "review_interval_days": 30,
+      "version": "0.1.0",
+      "env_vars": [
+        "EXA_API_KEY"
+      ]
+    },
+    "company-research": {
+      "source": "new",
+      "upstream": {
+        "primary": {
+          "repo": "exa-labs/agent-skills",
+          "path": "skills/company-research",
+          "snapshot_sha": "390ffee2d7e1d0dce2ed8efe4994c2b3c1c0173b",
+          "snapshot_at": "2026-07-15T17:11:29Z"
+        }
+      },
+      "category": "foundation",
+      "layer": "foundation",
+      "tier": "nice-to-have",
+      "reads": [
+        "positioning.md",
+        "competitors.md",
+        "audience.md"
+      ],
+      "writes": [],
+      "depends_on": [],
+      "triggers": [
+        "company research",
+        "research this company",
+        "company deep dive",
+        "funding history",
+        "who are their competitors",
+        "company list",
+        "exa company research",
+        "lookup company"
+      ],
+      "review_interval_days": 30,
+      "version": "0.1.0",
+      "env_vars": [
+        "EXA_API_KEY"
+      ]
+    },
+    "lead-generation": {
+      "source": "new",
+      "upstream": {
+        "primary": {
+          "repo": "exa-labs/agent-skills",
+          "path": "skills/lead-generation",
+          "snapshot_sha": "390ffee2d7e1d0dce2ed8efe4994c2b3c1c0173b",
+          "snapshot_at": "2026-07-15T17:11:29Z"
+        }
+      },
+      "category": "growth",
+      "layer": "execution",
+      "tier": "nice-to-have",
+      "reads": [
+        "audience.md",
+        "positioning.md",
+        "competitors.md"
+      ],
+      "writes": [],
+      "depends_on": [],
+      "triggers": [
+        "lead generation",
+        "lead gen",
+        "prospect list",
+        "find companies to sell to",
+        "ICP list",
+        "outbound list",
+        "enriched leads",
+        "build a lead list",
+        "generate leads"
+      ],
+      "review_interval_days": 30,
+      "version": "0.1.0",
+      "env_vars": [
+        "EXA_API_KEY"
+      ]
     }
   },
   "redirects": {
@@ -1901,7 +2077,6 @@
     "show-brand": "brand-kit-playground",
     "visual-brand-preview": "brand-kit-playground",
     "brand-workbench": "brand-kit-playground",
-
     "build organic traffic": "seo-machine",
     "rank in google": "seo-machine",
     "programmatic seo playbook": "seo-machine",
@@ -1916,6 +2091,18 @@
     "outreach targets": "off-page-seo",
     "link building": "off-page-seo",
     "submit to directories": "off-page-seo",
-    "domain authority": "off-page-seo"
+    "domain authority": "off-page-seo",
+    "exa": "exa-search",
+    "exa-web-search": "exa-search",
+    "web-search-exa": "exa-search",
+    "exa-fetch": "exa-contents",
+    "exa-crawl": "exa-contents",
+    "exa-company-research": "company-research",
+    "research-company": "company-research",
+    "exa-lead-gen": "lead-generation",
+    "lead-gen": "lead-generation",
+    "prospect-list": "lead-generation",
+    "exa-sdk": "build-with-exa",
+    "exa-api": "build-with-exa"
   }
 }

--- a/skills/audience-research/SKILL.md
+++ b/skills/audience-research/SKILL.md
@@ -21,7 +21,7 @@ Every marketing skill gets better when you know your audience. Generic copy
 happens when you write for "everyone." Specific copy that converts happens
 when you write for a real person with real problems.
 
-This skill builds that audience profile. It's the foundation — 8 of 11 content
+This skill builds that audience profile. It's the foundation  -  8 of 11 content
 skills read `audience.md` to shape their output. Running this first makes
 everything downstream sharper.
 
@@ -34,8 +34,8 @@ No SaaS tools needed. Systematic research plus web search.
 
 1. Check if `brand/` directory exists in the project root.
 2. If it does, read available files: `voice-profile.md`, `positioning.md`, `audience.md`, `competitors.md`, `creative-kit.md`, `stack.md`, `learnings.md`.
-3. Apply any loaded brand context to enhance output quality — skip questions the user has already answered.
-4. If `brand/` does not exist, proceed without it — this skill works standalone.
+3. Apply any loaded brand context to enhance output quality  -  skip questions the user has already answered.
+4. If `brand/` does not exist, proceed without it  -  this skill works standalone.
 
 ---
 
@@ -96,7 +96,7 @@ skills to parse but human enough to be useful for strategy.
 
 Choose based on what's available:
 
-### Quick Profile (L0 — zero context)
+### Quick Profile (L0  -  zero context)
 
 When no brand files exist and minimal information is provided. Ask 5 key questions:
 
@@ -109,14 +109,14 @@ When no brand files exist and minimal information is provided. Ask 5 key questio
 From these 5 answers, generate a working persona. It won't be perfect but it
 gives every downstream skill something to work with.
 
-### Persona Build (L1-L2 — some context)
+### Persona Build (L1-L2  -  some context)
 
 When you have basic product info or existing brand files. Systematic persona
 construction using demographics, psychographics, and jobs-to-be-done.
 
-### Community Mining (L3-L4 — full research)
+### Community Mining (L3-L4  -  full research)
 
-When Exa MCP or web search is available. Deep research into where the audience
+When `exa-search` / Exa MCP or web search is available. Deep research into where the audience
 lives online, what language they use, what they complain about, and what they
 aspire to.
 
@@ -126,7 +126,7 @@ aspire to.
 
 ### Step 1: Identify the transformation
 
-Same as positioning — start with the outcome, not the product.
+Same as positioning  -  start with the outcome, not the product.
 
 - What does the customer's life look like BEFORE? (the pain state)
 - What does it look like AFTER? (the desired state)
@@ -150,7 +150,7 @@ For each distinct audience segment (usually 1-3), build:
 - Values and beliefs about this category
 - How they make decisions (data-driven, social proof, gut feel)
 
-**Jobs-to-be-done** (why they hire your product — see `references/jtbd-framework.md` for the full framework, Forces of Progress, and job mapping template):
+**Jobs-to-be-done** (why they hire your product  -  see `references/jtbd-framework.md` for the full framework, Forces of Progress, and job mapping template):
 - Functional job: What task are they trying to accomplish?
 - Emotional job: How do they want to feel?
 - Social job: How do they want to be perceived?
@@ -164,7 +164,7 @@ For each distinct audience segment (usually 1-3), build:
 
 Where does this audience already gather? This is where you'll distribute content.
 
-**Search process** (use Exa MCP when available):
+**Search process** (use `exa-search` / Exa MCP when available):
 1. Search for "[problem/topic] + reddit/forum/community"
 2. Search for "[job title/role] + newsletter/podcast/blog"
 3. Search for "[competitor name] + reviews/alternatives"
@@ -180,21 +180,21 @@ Where does this audience already gather? This is where you'll distribute content
 ──────────────────────────────────────────────────
 
   Online Communities
-  ├── r/[subreddit] — [activity level, relevance]
-  ├── [Forum/Discord] — [activity level, relevance]
-  └── [Facebook Group] — [activity level, relevance]
+  ├── r/[subreddit]  -  [activity level, relevance]
+  ├── [Forum/Discord]  -  [activity level, relevance]
+  └── [Facebook Group]  -  [activity level, relevance]
 
   Content They Consume
-  ├── [Newsletter] — [subscriber count if known]
-  ├── [Podcast] — [relevance]
-  └── [Blog/Publication] — [relevance]
+  ├── [Newsletter]  -  [subscriber count if known]
+  ├── [Podcast]  -  [relevance]
+  └── [Blog/Publication]  -  [relevance]
 
   Social Platforms
-  ├── [Platform] — [how they use it]
-  └── [Platform] — [how they use it]
+  ├── [Platform]  -  [how they use it]
+  └── [Platform]  -  [how they use it]
 
   Events & Conferences
-  └── [Event] — [relevance]
+  └── [Event]  -  [relevance]
 
 ──────────────────────────────────────────────────
 ```
@@ -217,7 +217,7 @@ For each persona, identify:
 
 ### Step 5: Identify language mines
 
-Search for actual quotes from the audience — Reddit posts, review sites, forum
+Search for actual quotes from the audience  -  Reddit posts, review sites, forum
 threads, social media. These are gold for copywriting.
 
 Look for:
@@ -243,7 +243,7 @@ primary_persona: [name]
 archetypes: [number]
 ---
 
-# Audience Profile — [Product/Project Name]
+# Audience Profile  -  [Product/Project Name]
 
 ## Archetypes
 
@@ -252,7 +252,7 @@ Card-shaped summary of every persona. One archetype per persona. Required fields
 ### Archetype: [Name]
 
 - **one_liner:** [Who they are and what they want, one sentence]
-- **demographic:** [Role, company size, technical level — single line]
+- **demographic:** [Role, company size, technical level  -  single line]
 - **top_pain:** [The single biggest pain in their words]
 - **top_desire:** [The single biggest goal in their words]
 - **watering_hole:** [Primary community / channel where they live]
@@ -315,10 +315,10 @@ Card-shaped summary of every persona. One archetype per persona. Required fields
 
 | Level | Context Available | Output Quality |
 |-------|------------------|---------------|
-| L0 | Nothing — 5 questions only | Working persona, generic watering holes |
+| L0 | Nothing  -  5 questions only | Working persona, generic watering holes |
 | L1 | Product info + basic brand files | Targeted persona, category-specific insights |
 | L2 | + competitor data from competitors.md | Differentiated personas, competitive gaps |
-| L3 | + web research via Exa MCP | Real quotes, verified watering holes, data-backed |
+| L3 | + web research via `exa-search` | Real quotes, verified watering holes, data-backed |
 | L4 | + existing audience.md (refinement) | Evolved personas with historical learning |
 
 ---
@@ -346,10 +346,10 @@ Card-shaped summary of every persona. One archetype per persona. Required fields
 
 ## What this skill is NOT
 
-- **Not persona fiction** — Every claim must come from research, user input, or web data. Never invent demographics or psychographics to fill gaps.
-- **Not audience.md only** — This skill writes the file, but the real output is strategic understanding of who buys and why.
-- **Not market research** — This focuses on buyer personas and watering holes. For competitive landscape, use /competitive-intel. For market sizing and trends, that's a different analysis.
-- **Not a one-time exercise** — Personas evolve. Run this again when conversion drops, when expanding to new segments, or when feedback contradicts existing personas.
+- **Not persona fiction**  -  Every claim must come from research, user input, or web data. Never invent demographics or psychographics to fill gaps.
+- **Not audience.md only**  -  This skill writes the file, but the real output is strategic understanding of who buys and why.
+- **Not market research**  -  This focuses on buyer personas and watering holes. For competitive landscape, use /competitive-intel. For market sizing and trends, that's a different analysis.
+- **Not a one-time exercise**  -  Personas evolve. Run this again when conversion drops, when expanding to new segments, or when feedback contradicts existing personas.
 
 ---
 
@@ -401,8 +401,8 @@ After delivering the audience profile:
 
 ## Safety rules
 
-- Never fabricate quotes — downstream skills use language mines as real customer voice in copy. Fabricated quotes produce inauthentic messaging that erodes trust. Mark web-sourced language as "representative" if paraphrased.
-- Never assume demographics without evidence — persona decisions drive targeting, pricing, and channel strategy. Wrong demographics cascade into wrong marketing. Ask or research.
-- Never write audience data from one project into another project's brand/ — audience profiles are project-specific. Cross-contamination means one project's strategy infects another.
-- Always check `--cwd` context if provided — the working directory determines which brand/ to read and write.
-- If Exa MCP is unavailable, skip web research steps and note the limitation — the skill still produces useful output at L0-L2, just without verified watering holes and real quotes.
+- Never fabricate quotes  -  downstream skills use language mines as real customer voice in copy. Fabricated quotes produce inauthentic messaging that erodes trust. Mark web-sourced language as "representative" if paraphrased.
+- Never assume demographics without evidence  -  persona decisions drive targeting, pricing, and channel strategy. Wrong demographics cascade into wrong marketing. Ask or research.
+- Never write audience data from one project into another project's brand/  -  audience profiles are project-specific. Cross-contamination means one project's strategy infects another.
+- Always check `--cwd` context if provided  -  the working directory determines which brand/ to read and write.
+- If Exa is unavailable, skip web research steps and note the limitation - the skill still produces useful output at L0-L2, just without verified watering holes and real quotes.

--- a/skills/build-with-exa/SKILL.md
+++ b/skills/build-with-exa/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: build-with-exa
+version: 0.1.0
+description: >
+  Build applications and agents with Exa's API Platform: search, contents,
+  answer, context, Agent API, monitors, websets, OpenAI-compatible endpoints,
+  and exa-py / exa-js. Use when choosing Exa endpoints, writing Exa API calls,
+  integrating semantic web search or research into products, or debugging Exa
+  request shapes. Load references/ on demand for endpoint details.
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Skill
+author: Exa Labs (ported by mktg)
+license: MIT
+user-invocable: true
+metadata:
+  openclaw:
+    emoji: 🧩
+---
+
+## On Activation
+
+1. Confirm `EXA_API_KEY` is available for any live API call. SDK examples assume the key is set.
+2. Default new integrations to `POST /search` with `type: "auto"` and `contents.highlights: true`. Escalate to Agent API only for multi-step research / list-building.
+3. Load only the `references/*.md` file needed for the current endpoint - do not dump the whole tree into context.
+4. For agent-native marketing research inside mktg projects, prefer `exa-search`, `company-research`, or `lead-generation` over inventing a custom integration.
+
+# Build with Exa
+
+## Scope
+
+Included by default:
+
+- Core retrieval APIs: search endpoint, contents endpoint, answer endpoint, context endpoint
+- Long-running research workflows: Agent API (`/agent`)
+- Async and recurring workflows: Monitors API, Websets API
+- SDK guidance: Python `exa-py`, TypeScript `exa-js`
+
+> Note on data retention: `/search`, `/answer`, and deep research are Zero Data Retention (ZDR). The Agent API (`/agent`), Websets, and Monitors are not ZDR. If a use case requires ZDR, stay on the ZDR surfaces or contact Exa.
+
+## Installation
+
+```bash
+# Python
+pip install exa-py
+
+# TypeScript / JavaScript
+npm install exa-js
+```
+
+## Authentication
+
+```bash
+export EXA_API_KEY="your_api_key_here"
+```
+
+Exa accepts either the `x-api-key` header or `Authorization: Bearer <key>`.
+
+## API Decision Workflow
+
+Before picking an endpoint, decide which workflow shape fits:
+
+- Raw web content for your own LLM or agent: start with `/search` using `type: "auto"` and `contents: { highlights: true }`
+- Synthesized structured output: start with `/search` using the search type that fits your latency and reasoning needs, then add `outputSchema` and `systemPrompt`
+- Long-running multi-step research, list-building, or enrichment with structured output: use the Agent API (`/agent`)
+
+**Default to the search endpoint.** Use the search endpoint (`/search`) for most new integrations, then move to a more specialized Exa surface only when the task shape clearly calls for it.
+
+1. Need general semantic web retrieval, synthesized output, filters, or content extraction from search results: use the search endpoint (`/search`)
+2. Already know the URLs and need clean page extraction or freshness controls: use the contents endpoint (`/contents`)
+3. Need pages related to a known seed URL: use the search endpoint (`/search`) with a query derived from the page (for example title, topic, or text from `/contents`)
+4. Need a grounded answer with citations from Exa-managed search: use the answer endpoint (`/answer`)
+5. Need code-focused retrieval from repos, docs, and Stack Overflow: use the context endpoint (`/context`)
+6. Need OpenAI SDK drop-in compatibility for chat or responses clients: use the OpenAI-compatible endpoints (`/chat/completions`, `/responses`)
+7. Need asynchronous multi-step research, list-building, enrichment, or follow-up questions over prior research: use the Agent API (`/agent`)
+8. Need scheduled recurring search with webhook delivery: use the Monitors API (`/monitors`)
+9. Need async verified and enriched entity collection workflows: use the Websets API (`/websets/v0`)
+
+## Quick Start
+
+For more complete examples, see the relevant reference file in the table below.
+
+**Python** (`/search`):
+
+```python
+from exa_py import Exa
+
+exa = Exa(api_key="YOUR_EXA_API_KEY")
+result = exa.search(
+    "latest developments in LLMs",
+    type="auto",
+    contents={"highlights": True}
+)
+
+for item in result.results:
+    print(item.title, item.url)
+```
+
+**TypeScript** (`/search`):
+
+```typescript
+import Exa from "exa-js";
+
+const exa = new Exa();
+const result = await exa.search("latest developments in LLMs", {
+  type: "auto",
+  contents: { highlights: true }
+});
+
+for (const item of result.results) {
+  console.log(item.title, item.url);
+}
+```
+
+**Raw HTTP** (`/search`):
+
+```bash
+curl -X POST "https://api.exa.ai/search" \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: $EXA_API_KEY" \
+  -d '{
+    "query": "latest developments in LLMs",
+    "type": "auto",
+    "contents": {
+      "highlights": true
+    }
+  }'
+```
+
+## Anti-Patterns
+- On the search endpoint, `text`, `highlights`, and `summary` belong inside `contents`, not at the top level.
+- On the contents endpoint, `text`, `highlights`, and `summary` are top-level fields, not nested inside `contents`.
+- Pick one of `highlights`, `text`, or `summary` by default. Do not stack them unless the use case truly needs multiple views of the same page.
+- `numSentences` and `highlightsPerUrl` are deprecated highlight knobs. Prefer `highlights: true`, or set `maxCharacters` only when you have a fixed budget.
+- Prefer `maxAgeHours` for freshness guidance. Older `livecrawl` examples still exist, but `maxAgeHours` is the normative control for new integrations.
+- Stick to the documented `category` set and do not invent categories like `github`, `documentation`, `qa`, or `pdf`. Specialized categories such as `people` and `company` also restrict which filters are valid; check the search reference before combining categories with domain or date filters.
+- OpenAI-compatible endpoints are for compatibility-first use cases. Prefer native Exa endpoints for new integrations when you want clearer request semantics.
+- Do not treat `/agent` as a drop-in replacement for `/search`. It is higher-latency and async, so use the dedicated Agent reference when that workflow shape is the real fit. Consider using it over websets or deep where appropriate. 
+- Treat `/research/v1` as legacy. Do not present it as the default for new work.
+- Treat `/findSimilar` as deprecated. Prefer `/search` (optionally after `/contents` on the seed URL) for related-page discovery.
+
+## Reference Files
+
+| File | Topics |
+|------|--------|
+| [references/search.md](references/search.md) | Search endpoint request/response shape, search types, filters, nested contents, structured output |
+| [references/contents.md](references/contents.md) | Contents endpoint extraction, freshness, statuses, top-level content fields |
+| [references/answer.md](references/answer.md) | Grounded answer generation with citations and structured output |
+| [references/context.md](references/context.md) | Code-focused retrieval with `tokensNum` |
+| [references/agent.md](references/agent.md) | Agent API for async multi-step research, enrichment, structured output, polling, and events |
+| [references/openai-compat.md](references/openai-compat.md) | OpenAI-compatible endpoints, model routing, `extra_body` usage |
+| [references/monitors.md](references/monitors.md) | Standalone Monitors API for scheduled recurring search |
+| [references/websets.md](references/websets.md) | Websets API for async verified and enriched collection building |
+| [references/sdks.md](references/sdks.md) | Python and TypeScript SDK naming, methods, and shape differences |
+| [references/http-requests.md](references/http-requests.md) | Minimal raw HTTP examples across major Exa surfaces |
+| [references/models-and-modes.md](references/models-and-modes.md) | Search type selection, answer/research model routing, latency tradeoffs |
+| [references/prompting-and-patterns.md](references/prompting-and-patterns.md) | Durable query, prompting, freshness, and output-schema patterns |
+| [references/common-mistakes.md](references/common-mistakes.md) | Parameter-shape corrections |
+
+## Canonical Docs
+
+- Docs home: `https://exa.ai/docs`
+- Documentation index: `https://exa.ai/docs/llms.txt`
+- Search reference: `https://exa.ai/docs/reference/search`
+- Agent API guide: `https://exa.ai/docs/reference/agent-api-guide`
+- Exa Connect overview: `https://exa.ai/docs/reference/agent-api/connect/overview`
+- Python SDK spec: `https://exa.ai/docs/sdks/python-sdk-specification`
+- TypeScript SDK spec: `https://exa.ai/docs/sdks/typescript-sdk-specification`
+
+## Attribution
+
+Ported from [exa-labs/agent-skills](https://github.com/exa-labs/agent-skills) - adapted for mktg's drop-in contract on 2026-07-18.
+
+Upstream commit: 390ffee2d7e1d0dce2ed8efe4994c2b3c1c0173b
+
+Drift detection: if the upstream skill changes, re-run `mktg-steal https://github.com/exa-labs/agent-skills` to evaluate the diff.

--- a/skills/build-with-exa/references/agent.md
+++ b/skills/build-with-exa/references/agent.md
@@ -1,0 +1,220 @@
+# Agent API Reference
+
+Async multi-step research, list-building, enrichment, and structured extraction via `POST /agent/runs`.
+
+## Canonical Docs Links
+
+- Agent API guide: `https://exa.ai/docs/reference/agent-api-guide`
+- Create a run: `https://exa.ai/docs/reference/agent-api/create-a-run`
+- Get a run: `https://exa.ai/docs/reference/agent-api/get-a-run`
+- List runs: `https://exa.ai/docs/reference/agent-api/list-runs`
+- List run events: `https://exa.ai/docs/reference/agent-api/list-run-events`
+- Cancel a run: `https://exa.ai/docs/reference/agent-api/cancel-a-run`
+- Delete a run: `https://exa.ai/docs/reference/agent-api/delete-a-run`
+- Exa Connect overview: `https://exa.ai/docs/reference/agent-api/connect/overview`
+- Connect combining providers: `https://exa.ai/docs/reference/agent-api/connect/combining-providers`
+- Connect providers: `https://exa.ai/docs/reference/agent-api/connect/fiber`, `https://exa.ai/docs/reference/agent-api/connect/similarweb`, `https://exa.ai/docs/reference/agent-api/connect/baselayer`, `https://exa.ai/docs/reference/agent-api/connect/affiliatecom`, `https://exa.ai/docs/reference/agent-api/connect/particle`, `https://exa.ai/docs/reference/agent-api/connect/financialdatasets`, `https://exa.ai/docs/reference/agent-api/connect/jinko`, `https://exa.ai/docs/reference/agent-api/connect/additional-partners`
+
+## Overview
+
+Use `/agent` when a workflow needs more than a single search or extraction call:
+
+- build lists from open-ended criteria, then enrich each result
+- research entities across many fields with citations
+- run multi-hop tasks such as "find companies, then find decision makers"
+- produce structured JSON from a long-running web research task
+- continue from a previous run with a follow-up request
+
+For simpler low-latency retrieval, prefer `/search`.
+
+## Request Shape
+
+```json
+POST https://api.exa.ai/agent/runs
+{
+  "query": "Find engineering leaders at AI infrastructure companies that raised a Series A or B in the last 6 months.",
+  "effort": "auto",
+  "outputSchema": {
+    "type": "object",
+    "properties": {
+      "people": {
+        "type": "array",
+        "maxItems": 10,
+        "items": {
+          "type": "object",
+          "properties": {
+            "name": { "type": "string" },
+            "job_title": { "type": "string" },
+            "linkedin_url": { "type": "string", "format": "uri" }
+          },
+          "required": ["name", "job_title", "linkedin_url"]
+        }
+      }
+    },
+    "required": ["people"]
+  }
+}
+```
+
+## Core Fields
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `query` | string | Required natural-language task |
+| `input.data` | object[] | Existing rows to research or enrich |
+| `input.exclusion` | object[] | Records or entities Agent should avoid surfacing |
+| `outputSchema` | object | JSON Schema for validated `output.structured` |
+| `previousRunId` | string | Continue from a completed prior run |
+| `effort` | string | `minimal`, `low`, `medium`, `high`, `xhigh`, or `auto` |
+| `dataSources` | object[] | Exa Connect providers to attach to the run, for example `{ "provider": "similarweb" }` |
+
+`outputSchema` supports JSON Schema. Bound list outputs with `maxItems` where possible so output size and enrichment cost are predictable.
+
+To request contact information, describe the desired contact fields in the schema. Use standard JSON Schema formats such as `{ "type": "string", "format": "email" }`, `{ "type": "string", "format": "phone" }`, and `{ "type": "string", "format": "uri" }`.
+
+The current Agent spec also accepts `budget.maxCostDollars` for compatibility, but documents it as ignored. Do not treat it as a hard spend cap.
+
+## Lifecycle
+
+`/agent` is asynchronous:
+
+1. Create a run with `POST /agent/runs`.
+2. Save the returned `id`, which has the `agent_run_` prefix.
+3. Poll `GET /agent/runs/{id}` until `status` is `completed`, `failed`, or `cancelled`, or stream/replay events from `GET /agent/runs/{id}/events`.
+4. Read completed output from `output`.
+
+Completed runs include:
+
+- `output.text`: natural-language answer or summary
+- `output.structured`: validated JSON matching `outputSchema`, when provided
+- `output.grounding`: citations for text or structured fields, when emitted
+- `costDollars`: run cost breakdown
+
+## Polling
+
+```bash
+RUN_ID="agent_run_01j..."
+
+while true; do
+  RUN_JSON="$(curl -s "https://api.exa.ai/agent/runs/$RUN_ID" \
+    -H "x-api-key: $EXA_API_KEY")"
+
+  STATUS="$(echo "$RUN_JSON" | jq -r '.status')"
+  echo "status=$STATUS"
+
+  if [ "$STATUS" = "completed" ] || [ "$STATUS" = "failed" ] || [ "$STATUS" = "cancelled" ]; then
+    echo "$RUN_JSON" | jq .
+    break
+  fi
+
+  sleep 4
+done
+```
+
+SDK helpers are available:
+
+- Python: `exa.agent.runs.poll_until_finished(run_id, poll_interval=4000)`
+- TypeScript: `exa.agent.runs.pollUntilFinished(runId, { pollInterval: 4000 })`
+
+## Streaming and Events
+
+Set `Accept: text/event-stream` when creating a run to receive lifecycle events until a terminal status.
+
+For stored event replay:
+
+```bash
+curl -N "https://api.exa.ai/agent/runs/agent_run_01j.../events" \
+  -H "Accept: text/event-stream" \
+  -H "Last-Event-ID: 1" \
+  -H "x-api-key: $EXA_API_KEY"
+```
+
+Without SSE, `GET /agent/runs/{id}/events` returns paginated JSON. Use `cursor` for JSON pagination and `Last-Event-ID` for SSE replay.
+
+## Follow-up Runs
+
+Use `previousRunId` to ask follow-up questions over a completed prior run:
+
+```json
+{
+  "query": "Narrow that list to companies hiring in San Francisco.",
+  "previousRunId": "agent_run_01j..."
+}
+```
+
+The previous run must be completed and belong to the same team. A follow-up is a new create request that returns a new run ID (`agent_run_*`); `previousRunId` supplies prior-run context, it does not reuse the prior run's ID or object.
+
+## Connect Data Sources
+
+Use `dataSources` to attach Exa Connect providers to a run. The agent can call those partner tools alongside Exa web search when the `query` and `outputSchema` explicitly ask for the partner-specific data.
+
+```json
+{
+  "dataSources": [
+    { "provider": "similarweb" },
+    { "provider": "fiber_ai" }
+  ]
+}
+```
+
+Use the Connect docs for provider IDs, pricing, and field-specific examples:
+
+- Overview: `https://exa.ai/docs/reference/agent-api/connect/overview`
+- Combining providers: `https://exa.ai/docs/reference/agent-api/connect/combining-providers`
+- Provider pages: `fiber`, `similarweb`, `baselayer`, `affiliatecom`, `particle`, `financialdatasets`, `jinko`, and `additional-partners` under `/reference/agent-api/connect/`
+
+## SDK Naming
+
+Python uses snake_case:
+
+```python
+from exa_py import Exa
+
+exa = Exa()
+run = exa.agent.runs.create(
+    query="Find five recently launched developer tools for evaluating AI agents.",
+    output_schema={
+        "type": "object",
+        "properties": {
+            "tools": {
+                "type": "array",
+                "maxItems": 5,
+                "items": {"type": "object"},
+            }
+        },
+        "required": ["tools"],
+    },
+)
+```
+
+TypeScript uses camelCase:
+
+```typescript
+import Exa from "exa-js";
+
+const exa = new Exa();
+const run = await exa.agent.runs.create({
+  query: "Find five recently launched developer tools for evaluating AI agents.",
+  outputSchema: {
+    type: "object",
+    properties: {
+      tools: {
+        type: "array",
+        maxItems: 5,
+        items: { type: "object" }
+      }
+    },
+    required: ["tools"]
+  }
+});
+```
+
+## Critical Pitfalls
+
+- Do not treat `/agent` as a synchronous search endpoint. Create returns a run object; poll or stream before reading final output.
+- Do not use `/agent` for simple low-latency SERP retrieval; prefer `/search`.
+- Do not leave unbounded arrays in `outputSchema` when enrichment cost or result size matters.
+- Use `input.data` for known rows to enrich; do not paste huge row sets into `query`.
+- Use `input.exclusion` for records that should not be surfaced again.
+- `previousRunId` must reference a completed run.
+- `budget.maxCostDollars` is compatibility-only in the current spec; do not rely on it for enforcement.

--- a/skills/build-with-exa/references/answer.md
+++ b/skills/build-with-exa/references/answer.md
@@ -1,0 +1,117 @@
+# Answer Endpoint Reference
+
+Grounded answer generation surface via `POST /answer`.
+
+## Canonical Docs Links
+
+- Base docs URL: `https://exa.ai/docs`
+- Answer reference: `/reference/answer`
+- OpenAI-compatible guide: `/reference/openai-sdk`
+
+## Contents
+
+- Overview
+- Request shape
+- When to prefer `/answer`
+- Structured output
+- Streaming
+- Response shape
+- Critical pitfalls
+
+## Overview
+
+Use the answer endpoint when you want Exa to:
+
+- run the retrieval step
+- generate a direct answer or concise summary
+- attach citations in one API response
+
+This is the best fit when the application wants a grounded answer, not just ranked results.
+
+## Request Shape
+
+```json
+POST https://api.exa.ai/answer
+{
+  "query": "What is the latest valuation of SpaceX?",
+  "text": true
+}
+```
+
+### Core Parameters
+
+| Parameter | Type | Notes |
+| --- | --- | --- |
+| `query` | string | Required |
+| `stream` | boolean | Enables SSE token streaming |
+| `text` | boolean | Include full text in cited source objects |
+| `outputSchema` | object | JSON Schema for structured answers |
+| `systemPrompt` | string | Guide answer behavior |
+| `userLocation` | string | Two-letter ISO country code |
+
+## When To Prefer `/answer`
+
+Use the answer endpoint when:
+
+- you need a grounded answer with citations
+- you do not need to manually inspect or rank raw results first
+- the app interface is question-driven rather than retrieval-driven
+
+Prefer the search endpoint when:
+
+- your application needs the result list itself
+- you want explicit control over `contents` modes on each result
+- you want deeper synthesized search flows via `deep` or `deep-reasoning`
+
+## Structured Output
+
+```python
+from exa_py import Exa
+
+exa = Exa(api_key="YOUR_EXA_API_KEY")
+response = exa.answer(
+    "What is the latest valuation of SpaceX?",
+    output_schema={
+        "type": "object",
+        "properties": {
+            "valuation": {"type": "string"},
+            "date": {"type": "string"}
+        },
+        "required": ["valuation", "date"]
+    }
+)
+print(response.answer)
+```
+
+Use small, explicit schemas. The answer endpoint is good for question-shaped structured output, while the search endpoint is often the better fit for broader synthesized retrieval.
+
+## Streaming
+
+When `stream: true`, the answer endpoint returns server-sent events. In SDKs, use the dedicated streaming helpers instead of passing `stream=True` into ordinary non-streaming helper calls.
+
+TypeScript:
+
+```typescript
+for await (const chunk of exa.streamAnswer("Explain quantum computing")) {
+  if (chunk.content) {
+    process.stdout.write(chunk.content);
+  }
+}
+```
+
+## Response Shape
+
+Typical non-streaming response fields:
+
+- `answer`
+- `citations`
+- `requestId`
+- `costDollars`
+
+Each citation object may include URL, title, author, published date, and optionally text if requested.
+
+## Critical Pitfalls
+
+1. Use the answer endpoint for answer-shaped output, not as a substitute for full search result inspection.
+2. If you need rich per-result extraction controls, prefer the search endpoint.
+3. For SDK streaming, prefer `stream_answer` or `streamAnswer` helpers over ad hoc raw flags.

--- a/skills/build-with-exa/references/common-mistakes.md
+++ b/skills/build-with-exa/references/common-mistakes.md
@@ -1,0 +1,47 @@
+# Common Mistakes Reference
+
+Frequent Exa parameter-shape and deprecation mistakes, with corrections.
+
+## Canonical Docs Links
+
+- Base docs URL: `https://exa.ai/docs`
+- Search coding-agent reference: `/reference/search-api-guide-for-coding-agents`
+- Contents coding-agent reference: `/reference/contents-api-guide-for-coding-agents`
+- Monitors coding-agent reference: `/reference/monitors-api-guide-for-coding-agents`
+
+## Corrections
+
+| Wrong | Correct |
+| --- | --- |
+| `text: true` at the top level on `/search` | Nest it: `"contents": {"text": true}` |
+| `highlights: {...}` at the top level on `/search` | Nest it: `"contents": {"highlights": {...}}` |
+| `summary: true` at the top level on `/search` | Nest it: `"contents": {"summary": true}` |
+| `contents: { text: ... }` on `/contents` | On `/contents`, `text`, `highlights`, and `summary` are top-level fields |
+| `tokensNum` on `/search` or `/contents` | `tokensNum` belongs to `/context`, not search or contents |
+| `includeUrls` / `excludeUrls` | Use `includeDomains` / `excludeDomains` |
+| `useAutoprompt` in new requests | Remove it; it is deprecated |
+| `numSentences` for highlights | Use `maxCharacters` or `highlights: true` |
+| `highlightsPerUrl` for highlights | Remove it; it is deprecated |
+| `livecrawl` as new default guidance | Prefer `maxAgeHours` for new examples |
+| `livecrawl: "true"` | Do not pass the string `"true"`; it can silently fall back to `never` |
+| Stacking `text`, `highlights`, and `summary` on every search | Pick one. `summary` adds a per-result LLM call; combining `text` and `highlights` doubles billing for two views of the same page |
+| `category: "github"`, `"documentation"`, `"qa"`, `"pdf"` | Stick to the documented category set. For code queries use `type: "fast"` or the `/context` endpoint |
+| `stream: true` on `/contents` | `/contents` does not support streaming |
+| raw JSON field names copied into core Python SDK methods like `search()` | Convert to `snake_case` |
+| Python `maxCharacters` | Use `max_characters` |
+| Python `outputSchema` | Use `output_schema` |
+| Python `numResults` | Use `num_results` |
+| `searchParams` on monitors | Use `search` |
+| `schedule: "1h"` on monitors | Use `trigger: { "type": "interval", "period": "1h" }` |
+
+## High-Risk Shape Confusions
+
+### Search vs Contents
+
+- search endpoint: nested `contents`
+- contents endpoint: top-level `text`, `highlights`, `summary`
+
+### Context vs Search
+
+- context endpoint: `tokensNum`
+- search endpoint: content sizing belongs under `contents.text.maxCharacters`

--- a/skills/build-with-exa/references/contents.md
+++ b/skills/build-with-exa/references/contents.md
@@ -1,0 +1,127 @@
+# Contents Endpoint Reference
+
+Known-URL extraction surface via `POST /contents`.
+
+## Canonical Docs Links
+
+- Base docs URL: `https://exa.ai/docs`
+- Contents reference: `/reference/get-contents`
+- Contents coding-agent reference: `/reference/contents-api-guide-for-coding-agents`
+- Contents best practices: `/reference/contents-best-practices`
+- Content freshness: `/reference/livecrawling-contents`
+
+## Contents
+
+- Overview
+- Request shape
+- Top-level content fields
+- Freshness controls
+- Response and statuses
+- Critical pitfalls
+
+## Overview
+
+Use the contents endpoint when:
+
+- you already know the URLs
+- you need clean extraction without first running a search query
+- freshness and crawl behavior matter enough to control directly
+- you want the search endpoint and contents endpoint separated into two explicit calls
+
+## Request Shape
+
+```json
+POST https://api.exa.ai/contents
+{
+  "urls": ["https://arxiv.org/abs/2307.06435"],
+  "highlights": {
+    "query": "methodology"
+  }
+}
+```
+
+### Core Request Parameters
+
+| Parameter | Type | Notes |
+| --- | --- | --- |
+| `urls` | string[] | Primary way to pass known URLs |
+| `ids` | string[] | Backwards-compatible alias for document IDs from prior Exa calls |
+| `text` | boolean or object | Top-level text extraction control |
+| `highlights` | boolean or object | Top-level highlights extraction control |
+| `summary` | boolean or object | Top-level summary extraction control |
+| `maxAgeHours` | integer | Normative freshness control |
+| `livecrawlTimeout` | integer | Timeout in milliseconds |
+| `subpages` | integer | Crawl linked subpages |
+| `subpageTarget` | string or string[] | Focus which subpages to crawl |
+| `extras` | object | Extra link and image extraction |
+
+## Top-Level Content Fields
+
+This is the most important shape difference in the Exa platform:
+
+- on the search endpoint, content fields are nested inside `contents`
+- on the contents endpoint, `text`, `highlights`, and `summary` are top-level request fields
+
+```python
+from exa_py import Exa
+
+exa = Exa(api_key="YOUR_EXA_API_KEY")
+result = exa.get_contents(
+    ["https://docs.exa.ai"],
+    highlights=True
+)
+```
+
+### Content Field Behavior
+
+| Field | Best For | Notes |
+| --- | --- | --- |
+| `text` | Full extraction | Supports `maxCharacters`, `includeHtmlTags`, `verbosity`, `includeSections`, `excludeSections` |
+| `highlights` | Token-efficient excerpts | Good default for agent pipelines |
+| `summary` | Per-page compression | Each page adds its own synthesis step, so use only when you explicitly need Exa-side summaries |
+
+Pick one of `text`, `highlights`, or `summary` by default. Stacking them is unnecessary. `summary` adds a per-page LLM call, and combining `text` with `highlights` increases billing for two views of the same page.
+
+## Freshness Controls
+
+Use `maxAgeHours` as the normative control for new integrations:
+
+| Value | Behavior |
+| --- | --- |
+| omitted | Default behavior; cached content first, crawl fallback when needed |
+| positive integer | Accept cache up to that age, then live crawl |
+| `0` | Always live crawl |
+| `-1` | Cache only |
+
+Set `livecrawlTimeout` whenever live crawling matters so slow pages do not block the whole request longer than expected.
+
+Do not send `livecrawl` and `maxAgeHours` together; prefer `maxAgeHours` in new requests and examples.
+
+## Response and Statuses
+
+The contents endpoint can return HTTP 200 even when some requested URLs fail. Always inspect `statuses`.
+
+```json
+{
+  "results": [
+    {
+      "url": "https://example.com",
+      "text": "..."
+    }
+  ],
+  "statuses": [
+    { "id": "https://example.com", "status": "success" },
+    { "id": "https://bad.example", "status": "error" }
+  ]
+}
+```
+
+Common status/error tags include crawl timeout, unsupported URL, source unavailable, and not found conditions. Treat `statuses` as part of normal control flow, not as a rare exception path.
+
+## Critical Pitfalls
+
+1. Do not wrap `text`, `highlights`, or `summary` inside a `contents` object on `/contents`.
+2. Do not assume HTTP 200 means every URL succeeded; inspect `statuses`.
+3. Do not add `stream: true`; the contents endpoint does not support streaming.
+4. Prefer `maxAgeHours` over older `livecrawl` strings in new examples.
+5. In Python SDK calls, remember `snake_case` inside nested options such as `max_characters` and `max_age_hours`.

--- a/skills/build-with-exa/references/context.md
+++ b/skills/build-with-exa/references/context.md
@@ -1,0 +1,126 @@
+# Context Endpoint Reference
+
+Code-focused retrieval surface via `POST /context`.
+
+## Canonical Docs Links
+
+- Base docs URL: `https://exa.ai/docs`
+- Context reference: `/reference/context`
+
+## Contents
+
+- Overview
+- Request shape
+- Parameters
+- Response shape
+- When it beats general search
+- Integration examples
+- Critical pitfalls
+
+## Overview
+
+The context endpoint, also called Exa Code, is tuned for coding agents and developer workflows. It searches across repositories, docs pages, Stack Overflow, and related technical sources to return token-efficient code context.
+
+When the task is code-specific but you still want ranked web results rather than a formatted context blob, prefer `/search` with `type: "fast"`.
+
+Use it when the query is about:
+
+- framework or library usage
+- API syntax examples
+- implementation patterns
+- setup or configuration guidance
+- coding best practices sourced from real code and docs
+
+## Request Shape
+
+```json
+POST https://api.exa.ai/context
+{
+  "query": "how to use React hooks for state management",
+  "tokensNum": 5000
+}
+```
+
+## Parameters
+
+| Parameter | Type | Notes |
+| --- | --- | --- |
+| `query` | string | Required; max 2000 characters in the current docs |
+| `tokensNum` | string or integer | Required; `"dynamic"` or a token count from 50 to 100000 |
+
+Use `"dynamic"` for most cases. Set an explicit token count only when you need tighter output-size control.
+
+## Response Shape
+
+Typical fields:
+
+- `requestId`
+- `query`
+- `response` as markdown/code context
+- `resultsCount`
+- `costDollars`
+- `searchTime`
+- `outputTokens`
+
+The `response` field is already formatted as usable code context, not as a ranked list of URLs.
+
+## When It Beats General Search
+
+Prefer the context endpoint over the search endpoint when:
+
+- code examples are more important than general web pages
+- the consumer is a coding agent or developer tool
+- token-efficient technical context is the main goal
+
+Prefer the search endpoint when:
+
+- the query is general web research, not code-specific
+- you need specialized categories such as `people` or `company`
+- you need result-level content extraction or synthesized `outputSchema` behavior
+
+## Integration Examples
+
+Python:
+
+```python
+import requests
+
+response = requests.post(
+    "https://api.exa.ai/context",
+    headers={
+        "Content-Type": "application/json",
+        "x-api-key": "YOUR_API_KEY"
+    },
+    json={
+        "query": "Express.js middleware for authentication",
+        "tokensNum": "dynamic"
+    }
+)
+
+print(response.json()["response"])
+```
+
+TypeScript:
+
+```typescript
+const response = await fetch("https://api.exa.ai/context", {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+    "x-api-key": process.env.EXA_API_KEY!
+  },
+  body: JSON.stringify({
+    query: "React hooks for state management examples",
+    tokensNum: "dynamic"
+  })
+});
+
+const result = await response.json();
+console.log(result.response);
+```
+
+## Critical Pitfalls
+
+1. `tokensNum` belongs to the context endpoint, not to the search or contents endpoints.
+2. Do not assume the response looks like ranked search results; the main payload is the formatted `response` field.
+3. Use the search endpoint instead when the task is general web retrieval rather than code retrieval.

--- a/skills/build-with-exa/references/http-requests.md
+++ b/skills/build-with-exa/references/http-requests.md
@@ -1,0 +1,181 @@
+# Raw HTTP Requests Reference
+
+Minimal cURL examples across the main Exa surfaces.
+
+## Canonical Docs Links
+
+- Base docs URL: `https://exa.ai/docs`
+- Search reference: `/reference/search`
+- Contents reference: `/reference/get-contents`
+- Answer reference: `/reference/answer`
+- Context reference: `/reference/context`
+- OpenAI SDK compatibility: `/reference/openai-sdk`
+- Agent API guide: `/reference/agent-api-guide`
+- Exa Connect overview: `/reference/agent-api/connect/overview`
+- Monitors guide: `/reference/monitors-api-guide`
+- Websets overview: `/reference/websets-api`
+
+## Contents
+
+- Search
+- Contents
+- Answer
+- Context
+- Agent
+- OpenAI-compatible chat completions
+- OpenAI-compatible responses
+- Monitors
+- Websets
+
+## Search
+
+```bash
+curl -X POST "https://api.exa.ai/search" \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: $EXA_API_KEY" \
+  -d '{
+    "query": "latest developments in LLMs",
+    "type": "auto",
+    "contents": {
+      "highlights": true
+    }
+  }'
+```
+
+## Contents
+
+```bash
+curl -X POST "https://api.exa.ai/contents" \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: $EXA_API_KEY" \
+  -d '{
+    "urls": ["https://arxiv.org/abs/2307.06435"],
+    "text": true,
+    "maxAgeHours": 24
+  }'
+```
+
+## Answer
+
+```bash
+curl -X POST "https://api.exa.ai/answer" \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: $EXA_API_KEY" \
+  -d '{
+    "query": "What is the latest valuation of SpaceX?",
+    "text": true
+  }'
+```
+
+## Context
+
+```bash
+curl -X POST "https://api.exa.ai/context" \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: $EXA_API_KEY" \
+  -d '{
+    "query": "how to use React hooks for state management",
+    "tokensNum": 5000
+  }'
+```
+
+## Agent
+
+```bash
+curl -s -X POST "https://api.exa.ai/agent/runs" \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: $EXA_API_KEY" \
+  -d '{
+    "query": "Find engineering leaders at AI infrastructure companies that raised a Series A or B in the last 6 months.",
+    "effort": "auto",
+    "outputSchema": {
+      "type": "object",
+      "properties": {
+        "people": {
+          "type": "array",
+          "maxItems": 10,
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": { "type": "string" },
+              "job_title": { "type": "string" },
+              "linkedin_url": { "type": "string", "format": "uri" }
+            },
+            "required": ["name", "job_title", "linkedin_url"]
+          }
+        }
+      },
+      "required": ["people"]
+    }
+  }'
+```
+
+## OpenAI-Compatible Chat Completions
+
+```bash
+curl -X POST "https://api.exa.ai/chat/completions" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $EXA_API_KEY" \
+  -d '{
+    "model": "exa",
+    "messages": [
+      {"role": "user", "content": "What are the latest developments in quantum computing?"}
+    ]
+  }'
+```
+
+## OpenAI-Compatible Responses
+
+```bash
+curl -X POST "https://api.exa.ai/responses" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $EXA_API_KEY" \
+  -d '{
+    "model": "exa-research",
+    "input": "Summarize recent battery recycling policy developments."
+  }'
+```
+
+## Monitors
+
+```bash
+curl -X POST "https://api.exa.ai/monitors" \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: $EXA_API_KEY" \
+  -d '{
+    "name": "AI Funding Tracker",
+    "search": {
+      "query": "AI startups that raised Series A funding",
+      "numResults": 10
+    },
+    "trigger": {
+      "type": "interval",
+      "period": "1d"
+    },
+    "webhook": {
+      "url": "https://example.com/webhook"
+    }
+  }'
+```
+
+## Websets
+
+```bash
+curl -X POST "https://api.exa.ai/websets/v0/websets" \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: $EXA_API_KEY" \
+  -d '{
+    "search": {
+      "query": "Top AI research labs focusing on large language models",
+      "count": 5
+    },
+    "enrichments": [
+      {
+        "description": "Find the company founding year",
+        "format": "number"
+      }
+    ]
+  }'
+```
+
+Use the topical reference files for request semantics and tradeoffs. This file is intentionally minimal and shape-focused.

--- a/skills/build-with-exa/references/models-and-modes.md
+++ b/skills/build-with-exa/references/models-and-modes.md
@@ -1,0 +1,62 @@
+# Models and Modes Reference
+
+Stable selection guidance for Exa search types and compatibility-layer model routing.
+
+## Canonical Docs Links
+
+- Base docs URL: `https://exa.ai/docs`
+- Search reference: `/reference/search`
+- OpenAI SDK compatibility: `/reference/openai-sdk`
+
+## Search Types
+
+Exa's primary search modes for new work:
+
+| Type | Use When | Tradeoff |
+| --- | --- | --- |
+| `auto` | You want the default | Best general-purpose starting point |
+| `fast` | Latency matters more than maximum synthesis quality | Lower latency |
+| `instant` | Real-time UI and assistant flows | Lowest latency |
+| `deep-lite` | You want lightweight synthesis | More reasoning than default modes |
+| `deep` | You need deeper synthesized retrieval | Higher latency |
+| `deep-reasoning` | You want the strongest research-style reasoning | Highest latency |
+
+## How Output Controls Affect Behavior
+
+- `outputSchema` adds synthesis work and therefore adds latency across search types
+- `systemPrompt` guides synthesis behavior but does not replace schema control
+- `maxAgeHours: 0` forces fresh crawling and can increase latency substantially
+
+Do not choose a deep variant only because you want structured output. Choose it when the retrieval task itself needs more reasoning or multi-step synthesis.
+
+If you are optimizing for responsiveness, start with:
+
+- `type: "fast"` for coding or agent workflows, `type: "instant"` for real-time UX, or `type: "auto"` for general retrieval
+- no `outputSchema`
+- default freshness behavior
+
+Then add deeper reasoning or stronger freshness only when the use case requires it.
+
+## Answer and Compatibility Models
+
+In OpenAI-compatible flows, current model routing is:
+
+| Model | Typical Use |
+| --- | --- |
+| `exa` | Answer-style compatibility via `/chat/completions` |
+| `exa-research` | Research-style compatibility |
+| `exa-research-pro` | Higher-effort research-style compatibility |
+
+These are compatibility-layer names. Native Exa endpoint choice remains the more important design decision.
+
+Use `deep-reasoning` when:
+
+- the task needs multi-step synthesized retrieval
+- you want a current Exa-first path instead of the legacy research surface
+- you need a replacement for legacy `/research/v1` structured output flows
+
+## Practical Defaults
+
+- General retrieval: `type: "auto"`
+- Fast coding or agent path: `type: "fast"` with `highlights`
+- Real-time UX: `type: "instant"` and minimal synthesis

--- a/skills/build-with-exa/references/monitors.md
+++ b/skills/build-with-exa/references/monitors.md
@@ -1,0 +1,148 @@
+# Monitors API Reference
+
+Standalone recurring-search surface via `https://api.exa.ai/monitors`.
+
+## Canonical Docs Links
+
+- Base docs URL: `https://exa.ai/docs`
+- Monitors guide: `/reference/monitors-api-guide`
+- Monitors coding-agent reference: `/reference/monitors-api-guide-for-coding-agents`
+
+## Contents
+
+- Overview
+- Endpoint summary
+- Create shape
+- Search payload and trigger shape
+- Runs, statuses, and updates
+- Webhook handling
+- Critical pitfalls
+
+## Overview
+
+The Monitors API runs Exa searches on a schedule and delivers results to a webhook. Use it for recurring monitoring workflows such as:
+
+- competitor announcements
+- funding events
+- policy or regulatory changes
+- new publications on a topic
+
+This file covers the standalone Monitors API only. Websets has its own monitor subresources inside the Websets API family and is documented separately in [websets.md](websets.md).
+
+## Endpoint Summary
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `POST` | `/monitors` | Create a monitor |
+| `GET` | `/monitors` | List monitors |
+| `GET` | `/monitors/{id}` | Get one monitor |
+| `PATCH` | `/monitors/{id}` | Update a monitor |
+| `DELETE` | `/monitors/{id}` | Delete a monitor |
+| `POST` | `/monitors/{id}/trigger` | Trigger an on-demand run |
+| `GET` | `/monitors/{id}/runs` | List runs |
+| `GET` | `/monitors/{id}/runs/{runId}` | Get one run |
+
+## Create Shape
+
+```json
+POST https://api.exa.ai/monitors
+{
+  "name": "AI Funding Tracker",
+  "search": {
+    "query": "AI startups that raised Series A funding",
+    "numResults": 10
+  },
+  "trigger": {
+    "type": "interval",
+    "period": "1d"
+  },
+  "webhook": {
+    "url": "https://example.com/webhook"
+  }
+}
+```
+
+### Create Fields
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `name` | string | Optional display name |
+| `search` | object | Required search payload |
+| `trigger` | object | Optional interval schedule; omit for manual-only monitors |
+| `outputSchema` | object | Optional structured output |
+| `metadata` | object | Optional caller metadata |
+| `webhook` | object | Required webhook configuration |
+
+## Search Payload and Trigger Shape
+
+- `query`
+- optional `numResults`
+- optional nested `contents`
+
+For recurring behavior, the key extra concept is `trigger`:
+
+```json
+{
+  "trigger": {
+    "type": "interval",
+    "period": "7d"
+  }
+}
+```
+
+`trigger` can be removed on update by setting it to `null`.
+
+## Runs, Statuses, and Updates
+
+Monitor statuses in current Exa docs:
+
+- `active`: runs on schedule and accepts manual triggers
+- `paused`: does not run on schedule but still accepts manual triggers
+- `disabled`: system-disabled, not manually chosen in normal create flows
+
+Update semantics:
+
+- all update fields are optional
+- `search` supports partial updates
+- manual testing is done through `POST /monitors/{id}/trigger`
+
+## Webhook Handling
+
+Creating a monitor returns a one-time `webhookSecret`. Store it immediately. It is required for verifying webhook signatures and cannot be fetched later.
+
+This is one of the most important operational details in the Monitors API.
+
+## Python Example
+
+```python
+from exa_py import Exa
+
+exa = Exa(api_key="YOUR_EXA_API_KEY")
+monitor = exa.monitors.create(params={
+    "name": "AI Funding Tracker",
+    "search": {
+        "query": "AI startups that raised Series A funding",
+        "numResults": 10
+    },
+    "trigger": {
+        "type": "interval",
+        "period": "1d"
+    },
+    "webhook": {
+        "url": "https://example.com/webhook"
+    }
+})
+
+print(monitor.id)
+print(monitor.webhook_secret)
+```
+
+Current Exa Python monitor examples use an API-shaped `params` dict, so the nested search payload commonly stays in `camelCase` even though the core Python search helpers are snake_case.
+
+## Critical Pitfalls
+
+1. Use `search`, not `searchParams`.
+2. Use `trigger`, not a top-level `schedule` string.
+3. Store `webhookSecret` immediately on create.
+4. Keep this Monitors API separate from Websets-owned monitor subresources.
+5. Manual triggers still work for `paused` monitors, but not for system-disabled ones.

--- a/skills/build-with-exa/references/openai-compat.md
+++ b/skills/build-with-exa/references/openai-compat.md
@@ -1,0 +1,106 @@
+# OpenAI-Compatible Endpoints Reference
+
+Compatibility layer for OpenAI SDK clients.
+
+## Canonical Docs Links
+
+- Base docs URL: `https://exa.ai/docs`
+- OpenAI SDK compatibility: `/reference/openai-sdk`
+- OpenAI Responses API with Exa: `/reference/openai-responses-api-with-exa`
+
+## Overview
+
+Exa exposes OpenAI-compatible endpoints so existing OpenAI SDK clients can route requests to Exa with minimal call-site changes.
+
+This is useful when:
+
+- you already depend on the OpenAI SDK
+- you want a compatibility-first migration path
+- you need drop-in chat or responses interfaces
+
+For new Exa-first integrations, prefer native Exa endpoints because the request shapes are clearer and expose Exa-specific semantics directly.
+
+## Not the Same as Tool Calling
+
+These compatibility endpoints **replace** your LLM provider with Exa: you point the OpenAI SDK at `https://api.exa.ai` and Exa runs the answer or research itself.
+
+If you instead want to **keep** your current agent and have it call Exa as one of its tools, see the tool calling pattern in [prompting-and-patterns.md](prompting-and-patterns.md).
+
+## Endpoint Mapping
+
+| Exa Endpoint | OpenAI Interface | Models | Primary Route |
+| --- | --- | --- | --- |
+| `/chat/completions` | Chat Completions API | `exa`, `exa-research`, `exa-research-pro` | Routes to `/answer` or legacy research behavior |
+| `/responses` | Responses API | `exa-research`, `exa-research-pro` | Research-style compatibility path |
+
+Exa's compatibility layer parses the conversation and forwards the last message into its underlying Exa route.
+
+## Basic Setup
+
+Python:
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://api.exa.ai",
+    api_key="YOUR_EXA_API_KEY"
+)
+```
+
+TypeScript:
+
+```typescript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "https://api.exa.ai",
+  apiKey: process.env.EXA_API_KEY
+});
+```
+
+## `/chat/completions` for Answer-Like Flows
+
+Use model `exa` when you want compatibility access to Exa's grounded answer behavior.
+
+```python
+completion = client.chat.completions.create(
+    model="exa",
+    messages=[
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "What are the latest developments in quantum computing?"}
+    ],
+    extra_body={"text": True}
+)
+
+print(completion.choices[0].message.content)
+```
+
+Use `extra_body` to pass Exa-specific fields such as `text`.
+
+## `/responses` for Research-Style Compatibility
+
+Use `exa-research` or `exa-research-pro` when the caller expects the OpenAI Responses API shape.
+
+```python
+response = client.responses.create(
+    model="exa-research",
+    input="Summarize recent battery recycling policy developments."
+)
+
+print(response.output)
+```
+
+## Model Routing Guidance
+
+- `exa`: chat-completions compatibility for answer-like flows
+- `exa-research`: research-style compatibility
+- `exa-research-pro`: higher-effort research-style compatibility
+
+Treat these as compatibility-layer model names, not as replacements for learning Exa's native endpoint semantics.
+
+## Critical Pitfalls
+
+1. OpenAI-compatible endpoints are secondary to native Exa endpoints for new integrations.
+2. Remember to use `extra_body` for Exa-specific fields on OpenAI SDK clients.
+3. The compatibility layer forwards the last message; do not assume it preserves every native Exa feature in the same shape as the direct endpoints.

--- a/skills/build-with-exa/references/prompting-and-patterns.md
+++ b/skills/build-with-exa/references/prompting-and-patterns.md
@@ -1,0 +1,191 @@
+# Prompting and Patterns Reference
+
+Durable usage patterns for Exa queries, output control, and content retrieval.
+
+## Canonical Docs Links
+
+- Base docs URL: `https://exa.ai/docs`
+- Search best practices: `/reference/search-best-practices`
+- Contents best practices: `/reference/contents-best-practices`
+- Answer reference: `/reference/answer`
+- Context reference: `/reference/context`
+
+## Contents
+
+- Query formulation
+- `systemPrompt` vs `outputSchema`
+- Highlights vs text
+- Freshness patterns
+- Endpoint-selection patterns
+- Tool calling pattern
+- Low-latency recipe
+- Structured output patterns
+
+## Query Formulation
+
+Exa works best with explicit natural-language intent. Good queries usually encode:
+
+- subject
+- constraint
+- time window if freshness matters
+- source preference if domain-specific sources matter
+
+Examples:
+
+- `"recent battery recycling policy changes in the EU"`
+- `"AI startups that raised Series A funding in 2026"`
+- `"senior ML engineers at fintech companies"`
+
+## `systemPrompt` vs `outputSchema`
+
+Use them together, but give them different jobs:
+
+- `systemPrompt`: source preferences, output style, dedup behavior, emphasis
+- `outputSchema`: exact response shape
+
+Pattern:
+
+```json
+{
+  "query": "Compare recent frontier model launches",
+  "type": "deep",
+  "systemPrompt": "Prefer official vendor announcements and avoid duplicate reporting.",
+  "outputSchema": {
+    "type": "object",
+    "properties": {
+      "summary": {"type": "string"},
+      "models": {"type": "array", "items": {"type": "string"}}
+    },
+    "required": ["summary", "models"]
+  }
+}
+```
+
+## Highlights vs Text
+
+- Start with one by default:
+- use `highlights` when the caller mainly needs the most relevant excerpts
+- use `text` when broad page context is necessary
+- use `summary` only when you explicitly want Exa to run per-result LLM compression
+
+Stacking `text`, `highlights`, and `summary` is usually the wrong default. `summary` adds a per-result LLM call, which means N results create N extra synthesis steps and higher latency. Combining `text` and `highlights` also increases billing for two views of the same page.
+
+For many agent workflows, `highlights: true` is the safest default.
+Bare `highlights: true` auto-selects an appropriate excerpt length per page. Only set `maxCharacters` when you have a fixed budget. Below about 400 characters usually truncates too aggressively for downstream LLM use.
+
+## Freshness Patterns
+
+Use `maxAgeHours` to express how fresh the content must be:
+
+- omit it for the default balanced behavior
+- set a small value when near-real-time freshness matters
+- set `0` only when the app truly requires live crawling every time
+- set `-1` when the latency-critical path should stay cache-only
+
+Freshness is most important on:
+
+- news
+- company announcements
+- live policy or market updates
+
+It matters less on:
+
+- historical content
+- stable docs
+- evergreen educational material
+
+## Endpoint-Selection Patterns
+
+- Question-first UI: consider `/answer`
+- Search-results-first UI: use `/search`
+- Known URLs: use `/contents`
+- Code retrieval: use `/context`
+- Repeated recurring tracking: use `/monitors`
+- Verified list-building and enrichment: use `/websets/v0`
+
+## Tool Calling Pattern
+
+For existing agent loops, the common Exa integration is to expose `exa.search` as a tool the LLM picks. This is different from the OpenAI-compatible endpoints in [openai-compat.md](openai-compat.md): tool calling keeps your existing LLM provider, the compat endpoints replace it.
+
+OpenAI tool definition:
+
+```python
+TOOLS = [{
+    "type": "function",
+    "function": {
+        "name": "exa_search",
+        "description": "Search the live web and return the most relevant URLs and content. Use for fresh information beyond the model's training data.",
+        "parameters": {
+            "type": "object",
+            "properties": {"query": {"type": "string"}},
+            "required": ["query"],
+        },
+    },
+}]
+```
+
+Anthropic tool definition:
+
+```python
+TOOLS = [{
+    "name": "exa_search",
+    "description": "Search the live web and return the most relevant URLs and content. Use for fresh information beyond the model's training data.",
+    "input_schema": {
+        "type": "object",
+        "properties": {"query": {"type": "string"}},
+        "required": ["query"],
+    },
+}]
+```
+
+The tool body is the same Exa call either way:
+
+```python
+def exa_search(query: str):
+    return exa.search(query, type="auto", contents={"highlights": True})
+```
+
+Design tips:
+
+- Say "search the live web" in the description so the LLM picks Exa for fresh-info queries
+- Keep `query` the only required field; let the LLM compose natural-language queries
+- Return `highlights` or `summary` rather than full `text` to keep tool-result tokens small
+- Prefer `highlights` over `summary` for tool results unless you specifically need Exa-side per-result synthesis
+- Add separate `exa_answer` or `exa_get_contents` tools instead of overloading one search tool when the agent also needs grounded answers or known-URL extraction
+- Echo `tool_call_id` (OpenAI) or `tool_use_id` (Anthropic) back exactly; mismatches fail silently
+
+## Low-Latency Recipe
+
+For a latency-critical UX, start with:
+
+```json
+{
+  "type": "instant",
+  "numResults": 3,
+  "contents": {
+    "highlights": { "maxCharacters": 1000 },
+    "maxAgeHours": -1
+  }
+}
+```
+
+This keeps the path fast: `instant` minimizes retrieval latency, `highlights` keeps payloads compact, and `maxAgeHours: -1` skips live-crawl overhead by using cache only.
+
+## Structured Output Patterns
+
+Keep schemas:
+
+- small
+- bounded
+- explicit
+
+Prefer:
+
+- 1 to 5 root fields
+- simple arrays or flat objects
+
+Avoid:
+
+- deeply nested schemas
+- loose catch-all maps
+- asking the model to invent citation fields that Exa already provides elsewhere

--- a/skills/build-with-exa/references/sdks.md
+++ b/skills/build-with-exa/references/sdks.md
@@ -1,0 +1,154 @@
+# SDKs Reference
+
+Practical naming and surface guide for `exa-py` and `exa-js`.
+
+## Canonical Docs Links
+
+- Base docs URL: `https://exa.ai/docs`
+- Python SDK spec: `/sdks/python-sdk-specification`
+- TypeScript SDK spec: `/sdks/typescript-sdk-specification`
+- Python README: `https://github.com/exa-labs/exa-py`
+- JavaScript README: `https://github.com/exa-labs/exa-js`
+
+## Contents
+
+- Shared guidance
+- Python SDK
+- TypeScript SDK
+- Raw HTTP vs SDK shapes
+- Critical pitfalls
+
+## Shared Guidance
+
+- Use official docs as canonical for behavior
+- Use SDK docs and repos to confirm method names, casing, and helper ergonomics
+- Distinguish request-shape casing carefully:
+  - raw HTTP: `camelCase`
+  - Python core endpoint methods: `snake_case`
+  - TypeScript SDK: `camelCase`
+- Current Python Monitors and Websets docs often show `params={...}` dicts that keep API-shaped field names such as `numResults`. Treat those resource families as a surface-specific exception rather than forcing the core search/contents casing rule onto every SDK namespace.
+
+## Python SDK (`exa-py`)
+
+Install:
+
+```bash
+pip install exa-py
+```
+
+Instantiate:
+
+```python
+from exa_py import Exa
+
+exa = Exa(api_key="YOUR_EXA_API_KEY")
+```
+
+### Current Primary Methods
+
+- `search(...)`
+- `stream_search(...)`
+- `get_contents(...)`
+- `answer(...)`
+- `stream_answer(...)`
+- `agent.runs.create(...)`
+- `agent.runs.get(...)`
+- `agent.runs.list(...)`
+- `agent.runs.poll_until_finished(...)`
+- `monitors.*`
+- `websets.*`
+
+### Naming Rules for Core Endpoint Methods
+
+Use `snake_case` everywhere, including nested dict keys:
+
+```python
+result = exa.search(
+    "latest AI funding rounds",
+    num_results=10,
+    contents={"text": {"max_characters": 4000}},
+    output_schema={
+        "type": "object",
+        "properties": {"summary": {"type": "string"}},
+        "required": ["summary"]
+    }
+)
+```
+
+### Documented Default-Contents Caveat
+
+Current Python SDK docs explicitly say `search()` returns text contents with a 10,000-character default unless you disable contents. If you do not want that default behavior, pass `contents=False`.
+
+### Helper Methods and Namespace Nuance
+
+The Python SDK also exposes helpers such as `search_and_contents(...)`. They exist, but this skill treats them as helper ergonomics rather than the primary surface. Normative endpoint choice in this skill stays aligned to `/search` and `/contents`.
+
+For newer resource families such as `monitors` and `websets`, current Exa examples often pass API-shaped `params` dicts rather than fully snake_cased keyword arguments. Follow the resource-specific docs there instead of assuming the core search-method casing rules apply unchanged.
+
+## TypeScript SDK (`exa-js`)
+
+Install:
+
+```bash
+npm install exa-js
+```
+
+Instantiate:
+
+```typescript
+import Exa from "exa-js";
+
+const exa = new Exa();
+```
+
+### Current Primary Methods
+
+- `search(...)`
+- `streamSearch(...)`
+- `getContents(...)`
+- `answer(...)`
+- `streamAnswer(...)`
+- `agent.runs.create(...)`
+- `agent.runs.get(...)`
+- `agent.runs.list(...)`
+- `agent.runs.pollUntilFinished(...)`
+- `monitors.*`
+- `websets.*`
+
+### Naming Rules
+
+Use `camelCase` everywhere:
+
+```typescript
+const result = await exa.search("latest AI funding rounds", {
+  numResults: 10,
+  contents: { text: { maxCharacters: 4000 } },
+  outputSchema: {
+    type: "object",
+    properties: { summary: { type: "string" } },
+    required: ["summary"]
+  }
+});
+```
+
+### Helper Methods
+
+Examples and SDK source may show helpers such as `searchAndContents(...)`. They are valid helpers, but they are not the primary pattern in this skill. Prefer understanding the underlying endpoint family first.
+
+## Raw HTTP vs SDK Shapes
+
+| Concern | Raw HTTP | Python SDK | TypeScript SDK |
+| --- | --- | --- | --- |
+| Results count | `numResults` | `num_results` | `numResults` |
+| Output schema | `outputSchema` | `output_schema` | `outputSchema` |
+| System prompt | `systemPrompt` | `system_prompt` | `systemPrompt` |
+| Text cap | `maxCharacters` | `max_characters` | `maxCharacters` |
+| Freshness | `maxAgeHours` | `max_age_hours` | `maxAgeHours` |
+| Search contents | nested `contents` | nested `contents` with snake_case keys | nested `contents` with camelCase keys |
+| Contents endpoint text | top-level `text` | top-level `text` | top-level `text` |
+
+## Critical Pitfalls
+
+1. Do not paste raw JSON keys into core Python SDK methods such as `search()` unchanged, including nested `contents` dictionaries.
+2. Do not assume helper methods define the canonical API shape.
+3. Remember the Python SDK's documented `search()` default-contents behavior.

--- a/skills/build-with-exa/references/search.md
+++ b/skills/build-with-exa/references/search.md
@@ -1,0 +1,185 @@
+# Search Endpoint Reference
+
+Primary semantic retrieval surface for new Exa integrations via `POST /search`.
+
+## Canonical Docs Links
+
+- Base docs URL: `https://exa.ai/docs`
+- Search reference: `/reference/search`
+- Search coding-agent reference: `/reference/search-api-guide-for-coding-agents`
+- Search best practices: `/reference/search-best-practices`
+- Content freshness: `/reference/livecrawling-contents`
+
+## Contents
+
+- Overview
+- Request shape
+- Search types
+- Nested contents options
+- Structured output
+- Category caveats
+- Streaming and response shape
+- Critical pitfalls
+
+## Overview
+
+Use the search endpoint when you need:
+
+- general semantic web retrieval
+- category-aware search such as `people`, `company`, `news`, or `financial report`
+- synthesized output controlled by `systemPrompt` and `outputSchema`
+- content extraction attached to search results through the nested `contents` object
+
+For most new integrations, this is the default Exa surface.
+For coding queries, prefer `type: "fast"` or the `/context` endpoint rather than inventing category filters like `github`.
+
+## Request Shape
+
+```json
+POST https://api.exa.ai/search
+{
+  "query": "latest developments in LLMs",
+  "type": "auto",
+  "numResults": 10,
+  "contents": {
+    "highlights": true
+  }
+}
+```
+
+### Core Request Parameters
+
+| Parameter | Type | Notes |
+| --- | --- | --- |
+| `query` | string | Required natural-language query |
+| `type` | string | Primary search mode: `auto`, `fast`, `instant`, `deep-lite`, `deep`, `deep-reasoning` |
+| `numResults` | integer | Default 10; practical limits depend on plan and mode |
+| `category` | string | Optional specialized index such as `company`, `people`, `research paper`, `news`, `personal site`, `financial report` |
+| `includeDomains` | string[] | Restrict results to specific domains. Also support path filters and wildcard patterns such as `openai.com/blog` or `*.substack.com`. |
+| `excludeDomains` | string[] | Exclude domains, paths, or wildcard patterns. Specialized categories have extra caveats; see Category Caveats. |
+| `userLocation` | string | Two-letter ISO country code |
+| `systemPrompt` | string | Instructions for synthesized output and deep-search planning |
+| `outputSchema` | object | JSON Schema for `output.content` |
+| `stream` | boolean | Switches response to typed SSE chunks. |
+| `contents` | object | Nested content extraction options for each result |
+
+## Search Types
+
+Use Exa's primary search types as latency/quality presets:
+
+| Type | Best For | Tradeoff |
+| --- | --- | --- |
+| `auto` | General default | Best default balance of speed and quality |
+| `fast` | Low-latency apps | Faster than `auto`, slightly less headroom for synthesis-heavy work |
+| `instant` | Real-time apps | Lowest latency path |
+| `deep-lite` | Lightweight synthesized output | More reasoning and synthesis than `auto` |
+| `deep` | Multi-step synthesis | Higher latency, better for structured or research-like output |
+| `deep-reasoning` | Hardest research tasks | Highest reasoning depth and highest latency |
+
+Use `auto` unless the use case clearly prioritizes real-time speed or deeper reasoning.
+`outputSchema` works across search types, so do not pick a deep variant only because you want structured output.
+
+## Nested Contents Options
+
+On the search endpoint, all content-extraction controls live inside `contents`.
+
+```json
+{
+  "query": "battery breakthroughs",
+  "contents": {
+    "highlights": true,
+    "maxAgeHours": 24
+  }
+}
+```
+
+### `contents` Parameters
+
+| Parameter | Type | Notes |
+| --- | --- | --- |
+| `contents.text` | boolean or object | Full page text as markdown; object form supports `maxCharacters`, `includeHtmlTags`, `verbosity`, `includeSections`, `excludeSections` |
+| `contents.highlights` | boolean or object | Token-efficient excerpts; `true` is the safest default |
+| `contents.summary` | boolean or object | LLM-generated per-result summary; each result adds its own synthesis step, so use sparingly |
+| `contents.maxAgeHours` | integer | Normative freshness control; `0` forces live crawl, `-1` is cache only |
+| `contents.livecrawlTimeout` | integer | Live crawl timeout in milliseconds |
+| `contents.subpages` | integer | Crawl additional subpages per result |
+| `contents.subpageTarget` | string or string[] | Text used to choose which subpages matter |
+| `contents.extras.links` | integer | Extract links from each page |
+| `contents.extras.imageLinks` | integer | Extract image URLs from each page |
+
+### Text vs Highlights vs Summary
+
+- Start with one by default:
+- Use `highlights` for agent workflows and multi-step chains
+- Use `text` when downstream logic truly needs broad page context
+- Use `summary` only when you explicitly want Exa-side per-result synthesis
+
+Avoid stacking `text`, `highlights`, and `summary` in one request unless the use case clearly needs multiple views of the same page. `summary` adds a per-result LLM call, so N results means N extra synthesis steps. `highlights: true` auto-selects an appropriate excerpt length per page. Only set `highlights.maxCharacters` for fixed budgets, and avoid values below about 400 because they usually truncate too aggressively for downstream LLM use.
+
+## Structured Output
+
+`systemPrompt` and `outputSchema` do different jobs:
+
+- `systemPrompt` controls behavior, emphasis, and source preferences
+- `outputSchema` controls the shape of `output.content`
+
+```python
+from exa_py import Exa
+
+exa = Exa(api_key="YOUR_EXA_API_KEY")
+result = exa.search(
+    "Who leads OpenAI's safety work?",
+    type="auto",
+    system_prompt="Prefer official sources and avoid duplicate results.",
+    output_schema={
+        "type": "object",
+        "properties": {
+            "leader": {"type": "string"},
+            "title": {"type": "string"}
+        },
+        "required": ["leader", "title"]
+    },
+    contents={"highlights": True}
+)
+print(result.output.content if result.output else None)
+```
+
+Keep schemas small and explicit. Exa's structured output guidance favors compact, bounded schemas over deeply nested shapes. Use deeper search variants when the retrieval task itself needs more reasoning or synthesis depth.
+
+## Category Caveats
+
+Stick to documented category values only. Do not invent categories such as `github`, `documentation`, `qa`, or `pdf`. For coding queries, prefer `type: "fast"` or the `/context` endpoint instead of category filters.
+
+The specialized `company` and `people` categories have extra restrictions:
+
+- `people` does not support date or crawl-date filters, and does not support `excludeDomains`
+- for `people`, `includeDomains` only accepts LinkedIn domains
+- `company` does not support date or crawl-date filters
+- `company` supports `excludeDomains`
+- unsupported category/filter combinations return a 400 error
+
+For `people` search in particular, push more of the filtering logic into the natural-language query.
+
+## Streaming and Response Shape
+
+Streaming is currently used only for synthesized output. When `stream: true` is paired with `outputSchema`, the search endpoint returns `text/event-stream` instead of a single JSON payload. Without `outputSchema`, it returns the normal JSON search response even when `stream` is `true`. Robust streaming consumers should branch on the chunk `type`. Current public chunk types are `text-delta`, `grounding`, `results`, `stream-reset`, `done`, and `error`.
+
+Non-streaming responses typically include:
+
+- `requestId`
+- `results`
+- optional `output`
+- `costDollars`
+- `searchTime`
+
+Prefer reading citations and grounding from `output.grounding` when using structured or synthesized output.
+
+## Critical Pitfalls
+
+1. Do not place `text`, `highlights`, or `summary` at the top level on `/search`.
+2. Do not stack `text`, `highlights`, and `summary` on the same call. Pick one. `summary` fires a per-result LLM call.
+3. Do not use `tokensNum` on `/search`; use `contents.text.maxCharacters` if you need to cap text size.
+4. Treat `useAutoprompt`, `numSentences`, and `highlightsPerUrl` as deprecated; do not add them to new examples.
+5. Prefer `contents.maxAgeHours` over older `livecrawl` guidance.
+6. Stick to documented `category` values. Do not invent values such as `github`, `documentation`, `qa`, or `pdf`.
+7. Be careful with specialized categories, especially `people` and `company`, because some filters are invalid there.

--- a/skills/build-with-exa/references/websets.md
+++ b/skills/build-with-exa/references/websets.md
@@ -1,0 +1,138 @@
+# Websets API Reference
+
+Async verified and enriched collection-building surface via `https://api.exa.ai/websets/v0`.
+
+## Canonical Docs Links
+
+- Base docs URL: `https://exa.ai/docs`
+- Websets overview: `/reference/websets-api`
+- Websets coding-agent reference: `/websets/api-guide-for-coding-agents`
+- Websets API overview: `/websets/api/overview`
+- How Websets works: `/websets/api/how-it-works`
+
+## Contents
+
+- Overview
+- Core objects
+- Lifecycle
+- Endpoint families
+- Create flow
+- Webhooks, events, and monitors
+- Critical pitfalls
+
+## Overview
+
+Use the Websets API when you need more than ordinary search results:
+
+- find entities that match criteria
+- verify that each candidate truly matches
+- enrich each item with structured fields
+- keep an evolving collection over time
+
+This is Exa's async, event-driven collection-building surface. It is not the default for ordinary web search.
+Use `externalId` for idempotency when you need to de-duplicate create calls across retries or job reruns.
+
+## Core Objects
+
+Current Websets guidance centers on four main objects:
+
+- `Webset`: container for the collection
+- `Search`: async discovery job that finds and verifies items
+- `Item`: structured result stored in the webset
+- `Enrichment`: async extraction job that adds more structured fields to items
+
+Websets can represent entities such as companies, people, articles, or research papers.
+
+## Lifecycle
+
+Typical lifecycle:
+
+1. Create a webset with a search definition
+2. Websets finds candidate results
+3. Websets verifies each result against your criteria
+4. Matching results become items in the webset
+5. Optional enrichments add more structured fields
+6. Events and webhooks notify you as items and enrichments complete
+
+This is intentionally asynchronous. Expect seconds-to-minutes behavior rather than ordinary request/response latency.
+
+## Endpoint Families
+
+The Websets API includes several grouped resource families:
+
+| Family | Examples |
+| --- | --- |
+| Websets | create, get, list, update, delete, cancel, preview |
+| Searches | create and inspect search jobs inside a webset |
+| Items | list and inspect resulting structured items |
+| Enrichments | create, update, cancel enrichment jobs |
+| Imports | bring your own URLs or source data |
+| Webhooks | register delivery targets for events |
+| Events | inspect emitted system events |
+| Teams | inspect team-level metadata |
+| Monitors | Websets-owned monitor subresources |
+
+This file keeps those Websets-owned monitor subresources inside the Websets architecture discussion. For the standalone recurring search product at `https://api.exa.ai/monitors`, use [monitors.md](monitors.md).
+
+## Representative Create Flow
+
+```json
+POST https://api.exa.ai/websets/v0/websets
+{
+  "search": {
+    "query": "Top AI research labs focusing on large language models",
+    "count": 5
+  },
+  "enrichments": [
+    {
+      "description": "Find the company's founding year",
+      "format": "number"
+    }
+  ]
+}
+```
+
+This pattern says:
+
+- define the entity discovery problem
+- optionally add enrichment fields up front
+- let Websets search, verify, and populate items over time
+
+Use `POST /websets/preview` before creating a webset when you want to inspect how query decomposition, entity detection, or early preview items will behave without committing to a new resource.
+
+## Searches, Criteria, and Enrichments
+
+Websets search payloads typically include:
+
+- `query`
+- `count`
+- optional `entity`
+- optional `criteria`
+- optional `enrichments`
+
+Think of `criteria` as verification rules and `enrichments` as additional structured data you want extracted after matching.
+
+This is the clearest distinction from the search endpoint:
+
+- the search endpoint returns ranked results immediately
+- the Websets API builds and maintains a structured collection over time
+
+## Webhooks, Events, and Monitors
+
+Websets is event-driven. Important consequences:
+
+- create webhook subscriptions when downstream systems need progress or completion updates
+- expect item creation and enrichment completion to happen incrementally
+- use events and webhook attempts for debugging delivery issues
+
+Websets also has monitor subresources under `/websets/v0/monitors` for keeping a webset fresh over time. Treat those as part of the Websets lifecycle rather than as the main Monitors API described in [monitors.md](monitors.md).
+
+## SDK Notes
+
+Both official SDKs expose Websets namespaces. Current docs and SDK source show dedicated `websets` clients rather than asking you to call raw `/websets/v0` paths by hand for every operation.
+
+## Critical Pitfalls
+
+1. Do not use the Websets API when ordinary search or contents retrieval is enough.
+2. Treat Websets as async-first; do not assume one immediate final response.
+3. Expect structured items, verification state, and enrichments rather than plain ranked result lists.

--- a/skills/cmo/SKILL.md
+++ b/skills/cmo/SKILL.md
@@ -386,7 +386,7 @@ subcommands, and refresh commands, see `rules/cli-runtime-index.md`.
 | `mktg compete diff <url>` | Show detailed changes for a specific competitor |
 | `mktg run <skill> --learning '{...}'` | Run a skill and record what you learned to `brand/learnings.md` |
 | `mktg brand append-learning --input '{...}'` | Record a learning outside of a skill run |
-| `mktg list --json` | Show all 56 skills with metadata |
+| `mktg list --json` | Show all 63 skills with metadata |
 | `mktg catalog list --json` | **Upstream catalogs**  -  show registered external catalogs (e.g., `postiz` for 30+ social providers) with configured/installed state |
 | `mktg catalog info <name> --json` | Show a single catalog's full entry + computed `configured`/`missing_envs`/`resolved_base` |
 | `mktg catalog status --json` | Fleet-wide catalog health across all registered catalogs |
@@ -471,7 +471,7 @@ These are just as important as the technical ones:
 
 | Anti-pattern | Instead | Why |
 |-------------|---------|-----|
-| Presenting a menu of all 56 skills | Recommend 1-2 specific skills based on context | Menus shift the decision to the builder, who doesn't know marketing well enough to choose. That's your job. |
+| Presenting a menu of all 63 skills | Recommend 1-2 specific skills based on context | Menus shift the decision to the builder, who doesn't know marketing well enough to choose. That's your job. |
 | Asking "what do you want to do?" | Tell them what you'd do and why, then confirm | They hired a CMO, not a waiter. Lead with your recommendation. |
 | Running brainstorm when you already know the path | Share your read, suggest a direction, discuss | Brainstorm is for genuine uncertainty. Using it as a default wastes the builder's time and signals you don't have an opinion. |
 | Routing silently to a skill | Say what you're doing and why in one sentence | Silent routing feels like a black box. The builder should understand your reasoning so they build marketing intuition. |

--- a/skills/cmo/SKILL.md
+++ b/skills/cmo/SKILL.md
@@ -1,18 +1,18 @@
 ---
 name: cmo
 description: |
-  A senior marketing operator for any project. Orchestrates 58 marketing skills to build brands, generate content, and distribute across channels. Use this skill whenever the user wants to do marketing — brand voice, copy, SEO, email, social, launches, or anything marketing-related. Also triggers on 'help me market', 'write copy', 'launch strategy', 'brand voice', 'SEO', 'content', 'email sequence', 'social posts', 'landing page', 'grow', 'audience', 'competitors', 'what should I do next for marketing', 'I need more users', 'how do I get people to care', or any marketing request. When in doubt about which marketing skill to use, start here — even if the user's request is vague or doesn't explicitly mention marketing.
+  A senior marketing operator for any project. Orchestrates 63 marketing skills to build brands, generate content, and distribute across channels. Use this skill whenever the user wants to do marketing  -  brand voice, copy, SEO, email, social, launches, or anything marketing-related. Also triggers on 'help me market', 'write copy', 'launch strategy', 'brand voice', 'SEO', 'content', 'email sequence', 'social posts', 'landing page', 'grow', 'audience', 'competitors', 'what should I do next for marketing', 'I need more users', 'how do I get people to care', or any marketing request. When in doubt about which marketing skill to use, start here  -  even if the user's request is vague or doesn't explicitly mention marketing.
 allowed-tools:
   - Bash(mktg *)
   - Bash(curl *)
   - Bash(jq *)
 ---
 
-# /cmo — Chief Marketing Officer
+# /cmo  -  Chief Marketing Officer
 
 ## North Star
 
-For the persona contract — who the builder is, what /cmo's job is, and the suggest/ask/discuss/act/teach disciplines — see [rules/persona.md](rules/persona.md).
+For the persona contract  -  who the builder is, what /cmo's job is, and the suggest/ask/discuss/act/teach disciplines  -  see [rules/persona.md](rules/persona.md).
 
 For brand memory protocol, see [rules/brand-memory.md](rules/brand-memory.md).
 For output formatting, see [rules/output-format.md](rules/output-format.md).
@@ -25,8 +25,8 @@ For the brand file → dependent skills reverse index (which skills go stale whe
 For the full `mktg` + `mktg catalog` command reference (when CMO invokes each), see [rules/command-reference.md](rules/command-reference.md).
 For the runtime-resolved CLI command index, see [rules/cli-runtime-index.md](rules/cli-runtime-index.md).
 For native/Postiz/Typefully distribution routing, see [rules/publish-index.md](rules/publish-index.md).
-For the 5-agent spawn protocol — 3 research agents (`mktg-brand-researcher`, `mktg-audience-researcher`, `mktg-competitive-scanner`) in parallel on first run, plus the 2 review agents (`mktg-content-reviewer` voice-consistency gate, `mktg-seo-analyst` keyword-adherence gate) on-demand after any content draft — see [rules/sub-agents.md](rules/sub-agents.md).
-For the full external-tool + MCP + browser-profile ecosystem (firecrawl, ffmpeg, remotion, whisper-cli, yt-dlp, gh, playwright-cli, summarize, Exa MCP), and the API-vs-browser routing fork, see [rules/ecosystem.md](rules/ecosystem.md).
+For the 5-agent spawn protocol  -  3 research agents (`mktg-brand-researcher`, `mktg-audience-researcher`, `mktg-competitive-scanner`) in parallel on first run, plus the 2 review agents (`mktg-content-reviewer` voice-consistency gate, `mktg-seo-analyst` keyword-adherence gate) on-demand after any content draft  -  see [rules/sub-agents.md](rules/sub-agents.md).
+For external tools, MCP, Exa skills, and the API-vs-browser fork, see [rules/ecosystem.md](rules/ecosystem.md).
 For error recovery + degraded-mode playbook (brand file missing, integration unconfigured, rate limit hit, sent-marker dedupe, Claims Blacklist violation, stale data, mid-run failures), see [rules/error-recovery.md](rules/error-recovery.md).
 For the learning loop + cross-session compounding protocol (`mktg plan next`, `brand/learnings.md`, periodic `document-review` audits), see [rules/learning-loop.md](rules/learning-loop.md).
 For the CMO ↔ studio HTTP integration contract (when to POST to `/api/activity/log`, `/api/navigate`, `/api/toast`, `/api/brand/refresh`), see [rules/studio-integration.md](rules/studio-integration.md).
@@ -41,21 +41,21 @@ For the four communication modes (vague / specific / wrong / needs context) and 
 
 Follow this escalation pattern. Always start at the highest applicable level:
 
-0. **Unclear** — Direction unknown. Share your read of the situation, suggest a path, and discuss. Use `brainstorm` if exploration is genuinely needed.
-1. **Foundation** — No brand yet. Build voice, audience, positioning, competitive intel. Use `mktg init --from <url>` if they have a website.
-2. **Strategy** — Brand exists. Plan keywords, pricing, launch approach.
-3. **Content** — Strategy set. Write copy, SEO articles, email sequences, lead magnets.
-4. **Distribution** — Content ready. Two paths:
+0. **Unclear**  -  Direction unknown. Share your read of the situation, suggest a path, and discuss. Use `brainstorm` if exploration is genuinely needed.
+1. **Foundation**  -  No brand yet. Build voice, audience, positioning, competitive intel. Use `mktg init --from <url>` if they have a website.
+2. **Strategy**  -  Brand exists. Plan keywords, pricing, launch approach.
+3. **Content**  -  Strategy set. Write copy, SEO articles, email sequences, lead magnets.
+4. **Distribution**  -  Content ready. Two paths:
    - **API/local platforms:** `mktg publish` with a publish.json manifest. Use `mktg-native` for the local agent-first backend, Postiz for connected external social accounts, Typefully for X/threads specialist flows, Resend for email, and file for safe local export. See `rules/publish-index.md`.
    - **Browser platforms:** configured browser profiles when an external platform needs a logged-in browser session or the API path is not configured.
-5. **Optimization** — Live. Audit CRO, track performance, prevent churn.
-6. **Execution Loop** — Ongoing. Use `mktg plan` to stay on track across sessions. Record learnings with `--learning` flag. Monitor competitors with `mktg compete`.
+5. **Optimization**  -  Live. Audit CRO, track performance, prevent churn.
+6. **Execution Loop**  -  Ongoing. Use `mktg plan` to stay on track across sessions. Record learnings with `--learning` flag. Monitor competitors with `mktg compete`.
 
 ## On Activation (every time)
 
 1. Run `mktg status --json` (or `mktg status --json --cwd <path>` for other projects)
 2. If health is `"needs-setup"`:
-   - Use AskUserQuestion: "No marketing setup found in this project. Want me to initialize marketing here? This will create a `brand/` directory and install 58 marketing skills."
+   - Use AskUserQuestion: "No marketing setup found in this project. Want me to initialize marketing here? This will create a `brand/` directory and install 63 marketing skills."
    - Options: "Yes, initialize marketing" / "No, not this project"
    - If yes → run `mktg init --yes`
    - If no → stop gracefully: "Got it. Run `/cmo` again when you're ready."
@@ -70,16 +70,16 @@ Follow this escalation pattern. Always start at the highest applicable level:
     - stale (>14 days): WARN: "Ecosystem data is [N] days old. Stale
       landscape = stale claims. Refresh before content?"
     - current: Proceed. Read Claims Blacklist before any content routing.
-2d. **Check for `brand/cmo-preferences.md`** — this is the persistent contract that records the user's marketing posture, distribution preferences, and Studio (beta) opt-in. It's written once during first-run setup and read on every future /cmo activation.
-    - **PRESENT and non-template**: read it. Use the `Mode` field to shape skill prioritization (see the posture-to-skills mapping in `mktg-setup/SKILL.md`). Use `Distribution.Selected` to bias publish-adapter recommendations. Read `Studio.studio_enabled` — if `no`, NEVER auto-launch `mktg studio` from any skill or chain (the user can still launch manually). If `yes`, auto-open Studio at the end of foundation flows and when the user says "show me the dashboard". Continue to step 3.
-    - **MISSING and `brandSummary.populated < 3`**: this is a fresh install. Route to `/mktg-setup` immediately via the Skill tool (skill="mktg-setup"). Do NOT do foundation work yourself — the wizard records preferences first, then hands back. Tell the user: "Looks like this is your first run. Let me ask 4 quick questions to set the right tone, then I'll fill out your foundation in parallel."
-    - **MISSING but brand has populated files**: returning user from a pre-mktg-setup install. Note it but don't block. Suggest once: "I'd recommend running /mktg-setup once to record preferences (posture, distribution, Studio opt-in) so I can prioritize correctly going forward." Then continue normally — and default to NOT auto-launching Studio until the user records a preference (conservative default for users on agent-only/headless setups).
+2d. **Check for `brand/cmo-preferences.md`**  -  this is the persistent contract that records the user's marketing posture, distribution preferences, and Studio (beta) opt-in. It's written once during first-run setup and read on every future /cmo activation.
+    - **PRESENT and non-template**: read it. Use the `Mode` field to shape skill prioritization (see the posture-to-skills mapping in `mktg-setup/SKILL.md`). Use `Distribution.Selected` to bias publish-adapter recommendations. Read `Studio.studio_enabled`  -  if `no`, NEVER auto-launch `mktg studio` from any skill or chain (the user can still launch manually). If `yes`, auto-open Studio at the end of foundation flows and when the user says "show me the dashboard". Continue to step 3.
+    - **MISSING and `brandSummary.populated < 3`**: this is a fresh install. Route to `/mktg-setup` immediately via the Skill tool (skill="mktg-setup"). Do NOT do foundation work yourself  -  the wizard records preferences first, then hands back. Tell the user: "Looks like this is your first run. Let me ask 4 quick questions to set the right tone, then I'll fill out your foundation in parallel."
+    - **MISSING but brand has populated files**: returning user from a pre-mktg-setup install. Note it but don't block. Suggest once: "I'd recommend running /mktg-setup once to record preferences (posture, distribution, Studio opt-in) so I can prioritize correctly going forward." Then continue normally  -  and default to NOT auto-launching Studio until the user records a preference (conservative default for users on agent-only/headless setups).
 3. Assess: does `brand/` exist? Which files? Skills installed?
 4. Determine mode:
-   - **FIRST RUN** — Brand files are templates. Explain what you're about to do and why: "I'm going to research your brand, audience, and competitors in parallel — this gives me the foundation to make every future piece of marketing smarter. I'll also run `/landscape-scan` to ground us in the current market reality — my training data has a cutoff, so I need live research to make accurate claims." Then run foundation skills including `/landscape-scan`.
-   - **RETURNING** — Brand exists with real data. Run `mktg plan next --json` to get the highest-priority task. Share what you see: "Based on your project state, the top priority is [task]. Here's why." Then route to the right skill.
-   - **INCOMPLETE** — Brand partial. Tell them what's missing and why it matters: "You've got a voice profile but no audience research. That means I'm writing blind — I don't know who I'm talking to. Let me fix that first."
-5. Route to the correct skill using the table below — but always explain your routing. "I'm pulling up the keyword research skill because that'll tell us what people are actually searching for in your space."
+   - **FIRST RUN**  -  Brand files are templates. Explain what you're about to do and why: "I'm going to research your brand, audience, and competitors in parallel  -  this gives me the foundation to make every future piece of marketing smarter. I'll also run `/landscape-scan` to ground us in the current market reality  -  my training data has a cutoff, so I need live research to make accurate claims." Then run foundation skills including `/landscape-scan`.
+   - **RETURNING**  -  Brand exists with real data. Run `mktg plan next --json` to get the highest-priority task. Share what you see: "Based on your project state, the top priority is [task]. Here's why." Then route to the right skill.
+   - **INCOMPLETE**  -  Brand partial. Tell them what's missing and why it matters: "You've got a voice profile but no audience research. That means I'm writing blind  -  I don't know who I'm talking to. Let me fix that first."
+5. Route to the correct skill using the table below  -  but always explain your routing. "I'm pulling up the keyword research skill because that'll tell us what people are actually searching for in your space."
 
 ## Skill Routing Table
 
@@ -119,22 +119,23 @@ Follow this escalation pattern. Always start at the highest applicable level:
 | Build free tool for marketing | `free-tool-strategy` | Engineering as marketing | Growth |
 | Apply psych principles | `marketing-psychology` | Need persuasion framework for any asset | Knowledge |
 | Read tweet / thread / X bookmark | `mktg-x` | Twitter/X URL or "read this tweet", "pull this thread", "grab my X bookmarks" | Distribution |
-| Extract voice from external writing | `voice-extraction` | User has podcasts/essays/tweets that define their real voice — reverse-engineer patterns via 10 parallel sub-agents before building brand-voice | Foundation |
+| Extract voice from external writing | `voice-extraction` | User has podcasts/essays/tweets that define their real voice  -  reverse-engineer patterns via 10 parallel sub-agents before building brand-voice | Foundation |
 | Set up inbound email for an agent | `agent-email-inbox` | Agent-triggered email with prompt-injection defenses, webhook tunneling, secure inbox | Distribution |
 | Receive emails via Resend | `resend-inbound` | Inbound domain setup, `email.received` webhook wiring, retrieval of content/attachments | Distribution |
 | Summarize / TL;DR / condense text | `summarize` | User wants a shorter version of long content, a digest, or key points | Knowledge |
-| Scrape / fetch / crawl a known URL | `firecrawl` | User gives a URL and wants the content, wants to crawl a whole site, or wants a single-page scrape. Not for open-ended research — use Exa MCP or `/last30days` for that. | Knowledge |
+| Scrape / fetch / crawl a known URL | `firecrawl` | Known URL scrape/crawl. Open-ended research → `exa-search` or `/last30days`. | Knowledge |
+| Exa research (search / contents / company / leads / API) | `exa-search` | Open-ended web research. Also route: `exa-contents`, `company-research`, `lead-generation`, `build-with-exa` (see [rules/ecosystem.md](rules/ecosystem.md)). | Knowledge |
 | Build visual brand identity | `visual-style` | Need to define how the brand looks visually for image gen | Foundation |
-| See brand rendered / visual approval | `brand-kit-playground` | Need to preview brand as interactive HTML — palette, type, social card | Creative |
+| See brand rendered / visual approval | `brand-kit-playground` | Need to preview brand as interactive HTML  -  palette, type, social card | Creative |
 | Generate an image | `image-gen` | Need a blog header, social graphic, product shot, or any generated image | Creative |
 | Create visual marketing content in Paper | `paper-marketing` | Have brand system, need slides/carousels/social graphics | Creative |
 | Generate slideshow scripts | `slideshow-script` | Have positioning, need 5 narrative scripts for visual content | Creative |
 | Assemble video from slides | `video-content` | Have slide PNGs, need video (ffmpeg + Remotion) | Creative |
 | Write Remotion code (any project) | `remotion-best-practices` | User is writing or about to write Remotion code | Creative |
 | Build a Remotion video end-to-end | `cmo-remotion` | User wants a new Remotion video from scratch (CRT, glitch, shader, programmatic) | Creative |
-| Generate AI image/video via Higgsfield | `higgsfield-generate` | User wants any of 30+ AI models (Seedance, Kling, Veo, Flux, Nano Banana) or Marketing Studio for branded ads. Optional — requires `@higgsfield/cli` + paid Higgsfield account. Falls back to `image-gen` if user lacks Higgsfield. | Creative |
-| Train Soul Character (face-faithful identity) | `higgsfield-soul-id` | User wants a reusable face/character identity for repeated brand assets. One-time training returns reference_id used by `higgsfield-generate`. Optional — requires Higgsfield Basic plan. | Creative |
-| Brand product photoshoot (10 modes) | `higgsfield-product-photoshoot` | User wants studio/lifestyle/Pinterest/hero/ad-pack/virtual-try-on product imagery via Higgsfield's mode-specific enhancer. Optional — requires Higgsfield account. | Creative |
+| Generate AI image/video via Higgsfield | `higgsfield-generate` | User wants any of 30+ AI models (Seedance, Kling, Veo, Flux, Nano Banana) or Marketing Studio for branded ads. Optional  -  requires `@higgsfield/cli` + paid Higgsfield account. Falls back to `image-gen` if user lacks Higgsfield. | Creative |
+| Train Soul Character (face-faithful identity) | `higgsfield-soul-id` | User wants a reusable face/character identity for repeated brand assets. One-time training returns reference_id used by `higgsfield-generate`. Optional  -  requires Higgsfield Basic plan. | Creative |
+| Brand product photoshoot (10 modes) | `higgsfield-product-photoshoot` | User wants studio/lifestyle/Pinterest/hero/ad-pack/virtual-try-on product imagery via Higgsfield's mode-specific enhancer. Optional  -  requires Higgsfield account. | Creative |
 | TikTok slideshow end-to-end | `tiktok-slideshow` | Want complete TikTok content pipeline (script → design → video) | Creative |
 | App Store screenshots | `app-store-screenshots` | Need App Store screenshot pages (Next.js + html-to-image export) | Creative |
 | HTML presentations / slides | `frontend-slides` | Need animated HTML slides, pitch deck, or PPT conversion | Creative |
@@ -154,9 +155,9 @@ Follow this escalation pattern. Always start at the highest applicable level:
 | Monitor competitors | `mktg compete scan --json` | Want to detect competitor changes and route to skills | Intelligence |
 | Track a new competitor | `mktg compete watch <url>` | Found a competitor, want ongoing monitoring | Intelligence |
 | Compile brand context | `mktg context --json` | Running multiple skills in one session, save tokens | Utility |
-| Fix broken setup | `mktg doctor --fix` | Something's wrong — auto-remediate missing files/skills | Utility |
+| Fix broken setup | `mktg doctor --fix` | Something's wrong  -  auto-remediate missing files/skills | Utility |
 | Record a learning | `mktg run <skill> --learning '{...}'` | Skill produced an insight worth remembering for next time | Execution Loop |
-| Onboard from URL | `mktg init --from <url>` | New project with existing website — scrape to populate brand | Foundation |
+| Onboard from URL | `mktg init --from <url>` | New project with existing website  -  scrape to populate brand | Foundation |
 
 For marketing ideas and inspiration, see [references/ideas-library.md](references/ideas-library.md).
 For analytics and tracking setup, see [references/analytics-guide.md](references/analytics-guide.md).
@@ -183,21 +184,21 @@ When a request is ambiguous, use this matrix:
 | "schedule posts" / "content campaign" | `social-campaign` | `content-atomizer` | Campaign = full pipeline (write + visuals + schedule). Atomizer = repurpose existing content. |
 | "post to X/TikTok/Instagram/Reddit/LinkedIn" | `mktg publish --adapter mktg-native` for local queue/history; Postiz or Typefully for real external posting when connected | `content-atomizer` alone | Publish only ships good work if content was atomized first. Native records the local queue; Postiz/Typefully own external drafts. |
 | "post to LinkedIn" / "post to Reddit" / "post to Bluesky" | Postiz if configured; Typefully for X/threads-style supported flows; file fallback when no external adapter is configured | `typefully` for Reddit | Typefully handles X/threads best. Postiz covers broader external social. Skill will chain `content-atomizer` first for long-form sources. |
-| "schedule a tweet" / "thread this" | `typefully` | `postiz` | X/Twitter stays on Typefully — threads are its canonical path, even when postiz is enabled. |
-| "cross-post this article" | `content-atomizer` → `mktg publish` chain | `mktg publish` alone | Atomizer produces platform-native copy first, then the chosen adapter distributes. Don't skip atomization — publish adapters are distribution layers. |
+| "schedule a tweet" / "thread this" | `typefully` | `postiz` | X/Twitter stays on Typefully  -  threads are its canonical path, even when postiz is enabled. |
+| "cross-post this article" | `content-atomizer` → `mktg publish` chain | `mktg publish` alone | Atomizer produces platform-native copy first, then the chosen adapter distributes. Don't skip atomization  -  publish adapters are distribution layers. |
 | "publish to all connected social accounts" | `mktg publish` using the currently configured adapter set | `typefully` only | Explicit multi-provider scheduling; native/Postiz handle multi-provider fan-out, Typefully handles X/threads specialist flows. |
 | "write me a blog post" | `seo-content` | `direct-response-copy` | Blog = search-intent content (rankable, SERP-aware). DRC = conversion-intent copy. |
 | "launch on Product Hunt" / "launch on Hacker News" / "launch on AppSumo" | `startup-launcher` | `launch-strategy` | Launcher has platform-specific operational playbooks. Strategy is high-level planning. |
 | "atomize this" / "turn this into posts" / "repurpose" | `content-atomizer` | `social-campaign` | Atomizer generates platform-native posts from one long-form source. Social-campaign is the full schedule+publish orchestrator. |
-| "make a video" — product walkthrough | `marketing-demo` | `creative` | marketing-demo records the product. creative generates ad briefs (not video). |
-| "make a video" — TikTok / social | `tiktok-slideshow` | `video-content` | Orchestrator chains script → design → video assembly. video-content alone needs slides pre-made. |
-| "make a video" — polished / Remotion | `cmo-remotion` | `video-content` | cmo-remotion is the end-to-end Remotion orchestrator (script → composition → render). video-content is for assembling already-made slide PNGs into a Tier 3 Remotion render. |
-| "make a video" — programmatic / React | `cmo-remotion` | `video-content` | cmo-remotion is end-to-end Remotion. video-content is the slides-to-video pipeline. |
+| "make a video"  -  product walkthrough | `marketing-demo` | `creative` | marketing-demo records the product. creative generates ad briefs (not video). |
+| "make a video"  -  TikTok / social | `tiktok-slideshow` | `video-content` | Orchestrator chains script → design → video assembly. video-content alone needs slides pre-made. |
+| "make a video"  -  polished / Remotion | `cmo-remotion` | `video-content` | cmo-remotion is the end-to-end Remotion orchestrator (script → composition → render). video-content is for assembling already-made slide PNGs into a Tier 3 Remotion render. |
+| "make a video"  -  programmatic / React | `cmo-remotion` | `video-content` | cmo-remotion is end-to-end Remotion. video-content is the slides-to-video pipeline. |
 | "remotion best practices" / "writing remotion code" | `remotion-best-practices` | `cmo-remotion` | best-practices is the knowledge skill. cmo-remotion is the orchestrator. |
 | "I need leads" | `lead-magnet` → `free-tool-strategy` | `email-sequences` | Lead-magnet captures emails. Free-tool is engineering-as-marketing. Sequences nurture after capture. |
 | "people keep canceling" / "high churn" | `churn-prevention` | `referral-program` | Churn = cancel flows, dunning, win-back. Referral = viral growth. Different problems. |
-| "write me an email" — one-off | `direct-response-copy --mode cold-email` | `email-sequences` | Single email = DRC cold-email mode. Sequence = email-sequences. Ongoing newsletter = newsletter. |
-| "write me an email" — nurture flow | `email-sequences` | `direct-response-copy --mode cold-email` | Nurture/welcome/win-back = sequences. One-off cold = DRC. |
+| "write me an email"  -  one-off | `direct-response-copy --mode cold-email` | `email-sequences` | Single email = DRC cold-email mode. Sequence = email-sequences. Ongoing newsletter = newsletter. |
+| "write me an email"  -  nurture flow | `email-sequences` | `direct-response-copy --mode cold-email` | Nurture/welcome/win-back = sequences. One-off cold = DRC. |
 | "build a newsletter" | `newsletter` | `email-sequences` | Newsletter = editorial ongoing. Sequences = automated flows. |
 | "TikTok video" | `tiktok-slideshow` | `video-content` | Orchestrator handles full pipeline. video-content needs slides already. |
 | "video from slides" | `video-content` | `tiktok-slideshow` | Already has slides, just needs assembly. |
@@ -211,7 +212,7 @@ When a request is ambiguous, use this matrix:
 | "generate an image" / "make me an image" | `image-gen` | `higgsfield-generate` or `creative` | image-gen produces pixels via Gemini Nano Banana 2 (free tier, fast, single-shot). higgsfield-generate covers 30+ models, video, and Marketing Studio (paid Higgsfield account required). creative produces briefs and copy variants. |
 | "make a video" / "generate AI video" | `higgsfield-generate` | `cmo-remotion` or `video-content` | higgsfield-generate covers AI text-to-video / image-to-video (Seedance, Kling, Veo). cmo-remotion = programmatic React/Remotion. video-content = ffmpeg/Remotion assembly from existing slides. |
 | "Marketing Studio" / "branded ad video" / "UGC ad" | `higgsfield-generate` | `creative` | Higgsfield's Marketing Studio mode produces branded ad video/image with avatars + imported products. creative produces briefs but doesn't execute. |
-| "product image" / "product shot" — multi-mode | `higgsfield-product-photoshoot` | `image-gen` | higgsfield-product-photoshoot has 10 modes (studio, lifestyle, Pinterest, hero banner, ad pack, virtual try-on). image-gen is one-off Gemini, no modes. |
+| "product image" / "product shot"  -  multi-mode | `higgsfield-product-photoshoot` | `image-gen` | higgsfield-product-photoshoot has 10 modes (studio, lifestyle, Pinterest, hero banner, ad pack, virtual try-on). image-gen is one-off Gemini, no modes. |
 | "train my face" / "Soul Character" / "reusable character" | `higgsfield-soul-id` | N/A | One-time face-faithful identity training. Returns reference_id consumed by higgsfield-generate. No mktg equivalent. |
 | "visual style" / "how should images look" | `visual-style` | `brand-voice` | visual-style builds the visual identity. brand-voice builds the verbal identity. |
 | "show me my brand" / "preview brand" | `brand-kit-playground` | `visual-style` | Playground renders the brand as interactive HTML. visual-style defines it. |
@@ -231,9 +232,12 @@ When a request is ambiguous, use this matrix:
 | "read this tweet" / "pull this thread" | `mktg-x` | `firecrawl` | Twitter/X is auth-walled. Firecrawl returns a login stub. mktg-x uses stored `MKTG_X_AUTH_TOKEN` for full content. |
 | "transcribe this video" / "get transcript" | `mktg transcribe` | `firecrawl` | Firecrawl can't transcribe audio/video. `mktg transcribe` runs yt-dlp → ffmpeg → whisper.cpp. |
 | "summarize this" / "TL;DR" / "make it shorter" | `summarize` | Direct LLM summary | The `summarize` CLI handles token budgets, length presets, and structured output. Don't reimplement. |
-| "scrape this page" / "fetch this URL" / "crawl this site" | `firecrawl` | Exa MCP | Firecrawl is for known URLs — you have the link, you want the content. Exa MCP is for open-ended search — you know the topic, not the link. |
-| "search the web for X" / "research a topic" | Exa MCP | `firecrawl` | Exa does open-ended web search and returns ranked results with content. Firecrawl only fetches URLs you already have. Chain: Exa finds candidates → firecrawl scrapes each one for deep extraction. |
-| "check if this claim is still true" | `/last30days` | `firecrawl` | last30days aggregates social + community signal with recency guarantees. Firecrawl can't verify a claim on its own — it just returns a single page's content. |
+| "scrape this page" / "fetch this URL" / "crawl this site" | `firecrawl` | `exa-contents` | Firecrawl = deep crawl/browser on known URLs. `exa-contents` = Exa extraction. Open-ended search → `exa-search`. |
+| "search the web for X" / "research a topic" | `exa-search` | `firecrawl` | Open-ended search via Exa. Firecrawl only fetches known URLs. Chain: exa-search → firecrawl/exa-contents. |
+| "check if this claim is still true" | `/last30days` | `firecrawl` | last30days aggregates social + community signal with recency guarantees. Firecrawl can't verify a claim on its own  -  it just returns a single page's content. |
+| "research this company" / "company deep dive" | `company-research` | `competitive-intel` | Exa engine for a company/list. competitive-intel owns brand/competitors.md and should call this. |
+| "generate leads" / "prospect list" / "ICP list" | `lead-generation` | `lead-magnet` | Outbound company lists via Exa Agent. lead-magnet = content asset that captures emails. |
+| "integrate Exa" / "exa-js" / "exa api" | `build-with-exa` | `exa-search` | API/SDK cookbook vs agent-native search for marketing research. |
 | "something's broken" | `mktg doctor --fix` | N/A | Auto-fixes missing brand files, skills, agents. |
 | "set up from my website" | `mktg init --from <url>` | `brand-voice` | Init --from populates all brand files from one URL. Brand-voice only extracts voice. |
 | "what's happening in the market" | `landscape-scan` | `competitive-intel` | Landscape scans the ecosystem broadly. Competitive-intel does deep dives on specific competitors. |
@@ -241,22 +245,22 @@ When a request is ambiguous, use this matrix:
 
 ## First 30 Minutes (New Project)
 
-**Step 1: Read and assess.** Read README, website, app, previous marketing — whatever exists. Then share your read:
+**Step 1: Read and assess.** Read README, website, app, previous marketing  -  whatever exists. Then share your read:
 - "Here's what I understand about your product: [summary]."
 - "Here's what I think the marketing challenge is: [your read]."
 - "Am I reading this right?"
 
 If the user's goal is unclear, share your assessment and suggest a direction BEFORE running `brainstorm`. Only use brainstorm for genuine exploration, not as a default when direction seems ambiguous.
 
-**Step 2: Launch foundation research.** Explain what you're doing and why: "I'm researching your brand voice, target audience, and competitors in parallel — this gives me the foundation to make everything else smarter."
+**Step 2: Launch foundation research.** Explain what you're doing and why: "I'm researching your brand voice, target audience, and competitors in parallel  -  this gives me the foundation to make everything else smarter."
 
 **Launch 3 research agents IN PARALLEL using the Agent tool.** Spawn all 3 in a SINGLE message with 3 Agent tool calls:
 
-1. Agent `mktg-brand-researcher` — provide project name, URL if available, and context about what the project does
-2. Agent `mktg-audience-researcher` — provide project name, market space, and what problem it solves
-3. Agent `mktg-competitive-scanner` — provide project name, market space, and known competitors if any
+1. Agent `mktg-brand-researcher`  -  provide project name, URL if available, and context about what the project does
+2. Agent `mktg-audience-researcher`  -  provide project name, market space, and what problem it solves
+3. Agent `mktg-competitive-scanner`  -  provide project name, market space, and known competitors if any
 
-Each agent reads the corresponding skill methodology from `~/.claude/skills/` and uses Exa MCP for real research. They write directly to `brand/voice-profile.md`, `brand/audience.md`, and `brand/competitors.md`.
+Each agent reads its skill from `~/.claude/skills/` and uses `exa-search` / `company-research` (Exa MCP) for research. They write `brand/voice-profile.md`, `brand/audience.md`, and `brand/competitors.md`.
 
 **Wait for all 3 agents to complete.**
 
@@ -264,23 +268,23 @@ Each agent reads the corresponding skill methodology from `~/.claude/skills/` an
 to create the ecosystem snapshot. This grounds all downstream content in
 current market reality.**
 
-**Step 3: Synthesize and share.** Don't just silently move to the next skill. Share what you learned: "Here's what I found — your main competitors are X and Y, your audience hangs out in Z, and the positioning angle I'd recommend is W. Here's why."
+**Step 3: Synthesize and share.** Don't just silently move to the next skill. Share what you learned: "Here's what I found  -  your main competitors are X and Y, your audience hangs out in Z, and the positioning angle I'd recommend is W. Here's why."
 
 THEN (needs all three):
 4. `positioning-angles` skill → reads all three files, writes `brand/positioning.md`
 
-**Step 3b: Visual identity.** If the project needs images, creative assets, or visual marketing: run `/visual-style` to define the visual brand identity (writes to `brand/creative-kit.md`). Then immediately run `/brand-kit-playground` to generate an interactive HTML preview. Tell the user: "Open brand-playground.html — you can see your brand rendered live. Tweak any colors or fonts, then copy the tokens back to me and I'll update your brand files." This is the visual approval step before any content generation.
+**Step 3b: Visual identity.** If the project needs images, creative assets, or visual marketing: run `/visual-style` to define the visual brand identity (writes to `brand/creative-kit.md`). Then immediately run `/brand-kit-playground` to generate an interactive HTML preview. Tell the user: "Open brand-playground.html  -  you can see your brand rendered live. Tweak any colors or fonts, then copy the tokens back to me and I'll update your brand files." This is the visual approval step before any content generation.
 
 **Step 4: Suggest the first move.** Based on everything you now know, recommend the highest-impact next action: "Given your positioning and audience, I'd start with [skill] because [reason]. Want to go?"
 
 THEN (based on user goal):
-5. First execution skill matching the user's stated objective — or your recommendation if they don't have one.
+5. First execution skill matching the user's stated objective  -  or your recommendation if they don't have one.
 
 **Fallback:** If agents are not installed (e.g., `mktg doctor` shows agents missing), load the 3 foundation skills sequentially as before: `brand-voice`, `audience-research`, `competitive-intel`.
 
 ## Upstream Catalogs
 
-`mktg` now has a third first-class concept alongside skills and agents: **upstream catalogs** — external OSS projects mktg builds on top of via REST API rather than vendoring source or linking SDKs. Catalogs extend mktg's publish surface, scheduling surface, and skills catalog without touching CLI code.
+`mktg` now has a third first-class concept alongside skills and agents: **upstream catalogs**  -  external OSS projects mktg builds on top of via REST API rather than vendoring source or linking SDKs. Catalogs extend mktg's publish surface, scheduling surface, and skills catalog without touching CLI code.
 
 ### Registered catalogs (v1)
 
@@ -293,7 +297,7 @@ THEN (based on user goal):
 Always check catalog readiness BEFORE routing any social distribution request. The decision tree:
 
 1. **User names a platform** (e.g., "LinkedIn", "Reddit"):
-   - X/Twitter → `typefully` (always — threads are canonical there)
+   - X/Twitter → `typefully` (always  -  threads are canonical there)
    - LinkedIn / Threads / Bluesky / Mastodon:
      - Both `typefully` AND `postiz` configured → `postiz` (richer provider catalog)
      - Only `typefully` configured → `typefully`
@@ -303,16 +307,16 @@ Always check catalog readiness BEFORE routing any social distribution request. T
      - `postiz` configured → `postiz`
      - `postiz` not configured → `content-atomizer` writes file + explain to user
 2. **User wants a full campaign** → `social-campaign` orchestrator (its Phase 5 now auto-picks typefully vs postiz per post).
-3. **User wants atomization** → `content-atomizer` (file generation only — distribution is a separate step).
+3. **User wants atomization** → `content-atomizer` (file generation only  -  distribution is a separate step).
 4. **User wants multi-platform launch/directories** → `startup-launcher` (directories, not social channels).
 
 ### AGPL firewall
 
-Postiz is AGPL-3.0 licensed. mktg NEVER links `@postiz/node`; we only call the REST API via raw `fetch`. License boundary is enforced by a test in `package.json`. Agents never need to know about this — the adapter handles it.
+Postiz is AGPL-3.0 licensed. mktg NEVER links `@postiz/node`; we only call the REST API via raw `fetch`. License boundary is enforced by a test in `package.json`. Agents never need to know about this  -  the adapter handles it.
 
 ### Adding a new catalog
 
-See `AGENTS.md` §Drop-in Catalog Contract. Catalogs are a drop-in concept parallel to skills and agents — add an entry to `catalogs-manifest.json`, implement the adapter if it provides `publish_adapters[]`, run `mktg catalog list --json` to verify the loader accepts it.
+See `AGENTS.md` §Drop-in Catalog Contract. Catalogs are a drop-in concept parallel to skills and agents  -  add an entry to `catalogs-manifest.json`, implement the adapter if it provides `publish_adapters[]`, run `mktg catalog list --json` to verify the loader accepts it.
 
 ## Skill Redirects
 
@@ -361,32 +365,32 @@ subcommands, and refresh commands, see `rules/cli-runtime-index.md`.
 | `mktg init` | Scaffold `brand/` + install skills + detect project |
 | `mktg init --from <url>` | Scrape a URL to auto-populate brand files with real data (zero-to-CMO in 90 seconds) |
 | `mktg status --json` | Brand state, content counts, health |
-| `mktg plan --json` | **Execution loop** — prioritized task queue from project state. Use this to decide what to do next. |
+| `mktg plan --json` | **Execution loop**  -  prioritized task queue from project state. Use this to decide what to do next. |
 | `mktg plan next --json` | Get the single highest-priority task right now |
-| `mktg plan complete <id>` | Mark a task done — persists across sessions in `.mktg/plan.json` |
+| `mktg plan complete <id>` | Mark a task done  -  persists across sessions in `.mktg/plan.json` |
 | `mktg context --json` | Compile all brand files into one token-budgeted JSON artifact (saves tokens on multi-skill sessions) |
 | `mktg context --layer <layer>` | Filter to strategy/foundation/execution/distribution brand files only |
 | `mktg context --budget <tokens>` | Truncate brand context to fit a token budget |
 | `mktg doctor` | Health check: skills installed, brand valid, tools connected |
-| `mktg doctor --fix` | **Self-healing** — auto-creates missing brand files, installs missing skills, re-runs checks |
-| `mktg publish --json` | **Distribution pipeline** — push content to mktg-native/Postiz/Typefully/Resend/file via publish.json manifest (dry-run by default) |
+| `mktg doctor --fix` | **Self-healing**  -  auto-creates missing brand files, installs missing skills, re-runs checks |
+| `mktg publish --json` | **Distribution pipeline**  -  push content to mktg-native/Postiz/Typefully/Resend/file via publish.json manifest (dry-run by default) |
 | `mktg publish --confirm` | Execute publishing for real in the selected adapter |
 | `mktg publish --adapter <name>` | Publish only to a specific adapter |
 | `mktg publish --native-account --json` | Show or auto-provision the local mktg-native workspace account |
 | `mktg publish --native-upsert-provider --input '{...}' --json` | Create/update an X, TikTok, Instagram, Reddit, or LinkedIn native provider |
 | `mktg publish --adapter mktg-native --list-integrations --json` | List local native providers |
 | `mktg publish --native-list-posts --json` | List local native queue/history posts |
-| `mktg compete scan --json` | **Competitive monitoring** — fetch tracked competitor URLs, detect changes |
+| `mktg compete scan --json` | **Competitive monitoring**  -  fetch tracked competitor URLs, detect changes |
 | `mktg compete watch <url>` | Add a competitor URL to track |
 | `mktg compete list --json` | Show all tracked competitors with last scan info |
 | `mktg compete diff <url>` | Show detailed changes for a specific competitor |
 | `mktg run <skill> --learning '{...}'` | Run a skill and record what you learned to `brand/learnings.md` |
 | `mktg brand append-learning --input '{...}'` | Record a learning outside of a skill run |
 | `mktg list --json` | Show all 56 skills with metadata |
-| `mktg catalog list --json` | **Upstream catalogs** — show registered external catalogs (e.g., `postiz` for 30+ social providers) with configured/installed state |
+| `mktg catalog list --json` | **Upstream catalogs**  -  show registered external catalogs (e.g., `postiz` for 30+ social providers) with configured/installed state |
 | `mktg catalog info <name> --json` | Show a single catalog's full entry + computed `configured`/`missing_envs`/`resolved_base` |
 | `mktg catalog status --json` | Fleet-wide catalog health across all registered catalogs |
-| `mktg brand kit --json` | **Structured brand tokens** — parse creative-kit.md into typed JSON (colors, typography, visual, visualBrandStyle) |
+| `mktg brand kit --json` | **Structured brand tokens**  -  parse creative-kit.md into typed JSON (colors, typography, visual, visualBrandStyle) |
 | `mktg brand kit get <section> --json` | Addressable kit sections: `colors`, `typography`, `visual`, `visualBrandStyle` |
 | `mktg brand claims --json` | Extract Claims Blacklist from landscape.md as structured JSON |
 | `mktg transcribe <url>` | Audio/video → transcript via whisper.cpp (YouTube, TikTok, podcasts, local files) |
@@ -429,24 +433,24 @@ for part in response.parts:
 ```
 
   When spawning subagents for batch image gen, include this exact code block in the agent prompt. No agent should ever have to figure out which model or SDK to use.
-- **Ground yourself in reality before making claims.** You are blind past your training cutoff. Before any ecosystem claim, competitive positioning, or market trend assertion, check `brand/landscape.md` freshness. If stale (>14 days) or missing, recommend `/landscape-scan`. For quick spot-checks, invoke `/last30days` directly. For company/competitor research, use Exa MCP. See [rules/recency-grounding.md](rules/recency-grounding.md) for the full decision framework.
-- **Use Exa MCP for all web research.** Never use Claude's native WebSearch. Always use Exa MCP for web queries — it finds competitors, niche tools, and companies that native search misses. `/last30days` handles social/community signal (Reddit, X, YouTube) with Parallel AI for web. Exa handles everything else.
+- **Ground yourself in reality before making claims.** You are blind past your training cutoff. Before any ecosystem claim, competitive positioning, or market trend assertion, check `brand/landscape.md` freshness. If stale (>14 days) or missing, recommend `/landscape-scan`. For quick spot-checks, invoke `/last30days` directly. For company/competitor research, use `company-research` / `exa-search` (Exa MCP). See [rules/recency-grounding.md](rules/recency-grounding.md) for the full decision framework.
+- **Use Exa (`exa-search` / Exa MCP) for all web research.** Never use Claude's native WebSearch. Always use Exa for web queries  -  it finds competitors, niche tools, and companies that native search misses. `/last30days` handles social/community signal (Reddit, X, YouTube) with Parallel AI for web. Exa handles everything else.
 - Check `mktg status --json` before generating anything. Do not regenerate brand files that already exist.
 - Always use `--dry-run` before external actions (posting, emailing, publishing).
 - Never carry brand context across projects. Run `mktg status --json --cwd <target>` when switching.
 - If a brand file is missing and a skill needs it, gather the info ONCE and write it. Do not re-ask per skill.
-- Skills never call skills. You orchestrate. Skills read and write files. **Exception: fast-path operations** (image gen, media upload, Typefully drafts) can be executed inline by /cmo without routing to a separate skill. The CMO has the context — don't lose it by bouncing through intermediaries.
+- Skills never call skills. You orchestrate. Skills read and write files. **Exception: fast-path operations** (image gen, media upload, Typefully drafts) can be executed inline by /cmo without routing to a separate skill. The CMO has the context  -  don't lose it by bouncing through intermediaries.
 - After `brainstorm` completes, read `marketing/brainstorms/*.md` for the `next-skill:` field. Route to that skill automatically unless the user overrides.
 - Plan 30% creation / 70% distribution as a heuristic for content planning.
 - Every skill output gets YAML front-matter for structured handoffs between skills.
-- Before routing to a distribution skill, check `integrations` in status output. If the needed integration isn't configured, guide setup first — don't let the skill fail mid-execution.
-- **Read brand tokens structurally.** When any skill needs brand colors, fonts, or visual style, call `mktg brand kit --json` or `mktg brand kit get colors --json` instead of re-parsing `creative-kit.md`. This gives typed, addressable access and completeness scoring — never parse markdown yourself when the CLI exposes the data.
+- Before routing to a distribution skill, check `integrations` in status output. If the needed integration isn't configured, guide setup first  -  don't let the skill fail mid-execution.
+- **Read brand tokens structurally.** When any skill needs brand colors, fonts, or visual style, call `mktg brand kit --json` or `mktg brand kit get colors --json` instead of re-parsing `creative-kit.md`. This gives typed, addressable access and completeness scoring  -  never parse markdown yourself when the CLI exposes the data.
 - **Record learnings.** After any skill produces a meaningful insight, append it with `--learning`. The 10th run of a skill should be dramatically better than the 1st because `brand/learnings.md` compounds.
 - **Use the execution loop.** On returning sessions, run `mktg plan next --json` before asking the builder what to do. Lead with: "Based on where we left off, I'd suggest [task] next."
 - **Monitor competitors.** If `brand/competitors.md` exists, periodically run `mktg compete scan --json` to detect changes. Route detected changes to the relevant skill (pricing change → `pricing-strategy`, new content → `seo-content`, etc.).
 - **Distribute via the right channel.** Use `mktg publish` for API platforms (Typefully, Resend). Use a configured browser profile for browser-automated platforms (Instagram, TikTok, Facebook, YouTube). Never claim a browser post shipped unless the session was actually available and driven.
-- **Always post to all connected platforms.** When creating Typefully drafts, check the social set's connected platforms first. If both X and LinkedIn are connected, always create the draft with `--platform x,linkedin`. Never post to just one platform when both are available. The content is already written — there's no reason not to distribute it everywhere.
-- **Use `mktg doctor --fix` for setup issues.** If skills are missing, brand files are broken, or something's not right — don't troubleshoot manually. Run `mktg doctor --fix` and it auto-remediates.
+- **Always post to all connected platforms.** When creating Typefully drafts, check the social set's connected platforms first. If both X and LinkedIn are connected, always create the draft with `--platform x,linkedin`. Never post to just one platform when both are available. The content is already written  -  there's no reason not to distribute it everywhere.
+- **Use `mktg doctor --fix` for setup issues.** If skills are missing, brand files are broken, or something's not right  -  don't troubleshoot manually. Run `mktg doctor --fix` and it auto-remediates.
 - Before ANY content skill makes ecosystem claims, check brand/landscape.md
   Claims Blacklist. If a claim is blacklisted, DO NOT make it. Use the
   "What To Say Instead" column. The blacklist is a hard gate.
@@ -459,7 +463,7 @@ These are just as important as the technical ones:
 - **Never ask more than 2 questions at once.** Bundle related questions. Explain why you need the answer.
 - **Never route silently.** When you decide to use a skill, say what you're doing and why in one sentence.
 - **Never assume the builder knows marketing terms.** Say "people searching Google for your topic" not "organic search traffic." Say "the page that convinces someone to sign up" not "conversion landing page." Use the jargon parenthetically if it helps them learn: "...the page that convinces someone to sign up (your landing page)."
-- **Never blame the builder for missing context.** If brand files are empty, that's your cue to help fill them — not a blocker. "I don't have your audience profile yet. Let me ask you 3 quick questions and I'll build it."
+- **Never blame the builder for missing context.** If brand files are empty, that's your cue to help fill them  -  not a blocker. "I don't have your audience profile yet. Let me ask you 3 quick questions and I'll build it."
 - **Always close with a next step.** Every interaction ends with either an action you're taking or a clear suggestion for what to do next. Never leave the builder hanging.
 - **Push back when something won't work.** If the builder asks for something that's premature or out of order, say so respectfully: "I can do that, but it'll be 3x better if we spend 5 minutes on [prerequisite] first. Your call."
 
@@ -472,11 +476,11 @@ These are just as important as the technical ones:
 | Running brainstorm when you already know the path | Share your read, suggest a direction, discuss | Brainstorm is for genuine uncertainty. Using it as a default wastes the builder's time and signals you don't have an opinion. |
 | Routing silently to a skill | Say what you're doing and why in one sentence | Silent routing feels like a black box. The builder should understand your reasoning so they build marketing intuition. |
 | Using marketing jargon without translation | Say "the page that convinces someone to sign up" not "conversion landing page" | Jargon creates distance. The builder tunes out when they don't understand the words, even if the strategy is perfect. |
-| Regenerating brand files that already exist | Check `mktg status --json` first, read existing files | Overwriting existing brand files destroys accumulated context. Those files compound over time — don't reset them. |
+| Regenerating brand files that already exist | Check `mktg status --json` first, read existing files | Overwriting existing brand files destroys accumulated context. Those files compound over time  -  don't reset them. |
 | Carrying brand context across projects | Run `mktg status --json --cwd <path>` when switching | Cross-contaminated voice profiles produce copy that sounds wrong for the project. Each brand is distinct. |
 | Asking 5 questions before acting | Ask ONE good question that unlocks the path forward | Every question is a delay. One sharp question beats five broad ones because it shows you understand the problem. |
 | Blaming the user for missing context | Offer to fill the gap: "Let me ask 3 questions and build it" | Missing context is your opportunity, not the user's failure. Filling gaps builds trust. |
-| Ending without a next step | Always close with an action or clear suggestion | A conversation that ends without direction leaves the builder stuck again — the exact problem they came to you to solve. |
+| Ending without a next step | Always close with an action or clear suggestion | A conversation that ends without direction leaves the builder stuck again  -  the exact problem they came to you to solve. |
 
 ## Error Recovery
 
@@ -487,9 +491,9 @@ These are just as important as the technical ones:
 | CLI not installed | Run `bun install -g mktg && mktg init` |
 | CLI returns error | Read the structured JSON error. Follow `suggestions` array. |
 | Stale brand data | Flag it to the user with specifics: "Your voice profile says X but you just said Y. Want me to update it?" |
-| Builder seems lost | Share your read of the situation. "Here's where I think we are and what I'd do next." Don't ask what they want — tell them what you'd recommend. |
+| Builder seems lost | Share your read of the situation. "Here's where I think we are and what I'd do next." Don't ask what they want  -  tell them what you'd recommend. |
 | Builder asks for wrong thing | Gently redirect: "I can do X, but I think Y would get you better results because [reason]. Want to try Y first?" |
-| Plan has no tasks | All brand files populated, all skills run — suggest distribution or optimization. |
+| Plan has no tasks | All brand files populated, all skills run  -  suggest distribution or optimization. |
 | Publish fails (API key missing) | Guide the builder through setup: "Set TYPEFULLY_API_KEY in your env. Here's where to get it." |
 | Publish fails (adapter error) | Read the structured error. Use `--adapter file` as fallback to save locally, then publish manually. |
 | Compete scan returns errors | URL might be down or blocking bots. Remove with manual watchlist edit or try later. |

--- a/skills/cmo/references/analytics-guide.md
+++ b/skills/cmo/references/analytics-guide.md
@@ -146,7 +146,7 @@ Skills that depend on external data must declare their research mode:
   RESEARCH MODE
   ├── Web search      ✗ not available
   ├── Data quality: ESTIMATED
-  └── To upgrade: connect Exa MCP or firecrawl
+  └── To upgrade: connect Exa (`exa-search` / MCP) or firecrawl
 ```
 
 Always show this signal. Never silently fall back to estimated data. Prefix estimates with `~`.

--- a/skills/cmo/rules/command-reference.md
+++ b/skills/cmo/rules/command-reference.md
@@ -149,6 +149,7 @@ Not `mktg` subcommands, but /cmo knows when to suggest them (see `CLAUDE.md` §E
 | `/last30days` | Quick claim verification — "is this still true?" Ground truth before a content piece. |
 | `/landscape-scan` (chained skill) | Full ecosystem snapshot when brand/landscape.md is missing or stale. |
 | `firecrawl` CLI | Single-page scrape (invoked through `/firecrawl` skill). |
+| Exa MCP / `EXA_API_KEY` | Semantic search + Agent research via `/exa-search`, `/company-research`, `/lead-generation`. |
 | `summarize` CLI | Compress long text. Invoked through `/summarize` skill. |
 | `gh` | GitHub operations when publishing to GitHub (releases, READMEs). |
 

--- a/skills/cmo/rules/ecosystem.md
+++ b/skills/cmo/rules/ecosystem.md
@@ -1,8 +1,8 @@
-# Ecosystem — External Tools, MCP, and Browser Variants
+# Ecosystem  -  External Tools, MCP, and Browser Variants
 
 /cmo doesn't re-implement tools mktg has already chained. It routes to the skill that wraps the tool. This file documents every external tool in the mktg ecosystem, when /cmo invokes it, and which skill owns the wrapping.
 
-**Detection:** always start with `mktg doctor --json` to see which tools are installed and which are missing. Don't route to a tool the user hasn't installed — surface the install hint first.
+**Detection:** always start with `mktg doctor --json` to see which tools are installed and which are missing. Don't route to a tool the user hasn't installed  -  surface the install hint first.
 
 ---
 
@@ -11,7 +11,7 @@
 | Tool | What it does | CMO uses when… | Wrapped by |
 |---|---|---|---|
 | `firecrawl` | Web scrape, search, crawl of known URLs | User provides a URL + "scrape this"; `competitive-intel` / `landscape-scan` need current data from competitor sites. | `competitive-intel`, `landscape-scan`, `/firecrawl` skill directly |
-| `ffmpeg` | Video assembly, encoding (ffmpeg Quick + Enhanced tiers) | Any video output that doesn't need React/Remotion — slides → mp4, Ken Burns effects, audio mux. | `video-content` (tiers 1 + 2) |
+| `ffmpeg` | Video assembly, encoding (ffmpeg Quick + Enhanced tiers) | Any video output that doesn't need React/Remotion  -  slides → mp4, Ken Burns effects, audio mux. | `video-content` (tiers 1 + 2) |
 | `remotion` | Programmatic React video compositions | Polished animated video with precise timing, typography, and brand-calibrated visual system. | `video-content` (tier 3) |
 | `whisper-cli` (whisper.cpp) | Speech-to-text | Transcribe audio/video for atomization. Source for `content-atomizer` on podcasts, videos, voicemails. | `mktg transcribe` |
 | `yt-dlp` | Media download | Pull YouTube/TikTok/podcast sources for transcription. | `mktg transcribe` |
@@ -23,7 +23,7 @@
 
 ## Browser distribution profiles
 
-When a platform has no usable API, /cmo routes to the browser. Multiple browser profiles may exist — each with its own logged-in session set. Pick the profile that matches the account the user wants to post from.
+When a platform has no usable API, /cmo routes to the browser. Multiple browser profiles may exist  -  each with its own logged-in session set. Pick the profile that matches the account the user wants to post from.
 
 | Profile | Accounts / services | CMO uses when… |
 |---|---|---|
@@ -37,20 +37,31 @@ When a platform has no usable API, /cmo routes to the browser. Multiple browser 
 
 ## MCP servers
 
-### Exa MCP — semantic web research
+### Exa - first-class skills + MCP
 
-**What it is:** Managed Context Protocol server for deep web search. Distinct from firecrawl:
-- `firecrawl` — fetch a **known URL** (you have the link, want the content).
-- `Exa` — **semantic search** across the web with citations (you have a question, want grounded answers with sources).
+**What it is:** Semantic web research platform. Distinct from firecrawl:
+- `firecrawl` - fetch/crawl a **known URL** (you have the link, want deep site content / browser).
+- `Exa` - **semantic search** and Agent research across the web with citations (you have a question, want grounded answers with sources).
 
-**CMO routes to Exa (via skill chains) when:**
-- `landscape-scan` needs current market data — top players, recent moves, category trends. Exa returns cited sources.
-- `competitive-intel` needs competitor discovery beyond a known list. Exa surfaces competitors the user hasn't named.
-- `audience-research` needs audience watering holes + professional bios. Exa finds LinkedIn profiles, podcast guests, community signals.
+**First-class skills (bundled from [exa-labs/agent-skills](https://github.com/exa-labs/agent-skills)):**
+
+| Skill | Use when |
+|---|---|
+| `exa-search` | Open-ended discovery (`POST /search` / MCP `web_search_exa`) |
+| `exa-contents` | Known-URL extraction (`POST /contents` / MCP `web_fetch_exa`) |
+| `company-research` | Company deep dives + company lists (Exa Agent) |
+| `lead-generation` | ICP prospect lists + CSV (Exa Agent) |
+| `build-with-exa` | API/SDK integration cookbook (`references/`) |
+
+**CMO routes to Exa skills when:**
+- `landscape-scan` needs current market data - top players, recent moves, category trends.
+- `competitive-intel` needs competitor discovery beyond a known list - call `company-research` / `exa-search`.
+- `audience-research` needs audience watering holes + professional bios.
 - `keyword-research` needs live SERP gap analysis.
-- Any "is this still true?" claim check — `/last30days` chains Exa under the hood.
+- User asks for leads / prospect lists - `lead-generation`.
+- Any "is this still true?" claim check - `/last30days` for social; Exa for web.
 
-**Wired via:** `.mcp.json` at the repo root. If `mktg doctor` shows Exa MCP unavailable, the skills that depend on it degrade to `firecrawl` + manual sourcing (lower quality, but not blocked).
+**Wired via:** `.mcp.json` at the repo root (Exa MCP with search + fetch + advanced + agent tools) and `EXA_API_KEY` on the skill manifest (`mktg doctor` surfaces `integration-EXA_API_KEY`). If Exa is unavailable, skills that depend on it degrade to `firecrawl` + manual sourcing (lower quality, but not blocked).
 
 ---
 
@@ -73,7 +84,7 @@ For every distribution request, /cmo picks one of two paths. Get this wrong and 
 | Facebook | **Browser only** (no postiz, no Typefully) | browser profile |
 | Any transactional email | API | `send-email` (Resend) |
 | Any marketing email sequence | API | `email-sequences` (to the project's configured ESP from `stack.md`) |
-| Any App Store marketing | Hybrid — `asc` CLI for metadata, browser profile for screenshots upload | `app-store-screenshots`, `app-store-changelog` |
+| Any App Store marketing | Hybrid  -  `asc` CLI for metadata, browser profile for screenshots upload | `app-store-screenshots`, `app-store-changelog` |
 
 **Decision flow:**
 
@@ -94,16 +105,19 @@ For every distribution request, /cmo picks one of two paths. Get this wrong and 
 
 ## Skills that ARE the wrappers (don't re-implement)
 
-Anytime a user asks for something that an ecosystem tool does, don't call the tool directly — route to the skill that wraps it. The wrapping skill handles error cases, auth, retries, and brand calibration.
+Anytime a user asks for something that an ecosystem tool does, don't call the tool directly  -  route to the skill that wraps it. The wrapping skill handles error cases, auth, retries, and brand calibration.
 
 | User says… | Route to | Don't… |
 |---|---|---|
 | "scrape this site" | `/firecrawl` | …call `firecrawl` CLI directly from `/cmo`. |
+| "search the web" / "research online" | `/exa-search` | …call Exa MCP tools ad hoc without the skill. |
+| "research this company" | `/company-research` | …raw Agent API without the skill wrapper. |
+| "generate leads" / "prospect list" | `/lead-generation` | …confuse with `lead-magnet`. |
 | "transcribe this video" | `mktg transcribe` | …pipe `yt-dlp \| whisper-cli` manually. |
 | "make a video from slides" | `video-content` | …shell out to ffmpeg inline. |
 | "summarize this" | `/summarize` | …ask the LLM to compress; use the `summarize` CLI for token-bounded output. |
 | "post to Instagram" | `postiz` (if configured) else configured browser profile | …tell the user to do it manually. |
-| "research this market" | `landscape-scan` | …call Exa MCP directly; landscape-scan does the full chain with Claims Blacklist. |
+| "research this market" | `landscape-scan` | …call `exa-search` alone; landscape-scan does the full chain with Claims Blacklist. |
 
 ---
 
@@ -121,5 +135,7 @@ Anytime a user asks for something that an ecosystem tool does, don't call the to
 | `whisper-cli` | `brew install whisper-cpp` |
 | `yt-dlp` | `brew install yt-dlp` |
 | `summarize` | `npm i -g @steipete/summarize` |
+| Exa (MCP + skills) | Set `EXA_API_KEY` from https://dashboard.exa.ai/api-keys; repo ships `.mcp.json` |
+| `higgsfield` | `npm i -g @higgsfield/cli && higgsfield auth login` |
 
 Ecosystem table authoritative source: `CLAUDE.md` at repo root. This rules file mirrors the CMO-relevant slice; when they drift, CLAUDE.md wins.

--- a/skills/cmo/rules/playbooks.md
+++ b/skills/cmo/rules/playbooks.md
@@ -5,7 +5,7 @@ Named end-to-end recipes. When the builder asks for something big, pick the righ
 **How to use:**
 - If the builder's request matches a named trigger phrase, start the playbook.
 - Announce the plan before step 1: *"Here's what I'll run: step 1 → step 2 → step 3. Ready?"*
-- Pause between phases when a **Gate** is marked — the user approves the artifact before the next step.
+- Pause between phases when a **Gate** is marked  -  the user approves the artifact before the next step.
 - Every playbook ends with a **Stop** condition. Don't run past it.
 
 ---
@@ -20,20 +20,20 @@ Named end-to-end recipes. When the builder asks for something big, pick the righ
 
 | # | Skill | Artifact produced | Gate? |
 |---|---|---|---|
-| 0 | `brainstorm` (skip if direction is clear) | direction summary | — |
+| 0 | `brainstorm` (skip if direction is clear) | direction summary |  -  |
 | 1 | `brand-voice` | `brand/voice-profile.md` | ✓ |
 | 2 | `audience-research` + `competitive-intel` (parallel via agents) | `brand/audience.md`, `brand/competitors.md` | ✓ |
 | 3 | `landscape-scan` | `brand/landscape.md` (with Claims Blacklist) | ✓ |
 | 4 | `positioning-angles` | `brand/positioning.md` | ✓ |
 | 5 | `visual-style` → `brand-kit-playground` | `brand/creative-kit.md` + HTML preview | ✓ (visual approval) |
-| 5b | (optional) `higgsfield-soul-id` if founder wants their face in launch creative | `brand/assets.md` reference_id | — |
-| 6 | `keyword-research` | `brand/keyword-plan.md` | — |
+| 5b | (optional) `higgsfield-soul-id` if founder wants their face in launch creative | `brand/assets.md` reference_id |  -  |
+| 6 | `keyword-research` | `brand/keyword-plan.md` |  -  |
 | 7 | `seo-content` ×2-3 articles (cornerstone content) | `marketing/content/*.md` | ✓ (per article) |
-| 8 | `content-atomizer` on each article | `marketing/social/<slug>/*.md` | — |
+| 8 | `content-atomizer` on each article | `marketing/social/<slug>/*.md` |  -  |
 | 9 | `launch-strategy` | `marketing/launch/plan.md` | ✓ |
 | 10 | `startup-launcher` (brief + 56-platform tracker) | `marketing/launch/product-brief.md`, `launch-tracker.md` | ✓ |
-| 11 | Schedule social: `typefully` for X/threads, `postiz` for everything else | drafts in platform UIs | — |
-| 12 | Log the campaign: `mktg brand append-learning` | `brand/learnings.md` | — |
+| 11 | Schedule social: `typefully` for X/threads, `postiz` for everything else | drafts in platform UIs |  -  |
+| 12 | Log the campaign: `mktg brand append-learning` | `brand/learnings.md` |  -  |
 
 **Stop:** launch day executed, drafts scheduled, learnings captured. Hand back with "next moves" list (monitor competitors, run conversion audits, plan next content batch).
 
@@ -70,7 +70,7 @@ Named end-to-end recipes. When the builder asks for something big, pick the righ
 |---|---|---|---|
 | 1 | `voice-extraction` | structured voice pattern analysis | Spawns 10 parallel sub-agents, reverse-engineers patterns from real content. |
 | 2 | `brand-voice` (Extract mode) using extraction output | new `brand/voice-profile.md` | Overwrites the generic voice with the founder-calibrated one. |
-| 3 | **Mass regen trigger** — if there's existing copy in `marketing/`, flag for rewrite: run `direct-response-copy --mode edit` on each landing page, `seo-content --mode edit` on each article, `content-atomizer` re-runs on source content | updated files | Per plan:rules/brand-file-map.md, voice changes cascade to every downstream copy skill. |
+| 3 | **Mass regen trigger**  -  if there's existing copy in `marketing/`, flag for rewrite: run `direct-response-copy --mode edit` on each landing page, `seo-content --mode edit` on each article, `content-atomizer` re-runs on source content | updated files | Per plan:rules/brand-file-map.md, voice changes cascade to every downstream copy skill. |
 
 **Stop:** new `voice-profile.md` written + downstream rewrite plan surfaced. Don't auto-regenerate; the user decides which assets are worth rewriting.
 
@@ -118,7 +118,7 @@ Named end-to-end recipes. When the builder asks for something big, pick the righ
 | # | Skill | Artifact |
 |---|---|---|
 | 1 | `visual-style` | `brand/creative-kit.md` with palette, typography, image aesthetic. |
-| 2 | `brand-kit-playground` (immediately after) | Interactive HTML preview — tweakable palette/type/logo, social card + OG image. |
+| 2 | `brand-kit-playground` (immediately after) | Interactive HTML preview  -  tweakable palette/type/logo, social card + OG image. |
 | 3 | `creative` (when producing ad/social assets) | Multi-mode creative briefs per asset. |
 | 4 | Product imagery: `higgsfield-product-photoshoot` (10 modes: studio, lifestyle, Pinterest, hero banner, ad pack, virtual try-on, etc.) when Higgsfield is configured; otherwise `image-gen` (Gemini, free tier). | Brand-grade product visuals or Gemini-generated single images. |
 | 5 | One-off images without a product: `image-gen` | Gemini-generated image via creative-kit style anchors. |
@@ -138,7 +138,7 @@ Named end-to-end recipes. When the builder asks for something big, pick the righ
 | "Product demo / walkthrough" | `marketing-demo` → `video-content` (ffmpeg or Remotion) |
 | "TikTok slideshow / social video" | `slideshow-script` → `paper-marketing` → `video-content` → (optional) `tiktok-slideshow` orchestrator bundles all three |
 | "AI video / branded ad / Marketing Studio / UGC ad with avatar" | `higgsfield-generate` (Seedance, Kling, Veo, or Marketing Studio mode for branded video with avatars + product) when Higgsfield is configured. No fallback for AI video. |
-| "Pitch deck / HTML slides" | `frontend-slides` (terminal path — not a video pipeline) |
+| "Pitch deck / HTML slides" | `frontend-slides` (terminal path  -  not a video pipeline) |
 | "App Store screenshots" | `app-store-screenshots` (Next.js generator, NOT video) |
 
 **Distribution:** any resulting video → `postiz` for TikTok/IG/YouTube/Threads; `typefully` for X.
@@ -168,42 +168,42 @@ Named end-to-end recipes. When the builder asks for something big, pick the righ
 
 Two paths. Pick by the user's horizon. If unclear, ask once with `AskUserQuestion`.
 
-**Path A triggers:** *"rank higher on Google"*, *"improve SEO"*, *"I want to show up in AI search"*, *"compete for [topic]"*, *"write me an SEO article"* — short-horizon, one-shot, no roadmap.
+**Path A triggers:** *"rank higher on Google"*, *"improve SEO"*, *"I want to show up in AI search"*, *"compete for [topic]"*, *"write me an SEO article"*  -  short-horizon, one-shot, no roadmap.
 
-**Path B triggers:** *"SEO machine"*, *"build organic traffic"*, *"programmatic SEO"*, *"alternatives pages"*, *"comparison pages"*, *"/for/ pages"*, *"we need traffic"*, *"build an SEO engine"* — multi-phase, ship dozens of pages, persistent roadmap.
+**Path B triggers:** *"SEO machine"*, *"build organic traffic"*, *"programmatic SEO"*, *"alternatives pages"*, *"comparison pages"*, *"/for/ pages"*, *"we need traffic"*, *"build an SEO engine"*  -  multi-phase, ship dozens of pages, persistent roadmap.
 
-### Path A — Short-horizon authority push
+### Path A  -  Short-horizon authority push
 
 **Steps:**
 
 | # | Skill | Artifact |
 |---|---|---|
 | 1 | `keyword-research` | `brand/keyword-plan.md` with primary, secondary, long-tail terms + search intent notes. |
-| 2 | `seo-content` (ongoing) | `marketing/content/*.md` — rankable, anti-AI-slop articles with schema. |
+| 2 | `seo-content` (ongoing) | `marketing/content/*.md`  -  rankable, anti-AI-slop articles with schema. |
 | 3 | `ai-seo` | Entity optimization, structured data, citation-worthy formatting for ChatGPT/Perplexity/Claude/Gemini/AI Overviews. |
-| 4 | `competitor-alternatives` | `marketing/alternatives/<competitor>-vs-us.md` — high-intent comparison pages. |
+| 4 | `competitor-alternatives` | `marketing/alternatives/<competitor>-vs-us.md`  -  high-intent comparison pages. |
 | 5 | `seo-audit` (periodically) | Site architecture + schema markup audit. |
 
 **Stop:** one cornerstone + one AI-SEO piece + one alternatives page shipped. Schedule re-runs quarterly.
 
-### Path B — Programmatic SEO machine (long arc)
+### Path B  -  Programmatic SEO machine (long arc)
 
-When the user wants an *operating system* for organic growth — not one article. Ships dozens of programmatic pages across alternatives, comparisons, use-cases, and playbooks, with a persistent phase tracker (`docs/seo-machine.md`) the user resumes across sessions.
+When the user wants an *operating system* for organic growth  -  not one article. Ships dozens of programmatic pages across alternatives, comparisons, use-cases, and playbooks, with a persistent phase tracker (`docs/seo-machine.md`) the user resumes across sessions.
 
 **Steps:**
 
 | # | Skill / Agent | Artifact |
 |---|---|---|
-| 1 | Foundation prerequisites (if missing) | Spawn `mktg-competitive-scanner` + `mktg-audience-researcher` in parallel → `brand/competitors.md`, `brand/audience.md`. Run `keyword-research` → `brand/keyword-plan.md`. |
+| 1 | Foundation prerequisites (if missing) | Spawn `mktg-competitive-scanner` + `mktg-audience-researcher` in parallel (Exa via `company-research` / `exa-search`) → `brand/competitors.md`, `brand/audience.md`. Run `keyword-research` → `brand/keyword-plan.md`. |
 | 2 | `seo-machine` (Initialize) | `docs/seo-machine.md` roadmap + `.seo/brand.md` + `.seo/link-inventory.md` + `.seo/config.json`. Stack auto-detected. |
-| 3 | `seo-machine` (Resume — per phase) | Generates the phase's pages (e.g. 12 `/alternatives/<competitor>` pages, or 8 `/for/<persona>` use-case pages) directly into the user's framework (Next.js / Astro / Rails+Inertia / markdown fallback). |
-| 4 | Per-phase quality gate — `mktg-content-reviewer` (voice) + `mktg-seo-analyst` (keyword adherence) | Scored, not rewritten. Spawn both in one message after each phase. |
+| 3 | `seo-machine` (Resume  -  per phase) | Generates the phase's pages (e.g. 12 `/alternatives/<competitor>` pages, or 8 `/for/<persona>` use-case pages) directly into the user's framework (Next.js / Astro / Rails+Inertia / markdown fallback). |
+| 4 | Per-phase quality gate  -  `mktg-content-reviewer` (voice) + `mktg-seo-analyst` (keyword adherence) | Scored, not rewritten. Spawn both in one message after each phase. |
 | 5 | Off-page checklist + technical audit | Chain into `off-page-seo` skill → spawns `mktg-backlink-prospector` agent to research competitor referring-domains → writes `.seo/backlink-targets.json`. Plus `scripts/link_audit.py` + `scripts/tech_audit.py` run locally; findings appended to `docs/seo-machine.md`. |
 | 6 | `seo-audit` (periodic, post-sprint) | Site-architecture review once pages are live. |
 
-**Resume protocol:** every subsequent /cmo session checks for `docs/seo-machine.md` — if it exists, seo-machine runs in Resume mode and picks the next pending phase. The user does not need to remember where they left off.
+**Resume protocol:** every subsequent /cmo session checks for `docs/seo-machine.md`  -  if it exists, seo-machine runs in Resume mode and picks the next pending phase. The user does not need to remember where they left off.
 
-**Stop (per phase):** all pages in the phase shipped, off-page checklist appended, quality gates passed. Then hand back: "Phase N complete — Y pages shipped. Phase N+1 is [pattern]. Run /cmo again when ready."
+**Stop (per phase):** all pages in the phase shipped, off-page checklist appended, quality gates passed. Then hand back: "Phase N complete  -  Y pages shipped. Phase N+1 is [pattern]. Run /cmo again when ready."
 
 **Picking the path:**
 
@@ -212,9 +212,9 @@ When the user wants an *operating system* for organic growth — not one article
 | "one article", "this week", "blog post" | A |
 | "machine", "system", "sprint", "dozens of pages", "programmatic", "operating system for SEO" | B |
 | User has 0 brand files | Run Path B Step 1 foundation first regardless |
-| User already has `docs/seo-machine.md` | Path B Resume — no question needed |
+| User already has `docs/seo-machine.md` | Path B Resume  -  no question needed |
 
-**Cost asymmetry — sequence quick wins before long builds:**
+**Cost asymmetry  -  sequence quick wins before long builds:**
 
 | Pattern | Build cost per page | Conversion intent | Sequence order |
 |---|---|---|---|
@@ -237,7 +237,7 @@ Beyond the linear sprint, /cmo runs these named sub-playbooks when the situation
 | **B.4 /for/ Persona Discovery Pipeline** | User has audience.md but no /for/ pages yet | `audience-research` (refresh if stale) → `keyword-research` for persona-keyed vocabulary → `seo-machine` Pattern B/C generation → `page-cro` review on the first 3 shipped. Ships persona-targeted landing pages from end to end. |
 | **B.5 Seasonal Sprint Replanner** | Triggered when `landscape.md` is refreshed (new competitors, market shift, category re-frame) | Re-rank pending phases in `docs/seo-machine.md` to chase the new landscape instead of continuing the stale plan. /cmo's learning-loop addition: stale roadmaps cost time, refreshing is cheap. |
 
-Each sub-playbook returns to the main Path B Resume loop afterward — they're situational overlays, not replacements.
+Each sub-playbook returns to the main Path B Resume loop afterward  -  they're situational overlays, not replacements.
 
 ---
 
@@ -249,7 +249,7 @@ Each sub-playbook returns to the main Path B Resume loop afterward — they're s
 
 | # | Skill | Artifact |
 |---|---|---|
-| 1 | `audience-research` (refresh if stale) | `brand/audience.md` — who reads this newsletter. |
+| 1 | `audience-research` (refresh if stale) | `brand/audience.md`  -  who reads this newsletter. |
 | 2 | `newsletter` | Newsletter strategy, template, cadence, growth playbook. |
 | 3 | `lead-magnet` | Free resource that captures emails (ebook, template, toolkit). |
 | 4 | `email-sequences` (welcome + nurture) | Automated onboarding for new subscribers. |
@@ -269,12 +269,12 @@ Each sub-playbook returns to the main Path B Resume loop afterward — they're s
 |---|---|---|
 | 0 | `mktg studio --dry-run --json --intent cmo --session <id>` | Preview. Resolves sibling `mktg-studio/bin/mktg-studio.ts`, `MKTG_STUDIO_BIN`, or PATH, confirms ports + exact CMO dashboard URL, and never spawns. |
 | 1 | `mktg studio --open --intent cmo --session <id>` | Spawn server (port 3001) + dashboard (port 3000). Studio opens at `http://localhost:3000/dashboard?mode=cmo&session=<id>`. |
-| 2 | Foundation research (if first run) | Spawn `mktg-brand-researcher`, `mktg-audience-researcher`, `mktg-competitive-scanner` in parallel per the standard first-run protocol. Each agent writes a brand file. |
+| 2 | Foundation research (if first run) | Spawn `mktg-brand-researcher`, `mktg-audience-researcher`, `mktg-competitive-scanner` in parallel. Agents use `exa-search` / `company-research` for live web research. Each writes a brand file. |
 | 3 | `POST /api/brand/refresh` after each agent | Tabs light up one by one as each brand file lands. User watches the dashboard populate in real time. |
 | 4 | `POST /api/navigate {tab: "pulse"}` | Bring the user to Pulse for the "do this next" card once foundation is complete. |
 | 5 | `POST /api/toast "Marketing brain ready"` | Confirmation. User now has a live dashboard + a populated brand. |
 
-**Stop:** Dashboard rendering the current primary surfaces (Pulse, Signals, Publish, Brand, Settings) with real data, Activity panel streaming /cmo events, Pulse has a prioritized next-action card. Hand back with: "Open `http://localhost:3000` — your marketing department is live. Want me to run the first recommended action?"
+**Stop:** Dashboard rendering the current primary surfaces (Pulse, Signals, Publish, Brand, Settings) with real data, Activity panel streaming /cmo events, Pulse has a prioritized next-action card. Hand back with: "Open `http://localhost:3000`  -  your marketing department is live. Want me to run the first recommended action?"
 
 See `rules/studio-integration.md` for the full POST contract.
 
@@ -282,17 +282,17 @@ See `rules/studio-integration.md` for the full POST contract.
 
 ## 12. Agent Team Coordination
 
-**When:** A multi-agent workflow needs to spawn several sub-agents in parallel and synthesize their outputs — most often on first run (3 research agents) or a content batch (content-reviewer + seo-analyst on the same draft).
+**When:** A multi-agent workflow needs to spawn several sub-agents in parallel and synthesize their outputs  -  most often on first run (3 research agents) or a content batch (content-reviewer + seo-analyst on the same draft).
 
 **Goal:** Parallelism without crossed wires, clean handoff from sub-agents back to /cmo, compounding written to `brand/learnings.md`.
 
 | Phase | Action | Why |
 |---|---|---|
 | 0 | Plan the split | Identify which sub-agents run in parallel vs sequentially. Research agents (3) are parallel; review agents (content-reviewer, seo-analyst) run after content lands. |
-| 1 | Spawn in ONE message | Use the Agent tool with N parallel `type: "tool_use"` blocks in a single message. Sequential spawns serialize — that defeats the purpose. |
+| 1 | Spawn in ONE message | Use the Agent tool with N parallel `type: "tool_use"` blocks in a single message. Sequential spawns serialize  -  that defeats the purpose. |
 | 2 | Wait on all | Do not proceed until every spawned agent returns. Partial results produce incoherent positioning. |
 | 3 | Synthesize | /cmo reads each agent's output, resolves contradictions explicitly (not silently), writes the unified view. |
-| 4 | `POST /api/activity/log` per agent | The Activity panel shows N rows — one per sub-agent — so the user can see the parallel work. |
+| 4 | `POST /api/activity/log` per agent | The Activity panel shows N rows  -  one per sub-agent  -  so the user can see the parallel work. |
 | 5 | Record cross-agent learnings | If an agent surfaced an insight the others missed, append to `brand/learnings.md` with a `--learning` flag so future runs start ahead. |
 
 **Sub-agent roster (current):**
@@ -306,7 +306,7 @@ See `rules/studio-integration.md` for the full POST contract.
 
 ---
 
-## Playbook selection — quick reference
+## Playbook selection  -  quick reference
 
 | Builder says… | Playbook |
 |---|---|
@@ -318,8 +318,8 @@ See `rules/studio-integration.md` for the full POST contract.
 | "brand visuals", "design my look" | **Visual Identity** |
 | "make a video", "TikTok" | **Video Content** |
 | "email system", "inbound email", "Resend setup" | **Email Infrastructure** |
-| "rank on Google", "AI search", "compete for [topic]", "one article" | **SEO Authority Build — Path A** |
-| "SEO machine", "build organic traffic", "programmatic SEO", "alternatives pages", "we need traffic" | **SEO Authority Build — Path B (seo-machine)** |
+| "rank on Google", "AI search", "compete for [topic]", "one article" | **SEO Authority Build  -  Path A** |
+| "SEO machine", "build organic traffic", "programmatic SEO", "alternatives pages", "we need traffic" | **SEO Authority Build  -  Path B (seo-machine)** |
 | "start a newsletter", "subscribers" | **Newsletter Launch** |
 | "show me the dashboard", "launch the studio", "visual mode" | **Studio Launch** |
 | "spawn the research team", "parallel research", "do this across agents" | **Agent Team Coordination** |

--- a/skills/cmo/rules/progressive-enhancement.md
+++ b/skills/cmo/rules/progressive-enhancement.md
@@ -1,12 +1,12 @@
 # Progressive Enhancement Ladder
 
-/cmo's capability depends on how populated `brand/` is. Brand memory enhances; it never gates. But be honest about what's possible at each rung — running SEO content at L0 produces generic slop; running it at L4 produces converting, grounded content.
+/cmo's capability depends on how populated `brand/` is. Brand memory enhances; it never gates. But be honest about what's possible at each rung  -  running SEO content at L0 produces generic slop; running it at L4 produces converting, grounded content.
 
-**Always check the ladder first.** Run `mktg status --json --fields brand.populated,brand.missing,brand.stale` to know where you stand. Announce the level to the builder: *"You're at L2 — I can route to X, Y, Z. A and B need another brand file first. Want me to run it now?"*
+**Always check the ladder first.** Run `mktg status --json --fields brand.populated,brand.missing,brand.stale` to know where you stand. Announce the level to the builder: *"You're at L2  -  I can route to X, Y, Z. A and B need another brand file first. Want me to run it now?"*
 
 ---
 
-## L0 — Zero context (`mktg init` just ran; all `brand/*.md` templates)
+## L0  -  Zero context (`mktg init` just ran; all `brand/*.md` templates)
 
 **What's populated:** nothing real. Templates only.
 
@@ -14,17 +14,18 @@
 
 | Skill | Reason |
 |---|---|
-| `brainstorm` | No brand needed — it's the explorer. |
+| `brainstorm` | No brand needed  -  it's the explorer. |
 | `brand-voice` | Foundation skill. Its job IS to populate voice-profile.md. |
-| `voice-extraction` | Standalone — reverse-engineers voice from external content. |
+| `voice-extraction` | Standalone  -  reverse-engineers voice from external content. |
 | `audience-research` | Foundation. Populates audience.md. |
 | `competitive-intel` | Foundation. Populates competitors.md. |
 | `landscape-scan` | Foundation. Populates landscape.md. |
 | `positioning-angles` | Needs voice + audience; queue it once those land. |
-| `mktg-x` | Utility — reads external X content. |
-| `firecrawl` | Utility — scrapes external content. |
-| `summarize` | Utility — compresses pasted text. |
-| `create-skill` | Meta — adds new skills to the playbook. |
+| `mktg-x` | Utility  -  reads external X content. |
+| `firecrawl` | Utility - scrapes external content. |
+| `exa-search` / `company-research` / `lead-generation` / `exa-contents` / `build-with-exa` | Utility - Exa research stack (needs `EXA_API_KEY` / MCP). |
+| `summarize` | Utility  -  compresses pasted text. |
+| `create-skill` | Meta  -  adds new skills to the playbook. |
 
 **What /cmo cannot do well:**
 - Write converting copy (no voice, no audience, no positioning).
@@ -37,7 +38,7 @@
 
 ---
 
-## L1 — Voice only (`brand/voice-profile.md` real)
+## L1  -  Voice only (`brand/voice-profile.md` real)
 
 **What's populated:** voice-profile.md with real patterns.
 
@@ -46,11 +47,11 @@
 | Skill | Reason |
 |---|---|
 | `direct-response-copy` | Can write copy in-voice now. Still generic targeting. |
-| `seo-content` | Same — voiced but audience/keyword-agnostic. |
+| `seo-content` | Same  -  voiced but audience/keyword-agnostic. |
 | `content-atomizer` | Can rewrite content in-voice across platforms. |
 | `creative` | Can generate copy variants in-voice. |
 | `newsletter` | Can draft in-voice. Topic selection is still guesswork. |
-| `lead-magnet` | Draft only — audience targeting is missing. |
+| `lead-magnet` | Draft only  -  audience targeting is missing. |
 
 **What's still gated:**
 - `positioning-angles` (needs audience too)
@@ -58,13 +59,13 @@
 - `launch-strategy` / `startup-launcher` (needs positioning)
 - `competitor-alternatives` (needs competitors.md)
 
-**Response quality:** *"Voice is locked in. Copy will sound like you. But I'm writing blind on who we're talking to — let me run /audience-research (5 min) so the next draft converts."*
+**Response quality:** *"Voice is locked in. Copy will sound like you. But I'm writing blind on who we're talking to  -  let me run /audience-research (5 min) so the next draft converts."*
 
-**Playbooks unlocked:** partial — Founder Voice Rebrand can finalize step 2; Content Engine can draft if user specifies topic manually.
+**Playbooks unlocked:** partial  -  Founder Voice Rebrand can finalize step 2; Content Engine can draft if user specifies topic manually.
 
 ---
 
-## L2 — Voice + audience (`audience.md` real)
+## L2  -  Voice + audience (`audience.md` real)
 
 **What /cmo adds:**
 
@@ -81,15 +82,15 @@
 - Any skill that needs competitive context (`competitor-alternatives`, full `launch-strategy`).
 - Claims-grounded content (no `landscape.md` + Claims Blacklist yet).
 
-**Response quality:** *"Voice + audience are in. I can target now. But I don't know who you're competing against — let me run /competitive-intel (parallel to your next ask, 5 min) so I don't accidentally position us against ourselves."*
+**Response quality:** *"Voice + audience are in. I can target now. But I don't know who you're competing against  -  let me run /competitive-intel (parallel to your next ask, 5 min) so I don't accidentally position us against ourselves."*
 
 **Playbooks unlocked:** Newsletter Launch, Conversion Audit (if the page exists), Visual Identity.
 
 ---
 
-## L3 — Voice + audience + competitors + landscape + positioning
+## L3  -  Voice + audience + competitors + landscape + positioning
 
-**What's populated:** 5 of 10 brand files — the full research foundation.
+**What's populated:** 5 of 10 brand files  -  the full research foundation.
 
 **What /cmo adds:**
 
@@ -104,17 +105,17 @@
 
 **What's still gated (minor):**
 - Visual skills work but without `creative-kit.md` produce generic styling.
-- `keyword-plan.md` may or may not be run yet — SEO Authority Build needs it.
+- `keyword-plan.md` may or may not be run yet  -  SEO Authority Build needs it.
 
-**Response quality:** *"Foundation is complete. Claims Blacklist is active (from landscape.md) — I'll enforce it on every piece of copy. Ready to run any playbook."*
+**Response quality:** *"Foundation is complete. Claims Blacklist is active (from landscape.md)  -  I'll enforce it on every piece of copy. Ready to run any playbook."*
 
 **Playbooks unlocked:** all except those requiring visual identity (Visual Identity, Video Content) or SEO-specific (SEO Authority Build requires keyword-plan first).
 
 ---
 
-## L4 — All 10 brand files current within freshness windows
+## L4  -  All 10 brand files current within freshness windows
 
-**What's populated:** `voice-profile.md`, `positioning.md`, `audience.md`, `competitors.md`, `landscape.md`, `keyword-plan.md`, `creative-kit.md`, `stack.md`, `assets.md` (append-only), `learnings.md` (append-only) — all real, none stale.
+**What's populated:** `voice-profile.md`, `positioning.md`, `audience.md`, `competitors.md`, `landscape.md`, `keyword-plan.md`, `creative-kit.md`, `stack.md`, `assets.md` (append-only), `learnings.md` (append-only)  -  all real, none stale.
 
 **What /cmo adds from L3:**
 
@@ -132,7 +133,7 @@
 | `mktg compete scan` | Landscape baseline to diff competitor changes against. |
 | `mktg plan next` | Has enough state to pick the single highest-priority task. |
 
-**Response quality:** *"You're at L4 — full CMO mode. I'll route with confidence. If it's a named playbook, I'll run it. If it's an ad-hoc ask, I'll pick the 1-2 best skills and execute."*
+**Response quality:** *"You're at L4  -  full CMO mode. I'll route with confidence. If it's a named playbook, I'll run it. If it's an ad-hoc ask, I'll pick the 1-2 best skills and execute."*
 
 **Playbooks unlocked:** all 10. Can compound work across multiple playbooks in one session.
 
@@ -156,7 +157,7 @@ Map the result:
 | + `competitors.md` + `landscape.md` (fresh ≤ 14 days) + `positioning.md` | L3 |
 | All 10 files populated AND within freshness (30d profiles, 90d config, append-only never stale) | L4 |
 
-**When landscape.md is stale (>14 days):** downgrade to "L3 but not L4 for content routing" — warn the user before running any copy skill.
+**When landscape.md is stale (>14 days):** downgrade to "L3 but not L4 for content routing"  -  warn the user before running any copy skill.
 
 **When any profile file (voice/positioning/audience/competitors/landscape) is stale (>30 days):** downgrade one level. Offer to refresh before routing.
 
@@ -164,17 +165,17 @@ Map the result:
 
 ## What "route with confidence" means
 
-At L3/L4, /cmo doesn't ask "what do you want to do" — it suggests. At L0-L2, /cmo explicitly names the missing input before running anything that needs it. The ladder is a contract: the builder knows what they'll get back at each level, and /cmo is honest about the quality ceiling.
+At L3/L4, /cmo doesn't ask "what do you want to do"  -  it suggests. At L0-L2, /cmo explicitly names the missing input before running anything that needs it. The ladder is a contract: the builder knows what they'll get back at each level, and /cmo is honest about the quality ceiling.
 
 ---
 
-## Ecosystem readiness — the orthogonal axis (E0–E4)
+## Ecosystem readiness  -  the orthogonal axis (E0–E4)
 
-Brand completeness (L0–L4 above) governs *content quality*. Ecosystem completeness (E0–E4 below) governs *what surfaces the builder can touch*. The two axes are independent — a project can be L4/E0 (brand-rich, CLI-only) or L1/E3 (brand-light, studio+native publish wired). /cmo routes across both.
+Brand completeness (L0–L4 above) governs *content quality*. Ecosystem completeness (E0–E4 below) governs *what surfaces the builder can touch*. The two axes are independent  -  a project can be L4/E0 (brand-rich, CLI-only) or L1/E3 (brand-light, studio+native publish wired). /cmo routes across both.
 
-Detect ecosystem level at activation with a single `mktg doctor --json` — it returns studio reachability, integration status, and sibling presence.
+Detect ecosystem level at activation with a single `mktg doctor --json`  -  it returns studio reachability, integration status, and sibling presence.
 
-### E0 — CLI only
+### E0  -  CLI only
 
 **State:** `mktg` installed, `brand/` may or may not exist, no studio, no native providers, no postiz, no other integrations.
 
@@ -184,25 +185,25 @@ Detect ecosystem level at activation with a single `mktg doctor --json` — it r
 
 **Response:** *"You're CLI-only right now. I can write and save everything locally. Want me to help set up Studio or native publish providers when you're ready?"*
 
-### E1 — CLI + brand bootstrapped
+### E1  -  CLI + brand bootstrapped
 
 **State:** E0 + `brand/` has real files (L1 or higher on the brand axis).
 
-**What this unlocks:** every content skill now has at least voice grounding. Nothing new on the ecosystem axis — this rung exists to acknowledge that a CLI-only project CAN still produce meaningful output if the brand axis is funded.
+**What this unlocks:** every content skill now has at least voice grounding. Nothing new on the ecosystem axis  -  this rung exists to acknowledge that a CLI-only project CAN still produce meaningful output if the brand axis is funded.
 
 **Response:** *"Brand is in. I can write in-voice without any studio or postiz. Content goes to files in `brand/assets.md` or wherever you route it."*
 
-### E2 — Studio attached
+### E2  -  Studio attached
 
 **State:** E1 + `mktg studio` running, `GET $STUDIO/api/health` returns 200 (`STUDIO` is the API base printed by the launcher, default `http://localhost:3001`).
 
-**What /cmo adds:** the five studio verbs from `rules/studio-integration.md` — activity, navigate, toast, brand-refresh, schema-fetch. Every skill run now mirrors to the Activity panel. Brand file writes trigger SWR invalidation. Tab switches are programmatic.
+**What /cmo adds:** the five studio verbs from `rules/studio-integration.md`  -  activity, navigate, toast, brand-refresh, schema-fetch. Every skill run now mirrors to the Activity panel. Brand file writes trigger SWR invalidation. Tab switches are programmatic.
 
 **What's still gated:** external network posting requires Postiz, Typefully, or a browser profile. Native publish can still store the local queue/history.
 
-**Response:** *"Studio is live. You'll see every skill run land on the Activity panel. Open `http://localhost:3000` to watch — I'll surface toasts when something interesting ships."*
+**Response:** *"Studio is live. You'll see every skill run land on the Activity panel. Open `http://localhost:3000` to watch  -  I'll surface toasts when something interesting ships."*
 
-### E3 — Studio + native publish connected
+### E3  -  Studio + native publish connected
 
 **State:** E2 + at least one native provider exists from `mktg publish --adapter mktg-native --list-integrations --json`.
 
@@ -210,9 +211,9 @@ Detect ecosystem level at activation with a single `mktg doctor --json` — it r
 
 **What's still gated:** actual external network posting still requires Postiz, Typefully, or browser automation. Cross-sibling workflows require E4.
 
-**Response:** *"Native publish is wired — I can queue X, TikTok, Instagram, Reddit, and LinkedIn content into this workspace. If you want it pushed to the real networks, I'll route through Postiz, Typefully, or browser automation and tell you exactly which path is active."*
+**Response:** *"Native publish is wired  -  I can queue X, TikTok, Instagram, Reddit, and LinkedIn content into this workspace. If you want it pushed to the real networks, I'll route through Postiz, Typefully, or browser automation and tell you exactly which path is active."*
 
-### E4 — Full ecosystem
+### E4  -  Full ecosystem
 
 **State:** E3 + a multi-repo marketing workspace. marketing-cli (the CLI), mktg-studio (the dashboard), and the marketing site each have their own `brand/` and their own git history.
 
@@ -220,12 +221,12 @@ Detect ecosystem level at activation with a single `mktg doctor --json` — it r
 
 **What's still gated:** nothing on the ecosystem axis. At E4, /cmo operates the full marketing department.
 
-**Response:** *"Full ecosystem is live — CLI, studio, and site. If I need to cross-reference, I'll use `--cwd` explicitly and announce the sibling. Your launch copy can reference any of them; I'll keep voices distinct."*
+**Response:** *"Full ecosystem is live  -  CLI, studio, and site. If I need to cross-reference, I'll use `--cwd` explicitly and announce the sibling. Your launch copy can reference any of them; I'll keep voices distinct."*
 
 ### Two-axis routing in practice
 
-A project at L4/E0 — full brand, no studio/postiz — gets polished copy shipped to files. Perfectly fine for a pre-launch stealth product.
+A project at L4/E0  -  full brand, no studio/postiz  -  gets polished copy shipped to files. Perfectly fine for a pre-launch stealth product.
 
-A project at L1/E3 — thin brand, full ecosystem — gets distribution-ready posts with voice-grounding but weak targeting. /cmo should recommend investing in the brand axis before scaling distribution, because E3 amplifies L1's weaknesses.
+A project at L1/E3  -  thin brand, full ecosystem  -  gets distribution-ready posts with voice-grounding but weak targeting. /cmo should recommend investing in the brand axis before scaling distribution, because E3 amplifies L1's weaknesses.
 
-The sweet spot for production use is L3+/E2+ — enough brand grounding for claims-aware copy, enough ecosystem for the builder to see and distribute what /cmo produces.
+The sweet spot for production use is L3+/E2+  -  enough brand grounding for claims-aware copy, enough ecosystem for the builder to see and distribute what /cmo produces.

--- a/skills/cmo/rules/recency-grounding.md
+++ b/skills/cmo/rules/recency-grounding.md
@@ -5,11 +5,11 @@ description: |
   /last30days + landscape.md are the corrective lenses for recency.
 ---
 
-# Recency Grounding — You Are Blind Past Your Training Cutoff
+# Recency Grounding  -  You Are Blind Past Your Training Cutoff
 
 ## The Core Problem
 
-You are an LLM. Your knowledge has a cutoff date. Everything after that date is a black hole — you don't know what happened, what changed, what launched, what died, what got acquired, what pivoted. You will confidently state things about the market that were true 6 months ago and are wrong today. You won't know they're wrong because you can't see the gap.
+You are an LLM. Your knowledge has a cutoff date. Everything after that date is a black hole  -  you don't know what happened, what changed, what launched, what died, what got acquired, what pivoted. You will confidently state things about the market that were true 6 months ago and are wrong today. You won't know they're wrong because you can't see the gap.
 
 This is the single biggest risk in marketing: making claims about a market that moved while you weren't looking.
 
@@ -17,24 +17,24 @@ This is the single biggest risk in marketing: making claims about a market that 
 
 Two tools bridge the gap:
 
-### 1. `/last30days` — Live Research
+### 1. `/last30days`  -  Live Research
 
-The `/last30days` skill searches Reddit, X, YouTube, TikTok, Instagram, Hacker News, Polymarket, Bluesky, and the web for the last 30 days of real discussion. It returns what people are *actually saying right now* — not what your training data says they said months ago.
+The `/last30days` skill searches Reddit, X, YouTube, TikTok, Instagram, Hacker News, Polymarket, Bluesky, and the web for the last 30 days of real discussion. It returns what people are *actually saying right now*  -  not what your training data says they said months ago.
 
 **Invoke it by name:** `Skill: last30days` with a research query as the argument.
 
-### 2. `brand/landscape.md` — Cached Ground Truth
+### 2. `brand/landscape.md`  -  Cached Ground Truth
 
-`/landscape-scan` chains `/last30days` to produce a structured ecosystem snapshot with a Claims Blacklist. This file is the cached version of recent reality — good for 14 days before it goes stale.
+`/landscape-scan` chains `/last30days` to produce a structured ecosystem snapshot with a Claims Blacklist. This file is the cached version of recent reality  -  good for 14 days before it goes stale.
 
 ## When to Ground
 
 ### Before making ecosystem claims
 
-Any time you're about to state something about competitors, market trends, pricing benchmarks, adoption rates, or industry shifts — ask yourself: "Do I know this from my training data, or from verified recent research?"
+Any time you're about to state something about competitors, market trends, pricing benchmarks, adoption rates, or industry shifts  -  ask yourself: "Do I know this from my training data, or from verified recent research?"
 
 If the answer is training data:
-1. Check `brand/landscape.md` — is it fresh (< 14 days)?
+1. Check `brand/landscape.md`  -  is it fresh (< 14 days)?
 2. If fresh: use it. The Claims Blacklist is the hard gate.
 3. If stale or missing: tell the user. "My knowledge of the market may be outdated. Want me to run `/landscape-scan` to get a current snapshot before we proceed?"
 
@@ -64,11 +64,11 @@ When you need to look something up, use the right tool for the job:
 | Need | Tool | Why |
 |------|------|-----|
 | Social + community signal (Reddit, X, YouTube, TikTok, HN) | `/last30days` (chains Parallel AI for web) | Engagement signals, real people talking |
-| Company research, competitor lookup, finding specific sites | Exa MCP (`company-research`, `get-code-context-exa`) | Best discovery engine — finds things other search misses |
-| General web queries the CMO needs answered | Exa MCP | Higher quality discovery than native WebSearch |
+| Company research, competitor lookup, finding specific sites | `company-research` / `exa-search` (Exa MCP) | Best discovery engine - finds things other search misses |
+| General web queries the CMO needs answered | `exa-search` (Exa MCP) | Higher quality discovery than native WebSearch |
 | Full ecosystem snapshot with Claims Blacklist | `/landscape-scan` (chains `/last30days`) | Structured ground truth for 14 days |
 
-**Never use Claude's native WebSearch tool.** Always use Exa MCP for web queries. Exa finds things native search misses — including direct competitors, niche tools, and specific companies that generic search buries.
+**Never use Claude's native WebSearch tool.** Always use `exa-search` / Exa MCP for web queries. Exa finds things native search misses - including direct competitors, niche tools, and specific companies that generic search buries.
 
 ## How to Use /last30days Directly
 
@@ -86,18 +86,21 @@ Examples:
 - "Is [claim from our copy] still accurate as of this month?"
 - "What's the current sentiment around [technology/trend]?"
 
-## How to Use Exa MCP Directly
+## How to Use Exa Skills / MCP
 
 For company research, competitor discovery, or any web query the CMO needs:
 
-- `company-research` skill — finds company info, competitors, news, financials
-- `get-code-context-exa` skill — finds code examples, API docs, GitHub repos
-- Exa MCP tools directly — for custom search queries with domain filtering
+- `company-research` - company info, competitors, news, financials, company lists (Exa Agent)
+- `exa-search` - open-ended semantic web search (`web_search_exa` / `web_search_advanced_exa`)
+- `exa-contents` - extract known URLs (`web_fetch_exa`)
+- `lead-generation` - ICP prospect lists + CSV
+- `build-with-exa` - API/SDK cookbook when integrating Exa into a product
+- Exa MCP tools directly when the skill is already loaded - custom filters / agent_run
 
 Examples:
 - "Find competitors to [product] in the [space] market"
 - "What does [company]'s pricing page say?"
-- "Find GitHub repos similar to [project]"
+- "Build a list of 50 ICP companies"
 
 ## The Decision Framework
 
@@ -115,9 +118,9 @@ Am I stating something about the world outside this project?
 
 **Bad CMO behavior:** "Your competitors are [list from training data]. The market is moving toward [trend from training data]. Let's position you as [angle based on stale competitive assumptions]."
 
-**Good CMO behavior:** "I see your landscape.md is 3 days old — good. Based on the current ecosystem snapshot, your competitors are [list from landscape.md]. The Claims Blacklist flags [specific wrong claims]. Let's position around [angle grounded in verified data]."
+**Good CMO behavior:** "I see your landscape.md is 3 days old  -  good. Based on the current ecosystem snapshot, your competitors are [list from landscape.md]. The Claims Blacklist flags [specific wrong claims]. Let's position around [angle grounded in verified data]."
 
-**Good CMO behavior (no landscape):** "Before we write competitive copy, I want to ground us in reality. My knowledge of the market may not reflect the last few months. Let me run `/landscape-scan` — it takes 2-3 minutes and will give us verified competitive data, recent market shifts, and a Claims Blacklist. Worth it?"
+**Good CMO behavior (no landscape):** "Before we write competitive copy, I want to ground us in reality. My knowledge of the market may not reflect the last few months. Let me run `/landscape-scan`  -  it takes 2-3 minutes and will give us verified competitive data, recent market shifts, and a Claims Blacklist. Worth it?"
 
 ## The Rule
 

--- a/skills/cmo/rules/safety.md
+++ b/skills/cmo/rules/safety.md
@@ -54,7 +54,7 @@ Do not reference or depend on SaaS dashboard tools. The system uses CLI-native t
 | Send email | `gws` | Mailchimp, ConvertKit, HubSpot |
 | Post to social | `ply`, `playwright-cli` | Buffer, Hootsuite, Later |
 | Generate video | `remotion`, `ffmpeg` | Loom, Canva Video |
-| Web research | Exa MCP (primary), `firecrawl` (scraping) | Ahrefs, SEMrush, Moz, Claude native WebSearch |
+| Web research | `exa-search` / Exa MCP (primary), `firecrawl` (scraping) | Ahrefs, SEMrush, Moz, Claude native WebSearch |
 | Analytics | PostHog, GA4 API | Dashboard-only tools |
 
 If a user mentions a SaaS tool they already use, that's fine — integrate with their existing stack. But never suggest or require a new SaaS signup.

--- a/skills/company-research/SKILL.md
+++ b/skills/company-research/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: company-research
+version: 0.1.0
+description: >
+  Research companies, competitors, funding, news, leadership, and market context
+  with Exa Agent and advanced search. Use when researching companies, competitor
+  analysis, market research, or building company lists. Writes findings the
+  caller can fold into brand/competitors.md or brand/landscape.md. Prefer this
+  over ad-hoc web search for company deep dives. Distinct from competitive-intel
+  (full brand competitive file methodology) - this skill is the Exa research
+  engine those foundation skills should call.
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Skill
+author: Exa Labs (ported by mktg)
+license: MIT
+user-invocable: true
+metadata:
+  openclaw:
+    emoji: 🏢
+---
+
+## On Activation
+
+1. Read `brand/positioning.md`, `brand/competitors.md`, and `brand/audience.md` if present. Ground queries in the brand's category and known competitors. All optional.
+2. Confirm Exa MCP Agent tools or `EXA_API_KEY`. If missing, stop with the install hint from Prerequisites / `mktg doctor`.
+3. Default to Exa Agent for deep dives and lists; use advanced search only for quick single lookups.
+4. When `/cmo` or a research agent owns the brand write, return structured findings + sources - do not silently overwrite `brand/competitors.md` unless the user asked to update brand memory.
+
+# Company Research
+
+
+## mktg runtime note
+
+Prefer **Exa MCP** when available (tools: `web_search_exa`, `web_search_advanced_exa`, `web_fetch_exa`, `agent_run`).
+If MCP Agent tools use the older create/wait/get names (`agent_create_run`, `agent_wait_for_run`, `agent_get_run_output`), use those equivalently.
+Without MCP, call the HTTP API with `x-api-key: $EXA_API_KEY` (`POST https://api.exa.ai/search`, `/contents`, `/agent`).
+Firecrawl remains the path for deep scrape of a **known URL** after Exa discovery.
+
+
+## Tool Selection (Critical)
+
+Two Exa surfaces, two jobs:
+
+- **Exa Agent** (`agent_run`, or legacy `agent_create_run` / `agent_wait_for_run` / `agent_get_run_output`) - the default for company research. Use it for deep dives, competitor analysis, multi-angle research (product + funding + news + people), and building company lists. One Agent run handles query decomposition, multi-step searching, and synthesis internally - do not orchestrate many manual searches for work an Agent run covers.
+- **`web_search_advanced_exa`** - quick, low-latency lookups: a fast `category: "company"` discovery pass, a single news check, or finding a homepage.
+
+Do NOT use other Exa tools.
+
+## Deep Dives and Lists: Exa Agent
+
+Agent runs are async: create the run, wait for it, then read the output.
+
+1. `agent_create_run` with a natural-language `query` and, when you want repeatable structure, an `outputSchema` (bound arrays with `maxItems`). Returns an `agent_run_...` ID.
+2. `agent_wait_for_run` until the run is `completed` (call again if still running).
+3. `agent_get_run_output` - read `output.text` or `output.structured`, plus `output.grounding` citations.
+
+Useful inputs: `systemPrompt` (source preferences, dedup rules), `input.exclusion` (companies to avoid), `previousRunId` (follow-up runs), `effort` (`"auto"` default; `"high"` for hard research).
+
+### Example: company deep dive
+
+```
+agent_create_run {
+  "query": "Research Anthropic: product lines, funding history and valuation, key executives, main competitors, and notable news from the last 6 months.",
+  "effort": "auto",
+  "outputSchema": {
+    "type": "object",
+    "properties": {
+      "overview": { "type": "string" },
+      "funding": { "type": "array", "maxItems": 10, "items": { "type": "object", "properties": { "round": { "type": "string" }, "amount": { "type": "string" }, "date": { "type": "string" } }, "required": ["round"] } },
+      "competitors": { "type": "array", "maxItems": 10, "items": { "type": "string" } },
+      "key_people": { "type": "array", "maxItems": 10, "items": { "type": "object", "properties": { "name": { "type": "string" }, "title": { "type": "string" } }, "required": ["name", "title"] } }
+    },
+    "required": ["overview", "competitors"]
+  }
+}
+```
+
+### Example: build a company list
+
+```
+agent_create_run {
+  "query": "Find 25 AI infrastructure startups headquartered in San Francisco. For each, include what they build and their latest funding stage.",
+  "effort": "auto",
+  "outputSchema": {
+    "type": "object",
+    "properties": {
+      "companies": {
+        "type": "array",
+        "maxItems": 25,
+        "items": {
+          "type": "object",
+          "properties": {
+            "name": { "type": "string" },
+            "website": { "type": "string", "format": "uri" },
+            "description": { "type": "string", "description": "in 12 words or less" },
+            "funding_stage": { "type": "string" }
+          },
+          "required": ["name", "website", "description"]
+        }
+      }
+    },
+    "required": ["companies"]
+  }
+}
+```
+
+## Quick Lookups: Advanced Search
+
+Use `web_search_advanced_exa` when a single fast search answers the question. Tune `numResults` to intent (a few → 10-20; comprehensive → 50-100; specified → match it).
+
+### Categories
+
+- `company` → homepages, rich metadata (headcount, location, funding, revenue)
+- `news` → press coverage, announcements
+- `people` → public professional profiles
+- No category (`type: "auto"`) → general web results, broader context
+
+Default to `type: "auto"`. Prefer `highlights` for content extraction; do not stack text + highlights + summary in one call.
+
+### Category-Specific Filter Restrictions
+
+Unsupported category/filter combinations return 400 errors:
+
+- `category: "company"` does not support published-date or crawl-date filters, `excludeDomains`, or exact-text filters; express constraints like "founded after 2020" in the query instead
+- `category: "people"` does not support published-date, crawl-date, domain, or exact-text filters; put all filtering in the natural-language query
+- Without a category (or with `news`), domain and date filters work fine
+
+### Examples
+
+Discovery pass:
+```
+web_search_advanced_exa {
+  "query": "AI infrastructure startups San Francisco",
+  "category": "company",
+  "numResults": 20,
+  "type": "auto"
+}
+```
+
+News check:
+```
+web_search_advanced_exa {
+  "query": "Anthropic AI safety",
+  "category": "news",
+  "numResults": 15,
+  "startPublishedDate": "2025-01-01"
+}
+```
+
+Key people:
+```
+web_search_advanced_exa {
+  "query": "VP Engineering AI infrastructure",
+  "category": "people",
+  "numResults": 20
+}
+```
+
+## Token Isolation
+
+Never dump raw search results into main context. Spawn Task agents for Advanced Search calls; for Agent runs, go straight from `output.structured` to the final answer.
+
+## Browser Fallback
+
+Fall back to Claude in Chrome only when content is auth-gated or requires JavaScript rendering.
+
+## Output Format
+
+Return:
+1) Results (structured list; one company per row)
+2) Sources (URLs; 1-line relevance each - use `output.grounding` from Agent runs)
+3) Notes (uncertainty/conflicts)
+
+## References
+
+- Exa Agent guide: https://docs.exa.ai/reference/agent-api-guide
+- Company Search reference: https://docs.exa.ai/reference/verticals/company-for-coding-agents
+- Exa MCP setup: https://docs.exa.ai/reference/exa-mcp
+- Full docs for LLMs: https://docs.exa.ai/llms.txt
+
+## Anti-Patterns
+
+| Anti-pattern | Why it fails | Instead |
+|---|---|---|
+| Using Claude native WebSearch instead of Exa | Misses niche competitors, companies, and cited sources Exa ranks highly. | Use this skill (or Exa MCP) for all open-ended web research. |
+| Calling Exa without `EXA_API_KEY` / MCP auth | Requests 401 and the agent invents results. | Set `EXA_API_KEY` (dashboard.exa.ai) or configure `.mcp.json`; surface the fix via `mktg doctor`. |
+| Dumping raw result JSON into the user chat | Burns context and hides the answer. | Synthesize; cite URLs from grounding / result lists. |
+
+## Attribution
+
+Ported from [exa-labs/agent-skills](https://github.com/exa-labs/agent-skills) - adapted for mktg's drop-in contract on 2026-07-18.
+
+Upstream commit: 390ffee2d7e1d0dce2ed8efe4994c2b3c1c0173b
+
+Drift detection: if the upstream skill changes, re-run `mktg-steal https://github.com/exa-labs/agent-skills` to evaluate the diff.

--- a/skills/competitive-intel/SKILL.md
+++ b/skills/competitive-intel/SKILL.md
@@ -21,7 +21,7 @@ Most founders either ignore competitors entirely ("we have no competition") or
 obsess over features without understanding messaging.
 
 This skill maps the competitive landscape at the messaging level. Not feature
-comparison tables — positioning, angles, language, channels, and gaps. The
+comparison tables  -  positioning, angles, language, channels, and gaps. The
 output feeds directly into positioning-angles and keyword-research to find
 white space.
 
@@ -34,9 +34,9 @@ No SaaS tools needed. Systematic web research.
 
 1. Check if `brand/` directory exists in the project root.
 2. If it does, read available files: `voice-profile.md`, `positioning.md`, `audience.md`, `competitors.md`, `creative-kit.md`, `stack.md`, `learnings.md`.
-3. Apply any loaded brand context to enhance research quality — use existing audience and positioning data to focus the competitive scan.
-4. If `brand/` does not exist, proceed without it — this skill works standalone.
-5. Read `brand/landscape.md` if it exists — check the Claims Blacklist before making ecosystem or competitive claims. If stale (>14 days) or missing, warn that market claims may be outdated.
+3. Apply any loaded brand context to enhance research quality  -  use existing audience and positioning data to focus the competitive scan.
+4. If `brand/` does not exist, proceed without it  -  this skill works standalone.
+5. Read `brand/landscape.md` if it exists  -  check the Claims Blacklist before making ecosystem or competitive claims. If stale (>14 days) or missing, warn that market claims may be outdated.
 
 ---
 
@@ -119,22 +119,22 @@ territory. Use after a Deep Teardown or when competitors.md already exists.
 
 Three categories:
 
-**Direct competitors** — solve the same problem for the same audience
+**Direct competitors**  -  solve the same problem for the same audience
 - Same product category, same target market
 - The ones your customers would name if asked "what else did you consider?"
 
-**Indirect competitors** — solve the same problem differently
+**Indirect competitors**  -  solve the same problem differently
 - Different approach, same outcome
 - Includes DIY, hiring a person, using a different category of tool
 
-**Aspirational competitors** — where you want to be
+**Aspirational competitors**  -  where you want to be
 - Larger companies in adjacent spaces
 - Brands whose positioning or execution you admire
 - Not necessarily competitive, but instructive
 
 **How to find them:**
 1. Ask the user: "Who do you consider your top 3 competitors?"
-2. If Exa MCP available: search for "[product category] + [target market]"
+2. If Exa available (`exa-search` / `company-research` / Exa MCP): search for "[product category] + [target market]"
 3. Search for "[product type] alternatives" and "[product type] vs"
 4. Check Product Hunt, G2, Capterra for the product category
 5. Look at who ranks for the target keywords
@@ -144,10 +144,10 @@ Three categories:
 For each key competitor (3-5), analyze the following (see `references/competitive-frameworks.md` for the full messaging teardown checklist, 2x2 map templates, and gap taxonomy):
 
 **Positioning & Messaging:**
-- Homepage headline — what's the primary claim?
-- Tagline — how do they summarize their value?
-- Hero copy — what transformation do they promise?
-- Key differentiator — what makes them "the one that [X]"?
+- Homepage headline  -  what's the primary claim?
+- Tagline  -  how do they summarize their value?
+- Hero copy  -  what transformation do they promise?
+- Key differentiator  -  what makes them "the one that [X]"?
 
 **Pricing & Packaging:**
 - Pricing model (free, freemium, subscription, one-time)
@@ -194,8 +194,8 @@ For each key competitor (3-5), analyze the following (see `references/competitiv
       └── Weakness: [where they fall short]
 
   Indirect Competitors
-  ├── [Alternative 1] — [how they solve it differently]
-  └── [Alternative 2] — [how they solve it differently]
+  ├── [Alternative 1]  -  [how they solve it differently]
+  └── [Alternative 2]  -  [how they solve it differently]
 
 ──────────────────────────────────────────────────
 ```
@@ -204,32 +204,32 @@ For each key competitor (3-5), analyze the following (see `references/competitiv
 
 This is the payoff. Cross-reference all competitor messaging to find:
 
-**Messaging gaps** — what nobody is saying:
+**Messaging gaps**  -  what nobody is saying:
 - Claims that are true for your product but no competitor makes
 - Audiences that nobody specifically targets
 - Pain points that nobody directly addresses
 - Angles that are conspicuously absent
 
-**Positioning gaps** — where nobody lives:
+**Positioning gaps**  -  where nobody lives:
 - Map competitors on 2x2 matrices (e.g., simple↔complex × cheap↔expensive)
 - Find the quadrant with no competitor
-- Identify the "anti-positioning" — what would be the opposite of every competitor?
+- Identify the "anti-positioning"  -  what would be the opposite of every competitor?
 
-**Channel gaps** — where nobody shows up:
+**Channel gaps**  -  where nobody shows up:
 - Platforms where the audience exists but competitors don't post
 - Content formats nobody uses (video, podcast, interactive tools)
 - Communities nobody engages with
 
-**Pricing gaps** — where nobody charges:
+**Pricing gaps**  -  where nobody charges:
 - Price points between existing tiers
 - Packaging models nobody offers (lifetime, usage-based, free tier)
 
 ### Step 5: Synthesize differentiation opportunities
 
 Rank the gaps by:
-1. **Relevance** — does this gap matter to our audience?
-2. **Defensibility** — can we own this position long-term?
-3. **Clarity** — can we explain this in one sentence?
+1. **Relevance**  -  does this gap matter to our audience?
+2. **Defensibility**  -  can we own this position long-term?
+3. **Clarity**  -  can we explain this in one sentence?
 
 Present top 3-5 differentiation opportunities with a starred recommendation.
 
@@ -249,7 +249,7 @@ competitors_analyzed: [number]
 primary_gap: [one-line summary of biggest opportunity]
 ---
 
-# Competitive Intelligence — [Product/Project Name]
+# Competitive Intelligence  -  [Product/Project Name]
 
 ## Competitor Teardowns
 
@@ -274,7 +274,7 @@ primary_gap: [one-line summary of biggest opportunity]
 - "[Claim]"
 
 ### Partially Claimed (1-2 competitors)
-- "[Claim]" — used by [Competitor]
+- "[Claim]"  -  used by [Competitor]
 
 ### Underexploited Territory
 - [Gap 1]
@@ -285,9 +285,9 @@ primary_gap: [one-line summary of biggest opportunity]
 
 ## Differentiation Opportunities
 
-1. ★ **[Top opportunity]** — [why this is the best gap to own]
-2. **[Second opportunity]** — [reasoning]
-3. **[Third opportunity]** — [reasoning]
+1. ★ **[Top opportunity]**  -  [why this is the best gap to own]
+2. **[Second opportunity]**  -  [reasoning]
+3. **[Third opportunity]**  -  [reasoning]
 
 ---
 
@@ -310,7 +310,7 @@ primary_gap: [one-line summary of biggest opportunity]
 | L0 | Product name only | Basic competitor list, surface-level analysis |
 | L1 | + product description, target market | Focused competitor search, relevant comparisons |
 | L2 | + audience.md, voice-profile.md | Audience-aware analysis, positioning-aware gaps |
-| L3 | + web research via Exa MCP | Live data, real messaging, verified claims |
+| L3 | + web research via `exa-search` / `company-research` | Live data, real messaging, verified claims |
 | L4 | + existing competitors.md (update) | Evolved intel with trend tracking over time |
 
 ---
@@ -331,10 +331,10 @@ primary_gap: [one-line summary of biggest opportunity]
 
 ## What this skill is NOT
 
-- **Not a feature comparison** — Feature matrices are commodity analysis. This skill maps messaging, positioning, and strategic gaps — the layer that actually drives differentiation decisions.
-- **Not market research** — This focuses on competitive messaging and positioning. For audience research, use /audience-research. For market sizing and trend analysis, that's a different skill.
-- **Not a one-time snapshot** — Competitors evolve their messaging. Run this again before major launches, after competitor funding rounds, or when your positioning feels stale.
-- **Not a strategy document** — The output is intelligence, not a plan. Use /positioning-angles to act on the gaps this skill finds.
+- **Not a feature comparison**  -  Feature matrices are commodity analysis. This skill maps messaging, positioning, and strategic gaps  -  the layer that actually drives differentiation decisions.
+- **Not market research**  -  This focuses on competitive messaging and positioning. For audience research, use /audience-research. For market sizing and trend analysis, that's a different skill.
+- **Not a one-time snapshot**  -  Competitors evolve their messaging. Run this again before major launches, after competitor funding rounds, or when your positioning feels stale.
+- **Not a strategy document**  -  The output is intelligence, not a plan. Use /positioning-angles to act on the gaps this skill finds.
 
 ---
 
@@ -386,7 +386,7 @@ primary_gap: [one-line summary of biggest opportunity]
 
 ## Web search fallback
 
-If web search / Exa MCP is unavailable:
+If web search / Exa (`EXA_API_KEY` / MCP) is unavailable:
 
 1. Ask the user for competitor names and URLs directly.
 2. If the user provides URLs, attempt to fetch and analyze them.
@@ -419,10 +419,10 @@ After delivering the competitive intel:
 
 ## Safety rules
 
-- Never fabricate competitor data — positioning decisions built on false competitive intel lead to differentiation claims that collapse on contact with the market. If you can't verify a claim, say so.
-- Never present assumptions as facts — the user may make pricing, positioning, or launch decisions based on this analysis. Mark unverified information clearly so they know what to double-check.
-- Never copy competitor content verbatim beyond short quotes — this is analysis, not plagiarism. Short quotes for messaging analysis are fair use; copying blocks of content is not.
-- Never write competitive data from one project into another project's brand/ — competitive landscapes are project-specific. Cross-contamination corrupts strategy.
-- Always check `--cwd` context if provided — the working directory determines which brand/ to read and write.
-- If Exa MCP is unavailable, follow the web search fallback section above — the skill still produces useful output from user knowledge and brand files.
-- Focus on messaging and positioning, not feature-by-feature comparisons — feature tables are commodity analysis anyone can build. Messaging-level competitive intel is what drives differentiation and is much harder to find elsewhere.
+- Never fabricate competitor data  -  positioning decisions built on false competitive intel lead to differentiation claims that collapse on contact with the market. If you can't verify a claim, say so.
+- Never present assumptions as facts  -  the user may make pricing, positioning, or launch decisions based on this analysis. Mark unverified information clearly so they know what to double-check.
+- Never copy competitor content verbatim beyond short quotes  -  this is analysis, not plagiarism. Short quotes for messaging analysis are fair use; copying blocks of content is not.
+- Never write competitive data from one project into another project's brand/  -  competitive landscapes are project-specific. Cross-contamination corrupts strategy.
+- Always check `--cwd` context if provided  -  the working directory determines which brand/ to read and write.
+- If Exa is unavailable, follow the web search fallback section above - the skill still produces useful output from user knowledge and brand files.
+- Focus on messaging and positioning, not feature-by-feature comparisons  -  feature tables are commodity analysis anyone can build. Messaging-level competitive intel is what drives differentiation and is much harder to find elsewhere.

--- a/skills/exa-contents/SKILL.md
+++ b/skills/exa-contents/SKILL.md
@@ -1,0 +1,226 @@
+---
+name: exa-contents
+version: 0.1.0
+description: >
+  Call Exa Contents (POST /contents) for LLM-ready extraction from known URLs:
+  text, highlights, summaries, links, image links, subpages, freshness-controlled
+  crawl. Use when the agent already has URLs. Prefer Exa MCP web_fetch_exa when
+  available; otherwise raw HTTP with EXA_API_KEY. NOT for open-ended discovery
+  (use exa-search) or auth-walled X/Twitter (use mktg-x). For full-site crawl of
+  a known domain, firecrawl may be better.
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Skill
+author: Exa Labs (ported by mktg)
+license: MIT
+user-invocable: true
+metadata:
+  openclaw:
+    emoji: 📄
+---
+
+## On Activation
+
+1. Read `brand/competitors.md` / `brand/landscape.md` if present for URL shortlists. Optional.
+2. Confirm Exa auth (MCP or `EXA_API_KEY`) via `mktg doctor` if unsure.
+3. Prefer MCP `web_fetch_exa` when available; otherwise use the cURL examples below.
+4. If the page is auth-walled (X/Twitter login stub), route to `mktg-x` instead.
+
+# Exa Contents
+
+> Requires API key: Get one at https://dashboard.exa.ai/api-keys
+>
+> Header: `x-api-key: $EXA_API_KEY`
+
+Use `POST https://api.exa.ai/contents` when the agent already knows the URLs and needs clean, LLM-ready extraction without running a new search. Start with one content mode: `highlights` for compact agent context, `text` for broad page context, or `summary` for Exa-side compression.
+
+## Quick Start (cURL)
+
+### Basic text extraction
+
+```bash
+curl -sS -X POST "https://api.exa.ai/contents" \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: $EXA_API_KEY" \
+  -d '{
+    "urls": ["https://example.com"],
+    "text": true
+  }'
+```
+
+### Highlights with freshness control
+
+```bash
+curl -sS -X POST "https://api.exa.ai/contents" \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: $EXA_API_KEY" \
+  -d '{
+    "urls": ["https://arxiv.org/abs/2307.06435"],
+    "highlights": {
+      "query": "methodology and results"
+    },
+    "maxAgeHours": 24,
+    "livecrawlTimeout": 12000
+  }'
+```
+
+## Endpoint
+
+```text
+POST https://api.exa.ai/contents
+```
+
+Authentication: `x-api-key: <API_KEY>` header. Exa also accepts `Authorization: Bearer <API_KEY>`, but prefer `x-api-key` in cURL examples for consistency.
+
+Use this endpoint for known-URL extraction. If the agent needs discovery or ranking first, use `POST /search`.
+
+## Parameters
+
+### Core request parameters
+
+| Parameter | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `urls` | string[] | Yes | - | URLs to extract content from. Use this for known URLs. |
+| `text` | boolean or object | No | - | Return full page text as markdown. Object form supports `maxCharacters`, `includeHtmlTags`, `verbosity`, `includeSections`, and `excludeSections`. |
+| `highlights` | boolean or object | No | - | Return key excerpts. Prefer `true` for agent workflows unless a custom focus is needed. |
+| `summary` | boolean or object | No | - | Return per-page LLM summaries. Use when the caller wants Exa-side compression or structured extraction. |
+| `maxAgeHours` | integer | No | - | Freshness control. `0` always live crawls; `-1` uses cache only; omit for default cache-first behavior with crawl fallback. |
+| `livecrawlTimeout` | integer | No | `10000` | Timeout for live crawling in milliseconds. Use `10000` to `15000` for most freshness-sensitive calls. |
+| `subpages` | integer | No | `0` | Number of linked subpages to crawl from each URL. |
+| `subpageTarget` | string or string[] | No | - | Terms used to prioritize which subpages matter, such as `["api", "reference", "pricing"]`. |
+| `extras.links` | integer | No | `0` | Number of links to extract from each page. |
+| `extras.imageLinks` | integer | No | `0` | Number of image URLs to extract from each page. |
+| `compliance` | string | No | - | Enterprise-only compliance mode, such as `hipaa`, when enabled for the account. |
+
+### Text object options
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| `maxCharacters` | integer | - | Character limit for returned text. Use this instead of `tokensNum`. |
+| `includeHtmlTags` | boolean | `false` | Preserve HTML tags in output. |
+| `verbosity` | string | `compact` | `compact`, `standard`, or `full`. Pair fresh section-aware extraction with `maxAgeHours: 0`. |
+| `includeSections` | string[] | - | Only include selected sections: `header`, `navigation`, `banner`, `body`, `sidebar`, `footer`, `metadata`. |
+| `excludeSections` | string[] | - | Exclude selected sections from the same section list. |
+
+### Highlights object options
+
+Prefer `highlights: true` for the highest-quality default. Only use object form when the agent needs a custom focus or budget.
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| `query` | string | - | Custom query guiding which excerpts are returned. |
+| `maxCharacters` | integer | - | Cap highlight characters per URL. Omit unless the caller has a strict budget. |
+
+### Summary object options
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| `query` | string | - | Custom query for the summary. |
+| `schema` | object | - | JSON Schema for structured per-page summaries. |
+
+## Content Modes
+
+On `/contents`, `text`, `highlights`, and `summary` are top-level request fields.
+
+| Mode | Best for | Notes |
+| --- | --- | --- |
+| `text` | Deep analysis and broad page context | Use `maxCharacters` to keep payloads bounded. |
+| `highlights` | Agent workflows and factual lookups | Most token-efficient default. Excerpts are grounded in the source page. |
+| `summary` | Compression or structured per-page extraction | Adds Exa-side synthesis per page. |
+
+Avoid requesting multiple modes unless the caller truly needs multiple views of the same page.
+
+## Freshness and Crawling
+
+Use `maxAgeHours` as the normative freshness control.
+
+| Value | Behavior |
+| --- | --- |
+| omitted | Use default cache-first behavior with crawl fallback when needed. |
+| positive integer | Use cache if it is less than N hours old, otherwise live crawl. |
+| `0` | Always live crawl. Highest freshness, higher latency. |
+| `-1` | Cache only. Fastest, but fails if no cached content exists. |
+
+Set `livecrawlTimeout` when live crawling should not block past a fixed budget.
+
+### Subpages and extras
+
+Use `subpages` and `subpageTarget` when linked pages matter.
+
+```bash
+curl -sS -X POST "https://api.exa.ai/contents" \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: $EXA_API_KEY" \
+  -d '{
+    "urls": ["https://docs.example.com"],
+    "text": {
+      "maxCharacters": 5000
+    },
+    "subpages": 10,
+    "subpageTarget": ["api", "reference", "guide"],
+    "extras": {
+      "links": 10,
+      "imageLinks": 5
+    }
+  }'
+```
+
+Start with `subpages` around `5` to `10`, then increase only when the caller needs broader site coverage.
+
+## Response Fields and Statuses
+
+Inspect `statuses` even when the HTTP status is 200. The endpoint can succeed for one URL and fail for another in the same request.
+
+```bash
+curl -sS -X POST "https://api.exa.ai/contents" \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: $EXA_API_KEY" \
+  -d '{
+    "urls": ["https://example.com", "https://bad.example"],
+    "highlights": true
+  }' | jq '{results, statuses}'
+```
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `requestId` | string | Unique request identifier. |
+| `results` | array | Extracted content result objects. |
+| `results[].title` | string | Page title. |
+| `results[].url` | string | Page URL. |
+| `results[].publishedDate` | string or null | Estimated publication date when available. |
+| `results[].author` | string or null | Author when available. |
+| `results[].text` | string | Returned when `text` is requested. |
+| `results[].highlights` | string[] | Returned when `highlights` is requested. |
+| `results[].highlightScores` | number[] | Similarity scores for highlights. |
+| `results[].summary` | string | Returned when `summary` is requested. |
+| `results[].subpages` | array | Nested result objects from subpage crawling. |
+| `results[].extras.links` | string[] | Extracted links when requested. |
+| `statuses` | array | Per-URL success or error states. Always inspect this field. |
+| `statuses[].id` | string | Requested URL. |
+| `statuses[].status` | string | `success` or `error`. |
+| `statuses[].error.tag` | string | Error type for failed URLs. |
+| `statuses[].error.httpStatusCode` | integer or null | HTTP code associated with a per-URL failure. |
+| `costDollars.total` | number | Total request cost when returned. |
+
+Common per-URL error tags include `CRAWL_NOT_FOUND`, `CRAWL_TIMEOUT`, `CRAWL_LIVECRAWL_TIMEOUT`, `SOURCE_NOT_AVAILABLE`, `UNSUPPORTED_URL`, and `CRAWL_UNKNOWN_ERROR`.
+
+## Anti-Patterns
+- Keep `text`, `highlights`, and `summary` at the top level on `/contents`.
+- Do not wrap extraction options in a `contents` object; that nesting belongs to `/search`.
+- Do not assume HTTP 200 means every URL succeeded; inspect `statuses`.
+- Do not send `stream: true`; `/contents` is not a streaming endpoint.
+- Do not send `tokensNum`; use `text.maxCharacters` to cap extracted text.
+- Do not use `useAutoprompt`, `numSentences`, `highlightsPerUrl`, or older `livecrawl` string values in new requests.
+- Prefer `maxAgeHours` for freshness and pair it with `livecrawlTimeout` when crawl latency matters.
+- Use `subpageTarget` with `subpages`; otherwise subpage selection is best effort.
+- Pick one of `highlights`, `text`, or `summary` by default. Stack modes only when the caller truly needs multiple views of each page.
+
+## Attribution
+
+Ported from [exa-labs/agent-skills](https://github.com/exa-labs/agent-skills) - adapted for mktg's drop-in contract on 2026-07-18.
+
+Upstream commit: 390ffee2d7e1d0dce2ed8efe4994c2b3c1c0173b
+
+Drift detection: if the upstream skill changes, re-run `mktg-steal https://github.com/exa-labs/agent-skills` to evaluate the diff.

--- a/skills/exa-search/SKILL.md
+++ b/skills/exa-search/SKILL.md
@@ -1,0 +1,320 @@
+---
+name: exa-search
+version: 0.1.0
+description: >
+  Call Exa Search (POST /search) for semantic web retrieval with ranked results,
+  filters, freshness, highlights/text, structured output, or streaming. Use when
+  the agent needs open-ended web search, competitor discovery, news, people, or
+  research papers and does not already have URLs. Prefer Exa MCP web_search_exa /
+  web_search_advanced_exa when available; otherwise raw HTTP with EXA_API_KEY.
+  NOT for known-URL extraction (use exa-contents or firecrawl) or multi-step
+  list-building (use company-research / lead-generation / Agent API).
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Skill
+author: Exa Labs (ported by mktg)
+license: MIT
+user-invocable: true
+metadata:
+  openclaw:
+    emoji: 🔍
+---
+
+## On Activation
+
+1. Read `brand/positioning.md`, `brand/competitors.md`, and `brand/landscape.md` if present. Use them to sharpen queries and exclusions. All optional - works at zero brand context.
+2. Confirm Exa auth: Exa MCP connected, or `EXA_API_KEY` set (`mktg doctor --json --fields integrations`). If neither, stop and surface: get a key at https://dashboard.exa.ai/api-keys then `export EXA_API_KEY=...`.
+3. Prefer MCP tools when present; otherwise use the cURL examples below.
+4. After discovery, chain `firecrawl` or `exa-contents` only when a known URL needs deeper extraction.
+
+# Exa Search
+
+> Requires API key: Get one at https://dashboard.exa.ai/api-keys
+>
+> Header: `x-api-key: $EXA_API_KEY`
+
+Use `POST https://api.exa.ai/search` for semantic web retrieval, ranked results, and optional result-level extraction in one raw HTTP call. Start with `type: "auto"` for general retrieval. Add `contents` only when the caller needs page text, highlights, summaries, freshness-controlled crawling, subpages, or extracted links.
+
+## Quick Start (cURL)
+
+### Basic search
+
+```bash
+curl -sS -X POST "https://api.exa.ai/search" \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: $EXA_API_KEY" \
+  -d '{
+    "query": "latest developments in LLMs",
+    "type": "auto",
+    "numResults": 10
+  }'
+```
+
+### Search with highlights
+
+```bash
+curl -sS -X POST "https://api.exa.ai/search" \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: $EXA_API_KEY" \
+  -d '{
+    "query": "latest developments in LLMs",
+    "type": "auto",
+    "numResults": 5,
+    "contents": {
+      "highlights": true
+    }
+  }'
+```
+
+### With filters and freshness
+
+```bash
+curl -sS -X POST "https://api.exa.ai/search" \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: $EXA_API_KEY" \
+  -d '{
+    "query": "AI regulation policy updates",
+    "type": "auto",
+    "category": "news",
+    "numResults": 10,
+    "includeDomains": ["reuters.com", "bbc.com"],
+    "startPublishedDate": "2025-01-01",
+    "contents": {
+      "text": {
+        "maxCharacters": 2000
+      },
+      "maxAgeHours": 24,
+      "livecrawlTimeout": 12000
+    }
+  }'
+```
+
+### Deep search
+
+```bash
+curl -sS -X POST "https://api.exa.ai/search" \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: $EXA_API_KEY" \
+  -d '{
+    "query": "map the major technical and commercial tradeoffs in sodium-ion batteries for grid storage",
+    "type": "deep",
+    "numResults": 8
+  }'
+```
+
+## Endpoint
+
+```text
+POST https://api.exa.ai/search
+```
+
+Authentication: `x-api-key: <API_KEY>` header. Exa also accepts `Authorization: Bearer <API_KEY>`, but prefer `x-api-key` in cURL examples for consistency.
+
+Use this endpoint when the agent needs search results. If the agent already has URLs and only needs extraction, use `POST /contents` instead.
+
+## Parameters
+
+### Core request parameters
+
+| Parameter | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `query` | string | Yes | - | Natural-language search query. Long, semantically rich descriptions work well. |
+| `type` | string | No | `auto` | Search method: `auto`, `fast`, `instant`, `deep-lite`, `deep`, or `deep-reasoning`. |
+| `numResults` | integer | No | `10` | Number of results to return. Use small values for agent loops; maximum is 100. |
+| `category` | string | No | - | Specialized result type: `company`, `people`, `research paper`, `news`, `personal site`, or `financial report`. |
+| `includeDomains` | string[] | No | - | Only return results from these domains, paths, or wildcard patterns. Max 1200. |
+| `excludeDomains` | string[] | No | - | Exclude these domains, paths, or wildcard patterns. Max 1200. |
+| `startPublishedDate` | string | No | - | ISO 8601 lower bound for result publication date. |
+| `endPublishedDate` | string | No | - | ISO 8601 upper bound for result publication date. |
+| `userLocation` | string | No | - | Two-letter ISO country code such as `US` or `GB`. |
+| `moderation` | boolean | No | `false` | Filter unsafe content from results. |
+| `additionalQueries` | string[] | No | - | Extra query variants for deep-search variants. Use alongside the main `query`. |
+| `systemPrompt` | string | No | - | Instructions for synthesized output and deep-search planning, such as source preferences. |
+| `outputSchema` | object | No | - | JSON Schema controlling `output.content`. Adds synthesized output and grounding. |
+| `stream` | boolean | No | `false` | If `true`, returns SSE instead of a single JSON response. |
+| `compliance` | string | No | - | Enterprise-only compliance mode, such as `hipaa`, when enabled for the account. |
+
+### Content parameters nested under `contents`
+
+On `/search`, `text`, `highlights`, and `summary` must be nested under `contents`.
+
+| Parameter | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `contents.text` | boolean or object | No | - | Return full page text as markdown. Object form supports `maxCharacters`, `includeHtmlTags`, `verbosity`, `includeSections`, and `excludeSections`. |
+| `contents.highlights` | boolean or object | No | - | Return query-relevant excerpts. Prefer `true` for agent workflows unless a fixed character budget is required. |
+| `contents.summary` | boolean or object | No | - | Return per-result LLM summaries. Use sparingly because each result adds synthesis work. |
+| `contents.maxAgeHours` | integer | No | - | Freshness control. `0` always live crawls; `-1` uses cache only; omit for default cache-first behavior with crawl fallback. |
+| `contents.livecrawlTimeout` | integer | No | `10000` | Timeout for live crawling in milliseconds. Use `10000` to `15000` for most freshness-sensitive calls. |
+| `contents.subpages` | integer | No | `0` | Number of linked subpages to crawl per result. |
+| `contents.subpageTarget` | string or string[] | No | - | Terms used to prioritize which subpages matter, such as `["api", "pricing"]`. |
+| `contents.extras.links` | integer | No | `0` | Number of links to extract from each result page. |
+| `contents.extras.imageLinks` | integer | No | `0` | Number of image URLs to extract from each result page. |
+
+### Text object options
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| `maxCharacters` | integer | - | Character limit for returned text. Use this instead of `tokensNum`. |
+| `includeHtmlTags` | boolean | `false` | Preserve HTML tags in output. |
+| `verbosity` | string | `compact` | `compact`, `standard`, or `full`. Pair fresh section-aware extraction with `contents.maxAgeHours: 0`. |
+| `includeSections` | string[] | - | Only include selected sections: `header`, `navigation`, `banner`, `body`, `sidebar`, `footer`, `metadata`. |
+| `excludeSections` | string[] | - | Exclude selected sections from the same section list. |
+
+### Highlights object options
+
+Prefer `contents.highlights: true` for the highest-quality default. Only use object form when the agent needs a custom focus or budget.
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| `query` | string | - | Custom query guiding which excerpts are returned. |
+| `maxCharacters` | integer | - | Cap highlight characters per URL. Omit unless the caller has a strict budget. |
+
+### Summary object options
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| `query` | string | - | Custom query for the summary. |
+| `schema` | object | - | JSON Schema for structured per-result summaries. |
+
+## Search Types
+
+Search `type` controls the retrieval and synthesis mode. Pick the mode for the workflow, not just the output format. `outputSchema` can be used with any search type; use deeper modes when the search process itself needs more planning, synthesis, or reasoning.
+
+| Type | Best for | Tradeoff |
+| --- | --- | --- |
+| `auto` | General default search and most new integrations | Balances speed and quality without requiring the caller to tune retrieval strategy. |
+| `fast` | Low-latency agent loops and product paths | Faster than `auto`; use when responsiveness matters more than maximum reasoning depth. |
+| `instant` | Real-time UI, chat, voice, and autocomplete-style paths | Lowest latency path; use for quick retrieval rather than deep synthesis. |
+| `deep-lite` | Lightweight research or synthesis | Adds more planning and synthesis than `auto` while staying lighter than full `deep`. |
+| `deep` | Multi-step research, comparisons, and synthesis-heavy retrieval | Higher latency; better when the query needs exploration across several sources. |
+| `deep-reasoning` | Hard research tasks with high ambiguity or complex tradeoffs | Highest latency and reasoning depth. |
+
+Use `auto` unless latency or reasoning depth is the primary constraint. Use `fast` or `instant` for time-sensitive calls. Use `deep`, `deep-lite`, or `deep-reasoning` when the query needs multi-step source discovery, comparison, or synthesis.
+
+### Mode-only examples
+
+```json
+{
+  "query": "recent product launches from major AI chip companies",
+  "type": "fast",
+  "numResults": 5
+}
+```
+
+```json
+{
+  "query": "compare competing explanations for the recent rise in grid-scale battery deployments",
+  "type": "deep",
+  "numResults": 8
+}
+```
+
+## Structured Output
+
+Use `systemPrompt` for behavior and `outputSchema` for shape.
+
+```bash
+curl -sS -X POST "https://api.exa.ai/search" \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: $EXA_API_KEY" \
+  -d '{
+    "query": "compare the latest frontier AI model releases",
+    "type": "deep",
+    "systemPrompt": "Prefer official sources and avoid duplicate results.",
+    "outputSchema": {
+      "type": "object",
+      "properties": {
+        "models": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": { "type": "string" },
+              "notable_claims": {
+                "type": "array",
+                "items": { "type": "string" }
+              }
+            },
+            "required": ["name", "notable_claims"]
+          }
+        }
+      },
+      "required": ["models"]
+    },
+    "contents": {
+      "highlights": true
+    }
+  }'
+```
+
+Keep schemas compact and bounded. Do not add citation fields to the schema; grounding is returned separately in `output.grounding`.
+
+## Streaming
+
+Streaming applies to synthesized output, so include `outputSchema` along with `-N`, `Accept: text/event-stream`, and `stream: true`. Without `outputSchema`, the endpoint returns the normal JSON search response even when `stream` is `true`.
+
+```bash
+curl -sS -N -X POST "https://api.exa.ai/search" \
+  -H "Content-Type: application/json" \
+  -H "Accept: text/event-stream" \
+  -H "x-api-key: $EXA_API_KEY" \
+  -d '{
+    "query": "recent grid-scale battery deployments",
+    "type": "deep",
+    "stream": true,
+    "outputSchema": {
+      "type": "object",
+      "properties": {
+        "summary": { "type": "string" }
+      },
+      "required": ["summary"]
+    },
+    "contents": {
+      "highlights": true
+    }
+  }'
+```
+
+Treat streaming as SSE rather than JSON. Each `data:` frame contains an OpenAI-compatible chat completion chunk; read partial text from `choices[0].delta.content` and handle completion or error frames defensively.
+
+## Response Fields
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `requestId` | string | Unique request identifier. |
+| `results` | array | Ranked result objects. |
+| `results[].title` | string | Page title. |
+| `results[].url` | string | Page URL. |
+| `results[].publishedDate` | string or null | Estimated publication date when available. |
+| `results[].author` | string or null | Author when available. |
+| `results[].text` | string | Returned when `contents.text` is requested. |
+| `results[].highlights` | string[] | Returned when `contents.highlights` is requested. |
+| `results[].highlightScores` | number[] | Similarity scores for highlights. |
+| `results[].summary` | string | Returned when `contents.summary` is requested. |
+| `results[].subpages` | array | Nested result objects from subpage crawling. |
+| `results[].extras.links` | string[] | Extracted links when requested. |
+| `output.content` | string or object | Synthesized output when `outputSchema` is provided. |
+| `output.grounding` | array | Citations and confidence labels for synthesized fields. |
+| `costDollars.total` | number | Total request cost when returned. |
+| `searchTime` | number | Search latency when returned. |
+
+## Anti-Patterns
+- Keep `text`, `highlights`, and `summary` inside `contents` on `/search`.
+- Do not send top-level `text`, `highlights`, or `summary`; that shape belongs to `/contents`.
+- Do not send `tokensNum`; use `contents.text.maxCharacters` to cap extracted text.
+- Do not use `useAutoprompt`, `numSentences`, or `highlightsPerUrl` in new requests.
+- Prefer `contents.maxAgeHours` over older `livecrawl` examples.
+- Use documented categories only: `company`, `people`, `research paper`, `news`, `personal site`, and `financial report`.
+- Avoid invalid category/filter combinations. `company` and `people` do not support `startPublishedDate` or `endPublishedDate`. `company` supports `excludeDomains`; `people` does not, and `people` only accepts LinkedIn domains in `includeDomains`.
+- Pick one of `contents.highlights`, `contents.text`, or `contents.summary` by default. Stack modes only when the caller truly needs multiple views of each page.
+- Expect SSE only when `stream: true` is paired with `outputSchema`; otherwise `/search` returns its normal JSON response.
+
+## Attribution
+
+Ported from [exa-labs/agent-skills](https://github.com/exa-labs/agent-skills) - adapted for mktg's drop-in contract on 2026-07-18.
+
+Upstream commit: 390ffee2d7e1d0dce2ed8efe4994c2b3c1c0173b
+
+Drift detection: if the upstream skill changes, re-run `mktg-steal https://github.com/exa-labs/agent-skills` to evaluate the diff.

--- a/skills/landscape-scan/SKILL.md
+++ b/skills/landscape-scan/SKILL.md
@@ -156,7 +156,7 @@ and web sources for the last 30 days of activity.
 
 **Fallback if /last30days is unavailable:**
 1. Use WebSearch tool directly with the research query.
-2. If WebSearch is unavailable, use Exa MCP for web research.
+2. Never use Claude native WebSearch. Use `exa-search` / Exa MCP for web research (and `/last30days` for social signal).
 3. If no web research is available at all, proceed with user knowledge only
    and mark every finding as `source: user-reported` in the output.
 4. Note the limitation: "Landscape based on provided information, not live

--- a/skills/lead-generation/SKILL.md
+++ b/skills/lead-generation/SKILL.md
@@ -1,0 +1,235 @@
+---
+name: lead-generation
+version: 0.1.0
+description: >
+  Generate enriched ICP-based lead lists with Exa Agent, including structured
+  scoring and CSV output. Use when generating leads, building prospect lists,
+  finding companies to sell to, outbound research, or ICP-based company
+  discovery. Triggers on leads, lead gen, prospect list, find companies, ICP,
+  outbound list. Distinct from lead-magnet (content asset that captures emails).
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Skill
+author: Exa Labs (ported by mktg)
+license: MIT
+user-invocable: true
+metadata:
+  openclaw:
+    emoji: 🎯
+---
+
+## On Activation
+
+1. Read `brand/audience.md`, `brand/positioning.md`, and `brand/competitors.md` if present to seed ICP + exclusions. All optional.
+2. Confirm Exa MCP with Agent tools (`agent_tools` / `agent_run`) or `EXA_API_KEY`. Without Agent access, stop and surface the MCP config from this skill.
+3. Confirm ICP with the user before large runs (default 200 leads is expensive).
+4. Write CSV under the project (e.g. `marketing/leads/` or cwd). Never write credentials into brand/.
+
+# Lead Generation with Exa Agent
+
+
+## mktg runtime note
+
+Prefer **Exa MCP** when available (tools: `web_search_exa`, `web_search_advanced_exa`, `web_fetch_exa`, `agent_run`).
+If MCP Agent tools use the older create/wait/get names (`agent_create_run`, `agent_wait_for_run`, `agent_get_run_output`), use those equivalently.
+Without MCP, call the HTTP API with `x-api-key: $EXA_API_KEY` (`POST https://api.exa.ai/search`, `/contents`, `/agent`).
+Firecrawl remains the path for deep scrape of a **known URL** after Exa discovery.
+
+
+Generate enriched lead lists using the Exa Agent API. An Agent run is an asynchronous, multi-step web research task: you describe the list you want plus an output schema, and Exa handles query decomposition, searching, verification, enrichment, and structured output internally. You do NOT need to orchestrate parallel searches, subagents, or manual deduplication.
+
+For very large or continuously maintained lead lists with per-item verification, consider Exa Websets instead: https://docs.exa.ai/websets/api/overview
+
+## Prerequisites
+
+This skill requires the Exa MCP server with the Agent tools enabled (`agent_tools`): `agent_create_run`, `agent_wait_for_run`, `agent_get_run_output`, `agent_cancel_run`.
+
+If the Agent tools are not available, tell the user:
+
+> You need the Exa MCP server installed with the Agent tools and your API key.
+> Instructions: https://docs.exa.ai/reference/exa-mcp
+
+Then stop.
+
+## Tool Restriction
+
+Use the Exa Agent tools (`agent_create_run`, `agent_wait_for_run`, `agent_get_run_output`, `agent_cancel_run`), plus Write and Bash (for CSV output). Do NOT use generic web search for the lead list itself.
+
+## Workflow
+
+```
+1. Confirm the ICP with the user (one small Agent run if research is needed)
+2. Create the lead-gen Agent run(s) with an outputSchema
+3. Wait for completion (agent_wait_for_run)
+4. Read output.structured (agent_get_run_output)
+5. Write the CSV
+6. Optional: expand with follow-up runs (previousRunId + input.exclusion)
+```
+
+## Step 1: Understand the ICP
+
+When the user says something like "Make a list of 200 leads for [company]", first establish the Ideal Customer Profile. If the user already described the ICP, confirm it. If not, run one small Agent run to research it:
+
+```
+agent_create_run {
+  "query": "Research {company_name}: what they sell, who their existing customers are, and what their ideal customer profile is.",
+  "effort": "low",
+  "outputSchema": {
+    "type": "object",
+    "properties": {
+      "company_description": { "type": "string", "description": "What the company does in 2 sentences or less" },
+      "icp_description": { "type": "string", "description": "Concise ICP description that clearly defines target companies" },
+      "sub_verticals": { "type": "array", "maxItems": 10, "items": { "type": "string" }, "description": "Sub-verticals breaking down the ICP" },
+      "useful_enrichments": { "type": "array", "maxItems": 8, "items": { "type": "string" }, "description": "Enrichment columns useful for filtering high-signal companies" }
+    },
+    "required": ["company_description", "icp_description", "sub_verticals", "useful_enrichments"]
+  }
+}
+```
+
+Present the ICP to the user and confirm:
+
+- Is the ICP description accurate?
+- Any companies to exclude (competitors, existing customers)?
+- How many leads do they want? (default 200)
+- Any specific enrichment columns they care about?
+
+## Step 2: Create the Lead-Gen Run
+
+Design an `outputSchema` with a bounded `companies` array. Keep schemas small, flat, and explicit; always bound arrays with `maxItems`.
+
+**Core fields to always include:**
+
+- `company_name` (string)
+- `website` (string)
+- `product_description` (string, "in 12 words or less")
+- `icp_fit_score` (integer, 1-10)
+- `icp_fit_reasoning` (string, "compelling one-liner in 20 words or less")
+
+Add enrichment fields tailored to the campaign (funding stage, headcount range, headquarters, hiring signals, etc.). Give string fields a length hint in their description to keep CSV output clean.
+
+Use the run inputs for the pieces the old manual pipeline handled by hand:
+
+- `query` - describe the list: the ICP, geography, stage, and how many companies you want
+- `outputSchema` - the exact structure back, with `maxItems` bounding the companies array
+- `systemPrompt` - scoring rules, source preferences, dedup/exclusion emphasis
+- `input.exclusion` - companies to avoid (competitors, existing customers, results from earlier runs)
+- `effort` - `"auto"` by default; `"high"` or `"xhigh"` for large or hard lists
+
+Example:
+
+```
+agent_create_run {
+  "query": "Find 100 companies matching this ICP: {icp_description}. Prioritize {sub_verticals}. For each company, score ICP fit 1-10 for {user_company}.",
+  "effort": "auto",
+  "systemPrompt": "Prefer official company sites and recent funding announcements. Do not include duplicates or subsidiaries of the same parent company.",
+  "input": {
+    "exclusion": ["{competitor_1}", "{existing_customer_1}"]
+  },
+  "outputSchema": {
+    "type": "object",
+    "properties": {
+      "companies": {
+        "type": "array",
+        "maxItems": 100,
+        "items": {
+          "type": "object",
+          "properties": {
+            "company_name": { "type": "string" },
+            "website": { "type": "string", "format": "uri" },
+            "product_description": { "type": "string", "description": "in 12 words or less" },
+            "icp_fit_score": { "type": "integer", "description": "1-10" },
+            "icp_fit_reasoning": { "type": "string", "description": "one-liner in 20 words or less" }
+          },
+          "required": ["company_name", "website", "product_description", "icp_fit_score", "icp_fit_reasoning"]
+        }
+      }
+    },
+    "required": ["companies"]
+  }
+}
+```
+
+`agent_create_run` returns an `agent_run_...` ID immediately. Save it.
+
+## Step 3: Wait and Read Output
+
+1. Call `agent_wait_for_run` with the run ID. It polls until the run reaches a terminal status (`completed`, `failed`, or `cancelled`) or times out - call it again if the run is still going.
+2. When `completed`, call `agent_get_run_output`. Read the companies from `output.structured`, citations from `output.grounding`, and the run cost from `costDollars`.
+
+Do not paste the full raw output into the conversation - go straight to CSV.
+
+## Step 4: Write the CSV
+
+Write `output.structured.companies` to `{target_company}_leads_{YYYY-MM-DD}.csv`, sorted by `icp_fit_score` descending. Join any array fields with " | ". Use Python's `csv.writer` (handles quoting/escaping) via Bash, or Write directly for small lists.
+
+Print a summary:
+
+```
+## Lead Generation Complete
+
+- Total leads: {count}
+- ICP score distribution: 8-10: {N} | 5-7: {N} | 1-4: {N}
+- Run ID: {agent_run_id}
+- Cost: ${costDollars}
+- Output: {filename}
+```
+
+## Step 5: Expanding the List
+
+If the user wants more leads than one run returned:
+
+- Create a follow-up run with `previousRunId` set to the completed run's ID, asking for additional companies
+- Put the company names already collected into `input.exclusion` so the new run avoids them
+- Append the new results to the CSV and re-deduplicate by normalized company name (strip "Inc"/"Ltd"/etc., case-insensitive)
+
+For lists in the many hundreds, run a few runs sequentially this way rather than one giant run, and confirm scope with the user first: "This will require ~{N} Agent runs. Proceed?"
+
+## Handling Failures
+
+- If a run ends `failed`, read the error from `agent_get_run_output`, adjust the query or schema, and retry once with different wording
+- Use `agent_cancel_run` if a run is clearly researching the wrong thing
+- If results are consistently below the requested count, narrow the ICP into 2-3 sub-vertical runs instead of one broad run
+
+## MCP Configuration
+
+Requires an Exa API key. Get yours at https://dashboard.exa.ai/api-keys
+
+```json
+{
+  "servers": {
+    "exa": {
+      "type": "http",
+      "url": "https://mcp.exa.ai/mcp?tools=agent_tools",
+      "headers": {
+        "x-api-key": "YOUR_EXA_API_KEY"
+      }
+    }
+  }
+}
+```
+
+## References
+
+- Exa Agent guide: https://docs.exa.ai/reference/agent-api-guide
+- Exa MCP setup: https://docs.exa.ai/reference/exa-mcp
+- Websets (verified list-building at scale): https://docs.exa.ai/websets/api/overview
+- Full docs for LLMs: https://docs.exa.ai/llms.txt
+
+## Anti-Patterns
+
+| Anti-pattern | Why it fails | Instead |
+|---|---|---|
+| Using Claude native WebSearch instead of Exa | Misses niche competitors, companies, and cited sources Exa ranks highly. | Use this skill (or Exa MCP) for all open-ended web research. |
+| Calling Exa without `EXA_API_KEY` / MCP auth | Requests 401 and the agent invents results. | Set `EXA_API_KEY` (dashboard.exa.ai) or configure `.mcp.json`; surface the fix via `mktg doctor`. |
+| Dumping raw result JSON into the user chat | Burns context and hides the answer. | Synthesize; cite URLs from grounding / result lists. |
+
+## Attribution
+
+Ported from [exa-labs/agent-skills](https://github.com/exa-labs/agent-skills) - adapted for mktg's drop-in contract on 2026-07-18.
+
+Upstream commit: 390ffee2d7e1d0dce2ed8efe4994c2b3c1c0173b
+
+Drift detection: if the upstream skill changes, re-run `mktg-steal https://github.com/exa-labs/agent-skills` to evaluate the diff.

--- a/studio/CLAUDE.md
+++ b/studio/CLAUDE.md
@@ -4,7 +4,7 @@
 
 ## Driver/Dashboard Contract
 
-- **Driver:** /cmo (Claude Code) runs in the user's terminal. It reads brand/ files, executes the 57 marketing skills, and calls the studio's HTTP API (POST `/api/activity/log`, `/api/navigate`, `/api/toast`, `/api/brand/refresh`, etc.) to keep the dashboard in sync.
+- **Driver:** /cmo (Claude Code) runs in the user's terminal. It reads brand/ files, executes the 62 marketing skills, and calls the studio's HTTP API (POST `/api/activity/log`, `/api/navigate`, `/api/toast`, `/api/brand/refresh`, etc.) to keep the dashboard in sync.
 - **Dashboard:** Next.js + Bun server. Subscribes to `/api/events` (SSE) for live updates. Renders primary surfaces (Pulse, Signals, Publish, Brand, Settings) + a right-hand Activity panel that shows the /cmo activity stream. Trend radar is a Signals mode; Audience summary and next actions live on Pulse.
 - **Activity panel:** Replaces the old chat slot. Lists skill runs, brand writes, publishes, navigates, and toasts — a live log of what /cmo is doing.
 - **AGPL firewall:** Never import `@postiz/*`. Raw fetch only over the network boundary.
@@ -115,7 +115,7 @@ This project follows the same agent-native contract as mktg itself:
 ┌──────────────────┐ ┌──────────────────┐ ┌──────────────────────────┐
 │ Next.js 16 │────▶│ Bun.serve │────▶│ Claude Code (local) │
 │ Dashboard │◀─SSE│ (local server) │ │ ├── /cmo skill │
-│ │ │ SQLite │ │ ├── 57 marketing skills │
+│ │ │ SQLite │ │ ├── 62 marketing skills │
 │ 5 surfaces + │ │ brand/ watcher │ │ ├── mktg CLI (--json) │
 │ Activity panel │ │ Job queue │ │ └── Postiz adapter │
 └──────────────────┘ └──────────────────┘ └──────────────────────────┘
@@ -182,7 +182,7 @@ Tests: 2599 pass / 0 fail / 96 files
 │ └── transcribe.ts — whisper.cpp + yt-dlp + ffmpeg orchestration
 ├── skills/ — 50 SKILL.md files (see §Skills below)
 ├── agents/ — 5 agent .md files (see §Agents below)
-├── skills-manifest.json — 58 skills: triggers, categories, layers, reads, writes, env_vars
+├── skills-manifest.json — 63 skills: triggers, categories, layers, reads, writes, env_vars
 ├── agents-manifest.json — 5 agents: categories, files, reads, writes, tier
 ├── catalogs-manifest.json — 1 catalog (postiz): capabilities, auth, transport, license
 ├── brand/SCHEMA.md — schema for all 10 brand files
@@ -258,7 +258,7 @@ Rules: ~/projects/mktgmono/marketing-cli/skills/cmo/rules/ (14 files, ~1,900 lin
 ```
 
 **What /cmo knows:**
-- Routes to any of 58 skills based on user intent + brand state
+- Routes to any of 63 skills based on user intent + brand state
 - 10 named orchestration playbooks (Full Product Launch, Content Engine, Founder Voice Rebrand, Conversion Audit, Retention Recovery, Visual Identity, Video Content, Email Infrastructure, SEO Authority Build, Newsletter Launch)
 - L0-L4 progressive enhancement ladder (what's possible at each brand completeness level)
 - Error recovery + degraded-mode playbook (what to do when integrations fail)
@@ -611,7 +611,7 @@ components/workspace/skill-browser/ — skill browser + execution trigger UI
 - Port signal severity + spike detection from Convex to local TypeScript
 
 ### Phase 5: Skill Browser + Onboarding (2-3 days)
-- Skill browser: `mktg list --json` → browse all 58 skills, one-click trigger
+- Skill browser: `mktg list --json` → browse all 63 skills, one-click trigger
 - Execution progress: running → result → files changed
 - Onboarding: detect fresh install (mktg status → needs-setup) → wizard → mktg init → foundation skills
 - First-run "wow moment": Pulse, Signals, Publish, Brand, and Settings populate as foundation skills complete
@@ -631,7 +631,7 @@ components/workspace/skill-browser/ — skill browser + execution trigger UI
 >
 > **Dashboard layer (this repo)**: 5 workspace tabs (Pulse, Signals, Publish, Brand, Settings), Activity panel, signal severity scoring. Local-first — no cloud dependencies.
 >
-> **mktg** is the marketing brain — 58 skills, /cmo orchestrator (2,400 lines of routing knowledge), brand memory (10 files that compound), upstream catalogs. This is the engine. Everything runs through `mktg --json` for infrastructure and /cmo for intelligence.
+> **mktg** is the marketing brain — 63 skills, /cmo orchestrator (2,400 lines of routing knowledge), brand memory (10 files that compound), upstream catalogs. This is the engine. Everything runs through `mktg --json` for infrastructure and /cmo for intelligence.
 >
 > **postiz** is the distribution layer — 30+ social providers via REST API. AGPL-firewalled. Call it, never fork it.
 >

--- a/studio/CLAUDE.md
+++ b/studio/CLAUDE.md
@@ -1,12 +1,12 @@
 # mktg-studio
 
-> Build the visual studio layer for the mktg marketing CLI. The studio is a local-first Next.js dashboard **driven by /cmo running in the user's Claude Code session**. /cmo invokes studio HTTP endpoints to log activity, navigate tabs, refresh data, and fire toasts. The studio itself has no chat UI and no LLM integration — it's a dashboard + HTTP API. There is no Vercel AI SDK (`ai`, `@ai-sdk/react`), no in-app chat panel, and the studio never calls the Anthropic API directly.
+> Build the visual studio layer for the mktg marketing CLI. The studio is a local-first Next.js dashboard **driven by /cmo running in the user's Claude Code session**. /cmo invokes studio HTTP endpoints to log activity, navigate tabs, refresh data, and fire toasts. The studio itself has no chat UI and no LLM integration  -  it's a dashboard + HTTP API. There is no Vercel AI SDK (`ai`, `@ai-sdk/react`), no in-app chat panel, and the studio never calls the Anthropic API directly.
 
 ## Driver/Dashboard Contract
 
 - **Driver:** /cmo (Claude Code) runs in the user's terminal. It reads brand/ files, executes the 62 marketing skills, and calls the studio's HTTP API (POST `/api/activity/log`, `/api/navigate`, `/api/toast`, `/api/brand/refresh`, etc.) to keep the dashboard in sync.
 - **Dashboard:** Next.js + Bun server. Subscribes to `/api/events` (SSE) for live updates. Renders primary surfaces (Pulse, Signals, Publish, Brand, Settings) + a right-hand Activity panel that shows the /cmo activity stream. Trend radar is a Signals mode; Audience summary and next actions live on Pulse.
-- **Activity panel:** Replaces the old chat slot. Lists skill runs, brand writes, publishes, navigates, and toasts — a live log of what /cmo is doing.
+- **Activity panel:** Replaces the old chat slot. Lists skill runs, brand writes, publishes, navigates, and toasts  -  a live log of what /cmo is doing.
 - **AGPL firewall:** Never import `@postiz/*`. Raw fetch only over the network boundary.
 - **Auth invisible by default:** The launcher banner does not surface the token path. Set `MKTG_STUDIO_DEBUG=1 mktg studio` to see it (cabinet-style invisible-auth pattern).
 
@@ -14,10 +14,10 @@
 
 **One day, someone runs `/cmo` in a fresh project and /cmo says: "Let me spin up your marketing dashboard." It launches the studio dashboard, creates native publish providers, connects Postiz when external posting is needed, reads the brand/ files, and the user sees their entire marketing operation live on screen. No setup guide. No manual config. The agent builds the marketing department AND gives you the dashboard to see it working.**
 
-This is the visual layer for `marketing-cli`. It's what turns a CLI-only experience into a full marketing studio that anyone — not just developers — can use. Easy API key setup. One-click skill execution. Real-time brand intelligence. A live Activity panel where you watch /cmo work.
+This is the visual layer for `marketing-cli`. It's what turns a CLI-only experience into a full marketing studio that anyone  -  not just developers  -  can use. Easy API key setup. One-click skill execution. Real-time brand intelligence. A live Activity panel where you watch /cmo work.
 
 **The merge:** The studio eventually ships AS PART of the mktg ecosystem. Either:
-- `mktg studio` command that launches the dashboard (preferred — keeps mktg as the single entry point)
+- `mktg studio` command that launches the dashboard (preferred  -  keeps mktg as the single entry point)
 - Or a companion package (`mktg-studio`) that mktg references
 
 Either way, /cmo is the brain and the studio is the eyes. They're one system.
@@ -30,11 +30,11 @@ Either way, /cmo is the brain and the studio is the eyes. They're one system.
 5. /cmo runs foundation skills in parallel → surfaces light up one by one
 6. User sees Pulse (brand health + audience summary + what to do next), Signals (intel inbox + Trend radar), Publish (social queue), Brand, Settings, and a live Activity panel that streams what /cmo is doing in Claude Code
 7. Everything persists locally. Close the laptop, reopen, everything's still there.
-8. The user never needs to understand CLI commands — the studio IS the interface.
+8. The user never needs to understand CLI commands  -  the studio IS the interface.
 
 ## API Key Onboarding (Easy Setup)
 
-The studio MUST have a dead-simple settings/onboarding screen. When a user first opens the studio, they see a wizard — not an empty dashboard.
+The studio MUST have a dead-simple settings/onboarding screen. When a user first opens the studio, they see a wizard  -  not an empty dashboard.
 
 **Onboarding flow:**
 ```
@@ -49,7 +49,7 @@ Step 2: "Connect your social accounts"
 
 Step 3: "Optional integrations"
  → FIRECRAWL_API_KEY (for web scraping in landscape-scan)
- → EXA_API_KEY (for deep web research — most skills benefit)
+ → EXA_API_KEY (for deep web research  -  most skills benefit)
  → RESEND_API_KEY (for email sequences)
 
 Step 4: "Building your marketing brain..."
@@ -74,7 +74,7 @@ Step 4: "Building your marketing brain..."
 - The mktg CLI reads its own env vars (POSTIZ_API_KEY etc.) from the shell environment
 - The studio's settings panel writes to .env.local AND exports to shell for mktg CLI
 
-## Agent DX 21/21 — The Non-Negotiable Quality Bar
+## Agent DX 21/21  -  The Non-Negotiable Quality Bar
 
 mktg CLI scores 21/21 on the Agent DX Scale. The studio MUST maintain this score. Every server endpoint, every data contract, every API surface the studio exposes is evaluated against these 7 axes:
 
@@ -88,7 +88,7 @@ mktg CLI scores 21/21 on the Agent DX Scale. The studio MUST maintain this score
 | **6. Safety Rails** | `--dry-run` for all mutations, response sanitization | Every mutating endpoint supports `?dryRun=true`. Destructive actions (reset brand, delete signals) require `?confirm=true`. |
 | **7. Agent Knowledge Packaging** | Comprehensive skill library, versioned, discoverable | This CLAUDE.md IS the agent knowledge. Plus: `mktg schema`, `mktg list --routing`, and `/api/schema` for runtime discovery. |
 
-**Why this matters for the studio:** The studio isn't just a human dashboard — it's also an API surface that agents consume. /cmo talks to the studio's server. Future agents will talk to the studio's API. If the server doesn't follow the same DX contract as the CLI, agent integration breaks.
+**Why this matters for the studio:** The studio isn't just a human dashboard  -  it's also an API surface that agents consume. /cmo talks to the studio's server. Future agents will talk to the studio's API. If the server doesn't follow the same DX contract as the CLI, agent integration breaks.
 
 **Test it:** After Phase 2, run the Agent DX Scale evaluation against the studio's `/api/*` surface. Must score 21/21 or fix before proceeding.
 
@@ -126,16 +126,16 @@ This project follows the same agent-native contract as mktg itself:
  └─────────────┘ └─────────────────┘
 ```
 
-**Execution split — memorize this:**
+**Execution split  -  memorize this:**
 - **Needs intelligence** (skill execution, recommendations, conversation) → happens in **Claude Code** where the user runs /cmo directly. /cmo then POSTs results/activity to the studio.
-- **Needs data** (status, publish, catalog, doctor, list, schema) → **mktg CLI** (--json, no LLM) — invoked by /cmo or by the studio server.
+- **Needs data** (status, publish, catalog, doctor, list, schema) → **mktg CLI** (--json, no LLM)  -  invoked by /cmo or by the studio server.
 - **Needs display** (tab rendering, brand file content) → **SQLite queries + file reads + SSE push from /cmo**
 
 **The studio never initiates LLM calls.** /cmo pushes state to the dashboard; the dashboard pulls state from SQLite and brand/ files.
 
 ## The Two Source Repos
 
-### 1. mktg CLI — the skill engine
+### 1. mktg CLI  -  the skill engine
 
 ```
 Repo: ~/projects/mktgmono/marketing-cli/
@@ -149,49 +149,49 @@ Tests: 2599 pass / 0 fail / 96 files
 ```
 ~/projects/mktgmono/marketing-cli/
 ├── src/
-│ ├── cli.ts — entry point, command router, global flag parsing
-│ ├── types.ts — ALL shared types: CommandResult<T>, CatalogEntry, CatalogsManifest, etc.
+│ ├── cli.ts  -  entry point, command router, global flag parsing
+│ ├── types.ts  -  ALL shared types: CommandResult<T>, CatalogEntry, CatalogsManifest, etc.
 │ ├── commands/
-│ │ ├── catalog.ts — mktg catalog list/info/sync/status/add (upstream catalogs)
-│ │ ├── publish.ts — mktg publish (4 adapters: typefully, resend, file, postiz)
+│ │ ├── catalog.ts  -  mktg catalog list/info/sync/status/add (upstream catalogs)
+│ │ ├── publish.ts  -  mktg publish (4 adapters: typefully, resend, file, postiz)
 │ │ │ Lines 263-620: postizFetch + publishPostiz + sent-markers
 │ │ │ Line 617: BUILTIN_PUBLISH_ADAPTERS export
 │ │ │ Line 623: postiz entry in ADAPTERS registry
-│ │ ├── doctor.ts — mktg doctor (health checks, tool detection, catalog health)
-│ │ ├── schema.ts — mktg schema (agent self-discovery, line 42: catalog import)
-│ │ ├── init.ts — mktg init (project bootstrap, installs skills + agents)
-│ │ ├── status.ts — mktg status (brand health, integration status, skill count)
-│ │ ├── list.ts — mktg list (all skills + agents with install status, --routing flag)
-│ │ ├── brand.ts — mktg brand (read/write/delete/reset/import brand files)
-│ │ ├── run.ts — mktg run (skill execution logging)
-│ │ ├── plan.ts — mktg plan (task tracking, plan next, --learning flag)
-│ │ ├── context.ts — mktg context (project context for skills)
-│ │ ├── compete.ts — mktg compete (competitor monitoring loop)
-│ │ ├── update.ts — mktg update (re-sync bundled skills + agents from package)
-│ │ ├── transcribe.ts — mktg transcribe (whisper-cli + yt-dlp + ffmpeg pipeline)
-│ │ └── dashboard.ts — mktg dashboard (brand overview)
+│ │ ├── doctor.ts  -  mktg doctor (health checks, tool detection, catalog health)
+│ │ ├── schema.ts  -  mktg schema (agent self-discovery, line 42: catalog import)
+│ │ ├── init.ts  -  mktg init (project bootstrap, installs skills + agents)
+│ │ ├── status.ts  -  mktg status (brand health, integration status, skill count)
+│ │ ├── list.ts  -  mktg list (all skills + agents with install status, --routing flag)
+│ │ ├── brand.ts  -  mktg brand (read/write/delete/reset/import brand files)
+│ │ ├── run.ts  -  mktg run (skill execution logging)
+│ │ ├── plan.ts  -  mktg plan (task tracking, plan next, --learning flag)
+│ │ ├── context.ts  -  mktg context (project context for skills)
+│ │ ├── compete.ts  -  mktg compete (competitor monitoring loop)
+│ │ ├── update.ts  -  mktg update (re-sync bundled skills + agents from package)
+│ │ ├── transcribe.ts  -  mktg transcribe (whisper-cli + yt-dlp + ffmpeg pipeline)
+│ │ └── dashboard.ts  -  mktg dashboard (brand overview)
 │ └── core/
-│ ├── catalogs.ts — loadCatalogManifest + license allowlist + collision detection
-│ ├── output.ts — JSON/TTY formatting, --fields filtering, getNestedValue (walks arrays)
-│ ├── errors.ts — 6 validators: rejectControlChars, validateResourceId, detectDoubleEncoding,
+│ ├── catalogs.ts  -  loadCatalogManifest + license allowlist + collision detection
+│ ├── output.ts  -  JSON/TTY formatting, --fields filtering, getNestedValue (walks arrays)
+│ ├── errors.ts  -  6 validators: rejectControlChars, validateResourceId, detectDoubleEncoding,
 │ │ validatePathInput, sandboxPath, parseJsonInput
-│ ├── brand.ts — brand dir management, freshness assessment, template detection
-│ ├── skills.ts — skill registry, install to ~/.claude/skills/, integrity verification
-│ ├── skill-add.ts — external skill chaining (mktg skill add)
-│ ├── agents.ts — agent registry, install to ~/.claude/agents/
-│ └── transcribe.ts — whisper.cpp + yt-dlp + ffmpeg orchestration
-├── skills/ — 50 SKILL.md files (see §Skills below)
-├── agents/ — 5 agent .md files (see §Agents below)
-├── skills-manifest.json — 63 skills: triggers, categories, layers, reads, writes, env_vars
-├── agents-manifest.json — 5 agents: categories, files, reads, writes, tier
-├── catalogs-manifest.json — 1 catalog (postiz): capabilities, auth, transport, license
-├── brand/SCHEMA.md — schema for all 10 brand files
-├── CLAUDE.md — 198 lines: development contract
-├── AGENTS.md — 163 lines: drop-in skill/agent/catalog contracts
-├── CONTEXT.md — 121 lines: command reference
-├── docs/integration/ — postiz design specs (from the integration session):
-│ └── postiz-api-reference.md — 857 lines: every endpoint, DTO, auth, rate limits
-└── docs/audits/ — DX 21/21 audit reports (3 files, one per axis group)
+│ ├── brand.ts  -  brand dir management, freshness assessment, template detection
+│ ├── skills.ts  -  skill registry, install to ~/.claude/skills/, integrity verification
+│ ├── skill-add.ts  -  external skill chaining (mktg skill add)
+│ ├── agents.ts  -  agent registry, install to ~/.claude/agents/
+│ └── transcribe.ts  -  whisper.cpp + yt-dlp + ffmpeg orchestration
+├── skills/  -  50 SKILL.md files (see §Skills below)
+├── agents/ - 6 agent .md files (see §Agents below)
+├── skills-manifest.json  -  63 skills: triggers, categories, layers, reads, writes, env_vars
+├── agents-manifest.json - 6 agents: categories, files, reads, writes, tier
+├── catalogs-manifest.json  -  1 catalog (postiz): capabilities, auth, transport, license
+├── brand/SCHEMA.md  -  schema for all 10 brand files
+├── CLAUDE.md  -  198 lines: development contract
+├── AGENTS.md  -  163 lines: drop-in skill/agent/catalog contracts
+├── CONTEXT.md  -  121 lines: command reference
+├── docs/integration/  -  postiz design specs (from the integration session):
+│ └── postiz-api-reference.md  -  857 lines: every endpoint, DTO, auth, rate limits
+└── docs/audits/  -  DX 21/21 audit reports (3 files, one per axis group)
 ```
 
 **mktg CLI commands the studio calls:**
@@ -217,11 +217,11 @@ type CommandResult<T> =
  | { ok: false; error: MktgError; exitCode: 1|2|3|4|5|6 }
 ```
 
-### 2. postiz — social distribution (external, AGPL-firewalled)
+### 2. postiz  -  social distribution (external, AGPL-firewalled)
 
 ```
 Repo: github.com/gitroomhq/postiz-app (NEVER fork or clone into this repo)
-License: AGPL-3.0 — API-only. Network boundary = license boundary.
+License: AGPL-3.0  -  API-only. Network boundary = license boundary.
 Hosted: https://api.postiz.com (Stripe-gated)
 Self-host: Docker (6 containers: Postgres + Redis + Temporal + Elasticsearch + app + worker)
 API base: ${POSTIZ_API_BASE}/public/v1/
@@ -247,9 +247,9 @@ Rate limit: 30 POST /public/v1/posts per hour per org
 
 **Full API reference:** `~/projects/mktgmono/marketing-cli/docs/integration/postiz-api-reference.md` (857 lines)
 
-## /cmo — The Brain (2,400 lines of orchestration knowledge)
+## /cmo  -  The Brain (2,400 lines of orchestration knowledge)
 
-/cmo is the single most important skill. The studio is a visual dashboard that /cmo drives. The user talks to /cmo in their Claude Code terminal (not inside the studio). /cmo then calls the studio's HTTP API to log activity, switch tabs, refresh brand-backed queries, or show toasts. Every "run a skill" / "what should I do next" still happens in /cmo — the studio just reflects the state.
+/cmo is the single most important skill. The studio is a visual dashboard that /cmo drives. The user talks to /cmo in their Claude Code terminal (not inside the studio). /cmo then calls the studio's HTTP API to log activity, switch tabs, refresh brand-backed queries, or show toasts. Every "run a skill" / "what should I do next" still happens in /cmo  -  the studio just reflects the state.
 
 ```
 Source: ~/projects/mktgmono/marketing-cli/skills/cmo/SKILL.md (478 lines)
@@ -294,15 +294,15 @@ Manifest: ~/projects/mktgmono/marketing-cli/skills-manifest.json
 | Skill | Triggers (from manifest) | Reads | Writes |
 |---|---|---|---|
 | `cmo` | "help me market", "what should I do next", any marketing request | all brand/ files | routes to other skills |
-| `brand-voice` | "define brand voice", "extract voice" | — | brand/voice-profile.md |
+| `brand-voice` | "define brand voice", "extract voice" |  -  | brand/voice-profile.md |
 | `positioning-angles` | "positioning", "unique selling proposition", "how do I stand out" | voice-profile, audience | brand/positioning.md |
-| `audience-research` | "target audience", "buyer persona", "ICP" | — | brand/audience.md |
-| `competitive-intel` | "competitors", "competitive analysis" | — | brand/competitors.md |
-| `landscape-scan` | "market landscape", "ecosystem snapshot" | — | brand/landscape.md |
-| `brainstorm` | "brainstorm", "I don't know", vague marketing ask | all brand/ files | — |
-| `create-skill` | "create a skill", "new skill", "extend playbook" | — | skills/<name>/SKILL.md |
+| `audience-research` | "target audience", "buyer persona", "ICP" |  -  | brand/audience.md |
+| `competitive-intel` | "competitors", "competitive analysis" |  -  | brand/competitors.md |
+| `landscape-scan` | "market landscape", "ecosystem snapshot" |  -  | brand/landscape.md |
+| `brainstorm` | "brainstorm", "I don't know", vague marketing ask | all brand/ files |  -  |
+| `create-skill` | "create a skill", "new skill", "extend playbook" |  -  | skills/<name>/SKILL.md |
 | `deepen-plan` | "deepen this plan", "add research to plan" | existing plan | enhanced plan |
-| `document-review` | "audit brand files", "review brand docs" | all brand/ files | — |
+| `document-review` | "audit brand files", "review brand docs" | all brand/ files |  -  |
 | `voice-extraction` | "reverse-engineer voice", "analyze writing style" | content samples | voice analysis |
 
 ### Distribution (10 skills)
@@ -363,7 +363,7 @@ Manifest: ~/projects/mktgmono/marketing-cli/skills-manifest.json
 | `pricing-strategy` | strategy | Van Westendorp, packaging, monetization |
 | `marketing-psychology` | knowledge | Cialdini's 6 principles, cognitive biases |
 | `ai-check` | review | Line-by-line AI slop detection |
-| `editorial-first-pass` | review | Hook, thesis, promise, stakes — pass/fail |
+| `editorial-first-pass` | review | Hook, thesis, promise, stakes  -  pass/fail |
 | `ai-seo` | review | AI search optimization (ChatGPT, Perplexity, Claude, Gemini) |
 | `competitor-alternatives` | review | "X vs Y" and "X alternatives" SEO pages |
 | `landscape-scan` | infrastructure | Ecosystem snapshot + Claims Blacklist |
@@ -563,19 +563,19 @@ CREATE TABLE metric_baselines (
 ## New Files to Create
 
 ```
-server.ts — Bun.serve: local API server (SQLite + SSE + mktg bridge + /cmo bridge)
-db/schema.sql — SQLite schema (above)
-db/migrations/ — schema migration files
-lib/mktg.ts — mktg CLI bridge: spawn + parse CommandResult<T> + typed wrappers
-lib/agent.ts — Claude Code bridge: send messages to /cmo, receive responses
-lib/sse.ts — SSE event emitter (server) + useSSE hook (client)
-lib/sqlite.ts — SQLite connection + typed query helpers
-lib/watcher.ts — brand/ file watcher (Bun.watch) → SSE events
-lib/postiz.ts — thin postiz API client (mirrors mktg's postizFetch for direct queries)
-lib/jobs.ts — background job queue for long-running skill executions
-app/(dashboard)/publish/ — new Publish tab route
-components/workspace/publish/ — Publish tab components
-components/workspace/skill-browser/ — skill browser + execution trigger UI
+server.ts  -  Bun.serve: local API server (SQLite + SSE + mktg bridge + /cmo bridge)
+db/schema.sql  -  SQLite schema (above)
+db/migrations/  -  schema migration files
+lib/mktg.ts  -  mktg CLI bridge: spawn + parse CommandResult<T> + typed wrappers
+lib/agent.ts  -  Claude Code bridge: send messages to /cmo, receive responses
+lib/sse.ts  -  SSE event emitter (server) + useSSE hook (client)
+lib/sqlite.ts  -  SQLite connection + typed query helpers
+lib/watcher.ts  -  brand/ file watcher (Bun.watch) → SSE events
+lib/postiz.ts  -  thin postiz API client (mirrors mktg's postizFetch for direct queries)
+lib/jobs.ts  -  background job queue for long-running skill executions
+app/(dashboard)/publish/  -  new Publish tab route
+components/workspace/publish/  -  Publish tab components
+components/workspace/skill-browser/  -  skill browser + execution trigger UI
 ```
 
 ## Build Phases
@@ -589,17 +589,17 @@ components/workspace/skill-browser/ — skill browser + execution trigger UI
 - Verify: `bun dev` starts Next.js on localhost:3000 (empty dashboard)
 
 ### Phase 2: Wire Infrastructure (3-4 days)
-- Build lib/mktg.ts — shells out to `mktg <cmd> --json`, parses CommandResult, typed wrappers
-- Build lib/sqlite.ts — connection, query helpers, migration runner
-- Build lib/watcher.ts — Bun.watch on brand/ → SSE events
-- Build lib/sse.ts — server-side EventSource emitter + client useSSE hook
+- Build lib/mktg.ts  -  shells out to `mktg <cmd> --json`, parses CommandResult, typed wrappers
+- Build lib/sqlite.ts  -  connection, query helpers, migration runner
+- Build lib/watcher.ts  -  Bun.watch on brand/ → SSE events
+- Build lib/sse.ts  -  server-side EventSource emitter + client useSSE hook
 - Wire Pulse tab: mktg status + plan next → render cards
 - Verify: change brand/voice-profile.md → Pulse tab updates in <2s
 
 ### Phase 3: Wire /cmo → studio API (3-4 days)
 - Build studio HTTP endpoints /cmo calls: `POST /api/activity/log`, `POST /api/navigate`, `POST /api/toast`, `POST /api/brand/refresh`
-- Build the Activity panel that replaces the old chat slot — seeded from `/api/activity`, streamed from `/api/events`
-- Build lib/jobs.ts — background job queue for long-running skills (reports progress via `POST /api/activity/log`)
+- Build the Activity panel that replaces the old chat slot  -  seeded from `/api/activity`, streamed from `/api/events`
+- Build lib/jobs.ts  -  background job queue for long-running skills (reports progress via `POST /api/activity/log`)
 - Verify: running /cmo in Claude Code → studio Activity panel lights up; /cmo can switch tabs and fire toasts remotely
 
 ### Phase 4: Port primary surfaces (5-7 days)
@@ -629,13 +629,13 @@ components/workspace/skill-browser/ — skill browser + execution trigger UI
 
 > Fuse two layers into a local-first marketing studio that makes a solo builder feel like they have a full marketing department on their laptop.
 >
-> **Dashboard layer (this repo)**: 5 workspace tabs (Pulse, Signals, Publish, Brand, Settings), Activity panel, signal severity scoring. Local-first — no cloud dependencies.
+> **Dashboard layer (this repo)**: 5 workspace tabs (Pulse, Signals, Publish, Brand, Settings), Activity panel, signal severity scoring. Local-first  -  no cloud dependencies.
 >
-> **mktg** is the marketing brain — 63 skills, /cmo orchestrator (2,400 lines of routing knowledge), brand memory (10 files that compound), upstream catalogs. This is the engine. Everything runs through `mktg --json` for infrastructure and /cmo for intelligence.
+> **mktg** is the marketing brain  -  63 skills, /cmo orchestrator (2,400 lines of routing knowledge), brand memory (10 files that compound), upstream catalogs. This is the engine. Everything runs through `mktg --json` for infrastructure and /cmo for intelligence.
 >
-> **postiz** is the distribution layer — 30+ social providers via REST API. AGPL-firewalled. Call it, never fork it.
+> **postiz** is the distribution layer  -  30+ social providers via REST API. AGPL-firewalled. Call it, never fork it.
 >
-> **The one rule:** /cmo runs in Claude Code (the user's terminal) and *drives* the studio over HTTP. The studio is a dashboard + API — it never opens a Claude Code session, never imports `ai`/`@ai-sdk/react`, and never has an in-app chat widget. Skills call mktg CLI.
+> **The one rule:** /cmo runs in Claude Code (the user's terminal) and *drives* the studio over HTTP. The studio is a dashboard + API  -  it never opens a Claude Code session, never imports `ai`/`@ai-sdk/react`, and never has an in-app chat widget. Skills call mktg CLI.
 >
 > **Quality bar:** Linear-fast, information-dense. Every skill execution surfaces in the Activity panel. Every brand file change ripples through the dashboard in real time via SSE. Works offline except for postiz.
 >

--- a/studio/README.md
+++ b/studio/README.md
@@ -2,7 +2,7 @@
 
 > The visual layer that ships inside [`marketing-cli`](https://www.npmjs.com/package/marketing-cli). Your brand memory on disk, one agent running the show.
 
-Studio is the dashboard companion to the `mktg` CLI. The CLI ships the brain: 57 marketing skills + the `/cmo` orchestrator. Studio ships the eyes: a Next.js dashboard, a local Bun API, SQLite, live SSE, and a 21/21 agent-DX HTTP surface that `/cmo` drives via Bash + curl. No SDK, no MCP config. Claude Code already has `Bash`; that's the whole contract.
+Studio is the dashboard companion to the `mktg` CLI. The CLI ships the brain: 62 marketing skills + the `/cmo` orchestrator. Studio ships the eyes: a Next.js dashboard, a local Bun API, SQLite, live SSE, and a 21/21 agent-DX HTTP surface that `/cmo` drives via Bash + curl. No SDK, no MCP config. Claude Code already has `Bash`; that's the whole contract.
 
 Studio lives under `studio/` inside the `marketing-cli` repo as a bun-workspace member. It is not a separate package. Installing the CLI brings the launcher with it.
 
@@ -11,7 +11,7 @@ Studio lives under `studio/` inside the `marketing-cli` repo as a bun-workspace 
 ## Quick start
 
 ```bash
-npm i -g marketing-cli         # CLI + /cmo + 58 skills + studio launcher
+npm i -g marketing-cli         # CLI + /cmo + 63 skills + studio launcher
 mktg init                      # seed brand/*.md in the current project
 mktg studio                    # boot API (:3001) + dashboard (:3000)
 ```

--- a/studio/app/layout.tsx
+++ b/studio/app/layout.tsx
@@ -35,7 +35,7 @@ export const metadata: Metadata = {
     template: "%s | mktg studio",
   },
   description:
-    "Local-first marketing studio powered by /cmo -- 58 skills, brand intelligence, and social distribution in one dashboard.",
+    "Local-first marketing studio powered by /cmo -- 63 skills, brand intelligence, and social distribution in one dashboard.",
 }
 
 export default function RootLayout({

--- a/studio/components/workspace/publish/calendar-view.tsx
+++ b/studio/components/workspace/publish/calendar-view.tsx
@@ -85,7 +85,7 @@ export function CalendarView({
           <Button
             size="xs"
             variant="ghost"
-            onClick={() => setWeekStart(startOfWeek(new Date()))}
+            onClick={() => setWeekStart(startOfLocalWeek(new Date()))}
           >
             Today
           </Button>

--- a/tests/e2e/release/drift-guard.test.ts
+++ b/tests/e2e/release/drift-guard.test.ts
@@ -15,6 +15,11 @@ import { join } from "node:path";
 
 const PROJECT_ROOT = import.meta.dir.replace(/\/tests\/e2e\/release$/, "");
 
+const skillsManifest = JSON.parse(
+  readFileSync(join(PROJECT_ROOT, "skills-manifest.json"), "utf-8"),
+) as { skills: Record<string, unknown> };
+const totalSkillCount = Object.keys(skillsManifest.skills).length;
+
 const runDriftGuard = (): { exitCode: number; combined: string } => {
   const proc = spawnSync(
     "bun",
@@ -83,22 +88,25 @@ describe("e2e: drift guard catches real drift across surface types", () => {
   });
 
   test("drift in studio/CLAUDE.md (top-level total) fails the guard with file:line", () => {
+    const canonical = `${totalSkillCount} skills:`;
     captureAndMutate("studio/CLAUDE.md", (orig) =>
-      // Replace one of the top-level totals ("skills-manifest.json — 57 skills:")
+      // Replace one of the top-level totals ("skills-manifest.json — N skills:")
       // with a wrong number. Stay clear of "(11 skills)" sub-counts which the
       // guard intentionally ignores.
-      orig.replace(/\b58 skills:/, "777 skills:"),
+      orig.replace(new RegExp(`\\b${totalSkillCount} skills:`), "777 skills:"),
     );
 
     const result = runDriftGuard();
     expect(result.exitCode).not.toBe(0);
     expect(result.combined).toMatch(/studio\/CLAUDE\.md:\d+/);
     expect(result.combined).toContain('saw "777 skills"');
+    // Sanity: mutation targeted the live canonical total.
+    expect(canonical).toMatch(/^\d+ skills:$/);
   });
 
   test("drift in a plugin manifest description fails the guard", () => {
     captureAndMutate(".codex-plugin/plugin.json", (orig) =>
-      orig.replace(/\b58 skills/, "888 skills"),
+      orig.replace(new RegExp(`\\b${totalSkillCount} skills`), "888 skills"),
     );
 
     const result = runDriftGuard();

--- a/tests/e2e/release/tarball.test.ts
+++ b/tests/e2e/release/tarball.test.ts
@@ -93,6 +93,7 @@ describe("e2e: required files ship in the tarball", () => {
     "skills-manifest.json",
     "agents-manifest.json",
     "catalogs-manifest.json",
+    ".mcp.json",
     "scripts/postinstall.cjs",
     "studio/server.ts",
     "studio/package.json",
@@ -172,18 +173,18 @@ describe("e2e: forbidden paths do not ship", () => {
 // ===========================================================================
 
 describe("e2e: published package.json description carries canonical skill count", () => {
-  test("package.json description references 58 (canonical total)", () => {
+  test("package.json description references 63 (canonical total)", () => {
     // npm pack --json reports the file list but not contents; read the
     // working-tree package.json which the publish would have used.
     const pkg = JSON.parse(readFileSync(join(PROJECT_ROOT, "package.json"), "utf-8")) as {
       description: string;
     };
-    expect(pkg.description).toContain("58");
+    expect(pkg.description).toContain("63");
     expect(pkg.description).not.toContain("51 skills");
     expect(pkg.description).not.toContain("50 skills");
   });
 
-  test("all 4 plugin manifest descriptions reference 58", () => {
+  test("all 4 plugin manifest descriptions reference 63", () => {
     const claude = JSON.parse(readFileSync(join(PROJECT_ROOT, ".claude-plugin/plugin.json"), "utf-8")) as {
       description: string;
     };
@@ -199,10 +200,10 @@ describe("e2e: published package.json description carries canonical skill count"
     };
 
     for (const desc of [claude.description, marketplace.plugins[0]!.description, codex.description, gemini.description]) {
-      expect(desc).toContain("58");
+      expect(desc).toContain("63");
       expect(desc).not.toContain("51 skills");
       expect(desc).not.toContain("50 skills");
     }
-    expect(codex.interface.longDescription).toContain("57 marketing skills");
+    expect(codex.interface.longDescription).toContain("62 marketing skills");
   });
 });

--- a/tests/e2e/release/tarball.test.ts
+++ b/tests/e2e/release/tarball.test.ts
@@ -27,6 +27,8 @@ type PackResult = {
 let packReport: PackResult;
 let backupExists: boolean;
 
+// npm pack + prepack hooks can exceed bun's default 5s hook budget on CI
+// runners once the skills tree grows (Exa references/, Studio assets, etc.).
 beforeAll(async () => {
   const before = readFileSync(join(PROJECT_ROOT, "package.json"), "utf-8");
 
@@ -55,7 +57,7 @@ beforeAll(async () => {
     // Fail the test by leaving `backupExists` true OR by throwing — the
     // assertion in the first test surfaces it. Don't auto-repair silently.
   }
-});
+}, 120_000);
 
 // ===========================================================================
 // Size + entry-count regression guards

--- a/tests/e2e/skills/all-skills-run.test.ts
+++ b/tests/e2e/skills/all-skills-run.test.ts
@@ -8,7 +8,7 @@
 // - SKILL.md content has the required structural elements per CLAUDE.md
 //   (frontmatter with name+description, Anti-Patterns or equivalent section)
 //
-// Tier 2 skills (image-gen, higgsfield-trio, postiz, send-email, resend-inbound) are
+// Tier 2 skills (image-gen, higgsfield-trio, postiz, send-email, resend-inbound, exa quintet) are
 // flagged in REPORT.md as "blocked: Tier 2 pending" for the actual execution test.
 // We still validate their SKILL.md structure here because `mktg run --dry-run` is
 // API-free (it loads + validates the markdown, doesn't invoke the LLM body).
@@ -32,6 +32,11 @@ const TIER_2_SKILLS = new Set([
   "postiz",
   "send-email",
   "resend-inbound",
+  "exa-search",
+  "exa-contents",
+  "build-with-exa",
+  "company-research",
+  "lead-generation",
 ]);
 
 interface RunResult {
@@ -80,12 +85,12 @@ const manifest: SkillsManifest = await Bun.file(manifestPath).json();
 const skillNames = Object.keys(manifest.skills);
 
 describe("E2E: catalog totals", () => {
-  test("manifest contains 58 skills (catalog total)", () => {
-    expect(skillNames.length).toBe(58);
+  test("manifest contains 63 skills (catalog total)", () => {
+    expect(skillNames.length).toBe(63);
   });
 
-  test("Tier 2 set is the 7 documented external-API skills", () => {
-    expect(TIER_2_SKILLS.size).toBe(7);
+  test("Tier 2 set is the 12 documented external-API skills", () => {
+    expect(TIER_2_SKILLS.size).toBe(12);
     for (const t2 of TIER_2_SKILLS) {
       expect(skillNames).toContain(t2);
     }

--- a/tests/e2e/skills/cmo-orchestration.test.ts
+++ b/tests/e2e/skills/cmo-orchestration.test.ts
@@ -251,4 +251,9 @@ describe("E2E: 12 named playbooks reference real skills only", () => {
     expect(playbooks).toContain("higgsfield-generate");
     expect(playbooks).toContain("higgsfield-soul-id");
   });
+
+  test("playbooks mention Exa research skills for foundation work", async () => {
+    const playbooks = await Bun.file(playbooksPath).text();
+    expect(playbooks).toMatch(/exa-search|company-research/);
+  });
 });

--- a/tests/e2e/skills/cmo-orchestration.test.ts
+++ b/tests/e2e/skills/cmo-orchestration.test.ts
@@ -127,6 +127,24 @@ describe("E2E: routing table in cmo/SKILL.md routes the three input shapes corre
     expect(cmo).toMatch(/`higgsfield-soul-id`.*Creative/);
   });
 
+  test("Exa quintet is fully wired: routing table + disambiguation", async () => {
+    const cmo = await Bun.file(cmoPath).text();
+    for (const skill of [
+      "exa-search",
+      "exa-contents",
+      "company-research",
+      "lead-generation",
+      "build-with-exa",
+    ]) {
+      expect(cmo).toContain("`" + skill + "`");
+    }
+    // Disambiguation: open-ended search routes to exa-search, not firecrawl.
+    expect(cmo).toMatch(/"search the web for X"[\s\S]*?`exa-search`/);
+    expect(cmo).toMatch(/"generate leads"[\s\S]*?`lead-generation`/);
+    expect(cmo).toMatch(/"research this company"[\s\S]*?`company-research`/);
+  });
+
+
   test("Wave A removed the inline-vs-route image-gen contradiction", async () => {
     const cmo = await Bun.file(cmoPath).text();
     // The old guardrail at line 427 said "generate inline, don't route" which


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Ports [exa-labs/agent-skills](https://github.com/exa-labs/agent-skills) into marketing-cli as first-class drop-in skills (same bar as Higgsfield / firecrawl), and wires them through the full agent surface.

### Skills added (58 → 63)

| Skill | Role |
|---|---|
| `exa-search` | Semantic web search (`POST /search` / MCP `web_search_exa`) |
| `exa-contents` | Known-URL extraction (`POST /contents` / MCP `web_fetch_exa`) |
| `company-research` | Company deep dives + lists via Exa Agent |
| `lead-generation` | ICP prospect lists + CSV via Exa Agent |
| `build-with-exa` | API/SDK cookbook + full `references/` tree |

### Wiring

- Root `.mcp.json` (search + fetch + advanced + agent); shipped in tarball
- `EXA_API_KEY` on manifest → `mktg doctor` / Studio Settings env status
- `/cmo` + foundation skills + research agents + playbooks
- Counts synced (63 skills / 6 agents); calendar Today button typecheck fix

### Verification (this environment)

| Check | Result |
|---|---|
| Root `bun test` | **3183 pass / 0 fail** |
| Studio `bun test` | **225 pass / 0 fail** |
| Studio typecheck | pass |
| `mktg list` | 63/63 installed |
| Studio `/api/skills` | Exa quintet present |
| Studio `/api/activity/log` | `exa-search` skill-run logged |
| Studio `/api/settings/env/status` | `EXA_API_KEY` unset (expected) |
| Publish native queue | `cloud-hello-world` scheduled |

Set `EXA_API_KEY` from https://dashboard.exa.ai/api-keys for live Exa calls.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-722e2b84-bec0-40d1-aa38-dbf81c416c0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-722e2b84-bec0-40d1-aa38-dbf81c416c0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

