### PR TITLE
feat(skills): add /axi as main AXI catalog router

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "marketing-cli",
-      "description": "Agent-native marketing playbook CLI: 63 skills, 5 research/review agents, brand memory, and /cmo orchestration.",
+      "description": "Agent-native marketing playbook CLI: 64 skills, 5 research/review agents, brand memory, and /cmo orchestration.",
       "version": "0.6.0",
       "source": "./",
       "homepage": "https://github.com/MoizIbnYousaf/marketing-cli",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "marketing-cli",
   "version": "0.6.0",
-  "description": "Agent-native marketing playbook CLI: 63 skills, 5 research/review agents, brand memory, and /cmo orchestration.",
+  "description": "Agent-native marketing playbook CLI: 64 skills, 5 research/review agents, brand memory, and /cmo orchestration.",
   "author": {
     "name": "Moiz Ibn Yousaf",
     "url": "https://github.com/MoizIbnYousaf/marketing-cli"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "marketing-cli",
   "version": "0.6.0",
-  "description": "Agent-native marketing playbook CLI: 63 skills, 5 research/review agents, brand memory, and /cmo orchestration.",
+  "description": "Agent-native marketing playbook CLI: 64 skills, 5 research/review agents, brand memory, and /cmo orchestration.",
   "author": {
     "name": "Moiz Ibn Yousaf",
     "url": "https://github.com/MoizIbnYousaf/marketing-cli"
@@ -21,7 +21,7 @@
   "interface": {
     "displayName": "Marketing CLI",
     "shortDescription": "A CMO for your agent.",
-    "longDescription": "Install one CLI and give your agent 62 marketing skills, 5 research/review agents, persistent brand memory, native publishing workflows, and a local marketing studio.",
+    "longDescription": "Install one CLI and give your agent 63 marketing skills, 5 research/review agents, persistent brand memory, native publishing workflows, and a local marketing studio.",
     "developerName": "Moiz Ibn Yousaf",
     "category": "Productivity",
     "capabilities": [

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@
 > **For /cmo runtime indexes**, read `skills/cmo/rules/cli-runtime-index.md`,
 > `skills/cmo/rules/publish-index.md`, and
 > `skills/cmo/rules/studio-api-index.md`.
+> **For /axi (AXI catalog router — gh-axi, chrome-devtools-axi, principles)**, read `skills/axi/SKILL.md`.
 > **For development standards**, read `CLAUDE.md`.
 > This file covers the 5 marketing sub-agents and the drop-in contracts for skills and agents.
 
@@ -287,6 +288,8 @@ Studio auth: bearer token at `~/.mktg/.runtime/studio-token`. Open `http://127.0
 4. **Optional integrations**: Postiz / Typefully / Resend / Firecrawl / Exa are BYO. Exa is first-class via skills `exa-search`, `exa-contents`, `company-research`, `lead-generation`, `build-with-exa` + root `.mcp.json`. Set `EXA_API_KEY`; `mktg doctor` surfaces `integration-EXA_API_KEY`.
 5. **Tests**: root `bun test` (CLI); studio `bun run --cwd studio test` (or `bun run test` inside `studio/`). Do **not** run bare `bun test` in `studio/` — that also picks up `tests/e2e/perf` (Lighthouse fixtures) and fails without a prior `bun run tests/e2e/perf/run-lighthouse.ts`. No mocks — real temp-dir I/O.
 6. **Studio UI vs API in cloud VMs**: Bun API on `:3001` is the source of truth. The Next dashboard on `:3000` rewrites `/api/*` → Bun; that proxy can hang (`socket hang up` / HTTP 000) while direct `:3001` curls stay healthy. If the UI stays on skeletons, verify with `curl -H "Authorization: Bearer $(cat ~/.mktg/.runtime/studio-token)" http://127.0.0.1:3001/api/skills` and restart via `mktg studio --no-open` with `MKTG_PROJECT_ROOT` set to the checkout root. Do not start `bun run server.ts` alone without that root — native publish / brand paths will miss `/workspace/.mktg`.
+
+5. **`/axi`**: tool-interface orchestrator (parallel to `/cmo` for marketing). Prefer `npx -y gh-axi` / `npx -y chrome-devtools-axi` over eager MCP. See `skills/axi/SKILL.md`.
 
 ### Standard commands
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,16 @@
 
 ### feat
 
+- add `/axi` skill — main AXI ([axi.md](https://axi.md)) catalog router (same role as `/cmo` for marketing). Routes GitHub → `gh-axi`, browser → `chrome-devtools-axi`, plus community AXIs; ships the 10 principles, prefer-AXI vs MCP decision tree, build/review checklist, and benchmark snapshot. Upstream provenance from `kunchenguid/axi`.
+- `mktg doctor` optional CLI checks for `gh-axi` and `chrome-devtools-axi`.
+- `/cmo` ecosystem + disambiguation hand off GitHub/browser/tool-interface questions to `/axi`.
 - Port [exa-labs/agent-skills](https://github.com/exa-labs/agent-skills) as first-class mktg skills: `exa-search`, `exa-contents`, `company-research`, `lead-generation`, `build-with-exa` (with `build-with-exa/references/`).
 - Ship root `.mcp.json` for Exa MCP (search + fetch + advanced + agent tools); `EXA_API_KEY` on skill manifest surfaces via `mktg doctor`.
 - Wire Exa into `/cmo` routing + disambiguation, ecosystem/recency/safety rules, and all research/review agents.
 
 ### counts
 
-- 58 → 63 skills (1 orchestrator + 62 playbook skills).
+- 58 → 64 skills (2 orchestrators `/cmo` + `/axi`, plus Exa quintet and playbook skills).
 
 ## v0.6.0
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,17 +5,19 @@
 > **For `/cmo` runtime indexes**, read `skills/cmo/rules/cli-runtime-index.md`,
 > `skills/cmo/rules/publish-index.md`, and
 > `skills/cmo/rules/studio-api-index.md`.
+> **For `/axi` (AXI catalog router)**, read `skills/axi/SKILL.md` and `skills/axi/rules/`.
 > **For agent/skill contributor guidance**, read `AGENTS.md`.
 > This file is the project's development contract: architecture, standards, and rules.
 
 ## What This Is
 
-A TypeScript/Bun agent-native marketing playbook CLI. 63 marketing skills (62 playbook + `/cmo`), 6 agents, 20 commands, 1 upstream catalog. The Studio dashboard (Next.js + Bun API) ships inside the same tarball and is launched via `mktg studio`.
+A TypeScript/Bun agent-native marketing playbook CLI. 64 marketing skills (62 playbook + `/cmo`), 6 agents, 20 commands, 1 upstream catalog. The Studio dashboard (Next.js + Bun API) ships inside the same tarball and is launched via `mktg studio`.
 
 | Component | Count | Purpose |
 |---|---|---|
 | `mktg` CLI | 20 commands | Infrastructure: setup, health, skill management, catalog registry, verification, and orchestration |
 | `/cmo` skill | 1 orchestrator | Routes every marketing request to the right skill |
+| `/axi` skill | 1 orchestrator | Routes agent-tool work to AXI-catalog CLIs (gh-axi, chrome-devtools-axi, …) |
 | `brand/` directory | 10 memory files (+ SCHEMA.md) | Persistent marketing memory, compounds across sessions |
 | Marketing skills | 62 | The playbook, installed to `~/.claude/skills/` |
 | Marketing agents | 6 | Parallel sub-agents for research + review, installed to `~/.claude/agents/` |
@@ -46,7 +48,7 @@ src/
 │   ├── skill-add.ts    # External skill chaining (mktg skill add)
 │   ├── agents.ts       # Agent registry, install to ~/.claude/agents/
 │   └── transcribe.ts   # whisper.cpp + yt-dlp + ffmpeg pipeline
-skills/                  # 63 SKILL.md files installed to ~/.claude/skills/
+skills/                  # 64 SKILL.md files installed to ~/.claude/skills/
 skills-manifest.json     # Definitive skill list with metadata
 agents/                  # 6 agent .md files installed to ~/.claude/agents/
 agents-manifest.json     # Definitive agent list with metadata
@@ -219,7 +221,9 @@ mktg orchestrates external tools but does not bundle them. `mktg doctor` detects
 | `ffmpeg` | Video assembly, encoding | `brew install ffmpeg` |
 | `remotion` | Programmatic React video | `npm i -g @remotion/cli` |
 | `playwright-cli` | Browser automation | `npm i -g @playwright/cli` |
-| `gh` | GitHub CLI | `brew install gh` |
+| `gh` | GitHub CLI (prefer `gh-axi` via `/axi`) | `brew install gh` |
+| `gh-axi` | Agent-ergonomic GitHub CLI ([AXI](https://axi.md)) | `npm i -g gh-axi` or `npx -y gh-axi` |
+| `chrome-devtools-axi` | Agent-ergonomic browser CLI (AXI) | `npm i -g chrome-devtools-axi` or `npx -y chrome-devtools-axi` |
 | `whisper-cli` | Speech-to-text | `brew install whisper-cpp` |
 | `yt-dlp` | Media download | `brew install yt-dlp` |
 | [`summarize`](https://github.com/steipete/summarize) | Text compression | `npm i -g @steipete/summarize` |

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -144,6 +144,17 @@ mktg publish --native-list-posts --json
 Use Postiz or a browser profile when the user needs actual external network
 posting and the native backend is only acting as the local queue.
 
+## When to use `/axi` (AXI catalog router)
+
+`/axi` is the tool-interface orchestrator ([axi.md](https://axi.md)) — parallel to `/cmo` for marketing. Depth lives in `skills/axi/rules/`.
+
+| Situation | Use |
+|-----------|-----|
+| GitHub issues / PRs / CI / releases | `/axi` → `npx -y gh-axi` (prefer over raw `gh` / GitHub MCP) |
+| Browser click/fill/extract | `/axi` → `npx -y chrome-devtools-axi` |
+| "AXI vs MCP" / build an agent CLI | `/axi` (principles + build rules) |
+| Marketing copy / SEO / publish | `/cmo` (not `/axi`) |
+
 ## When to use `/cmo` vs direct commands
 
 | Situation | Use |

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p align="center">
   <a href="https://github.com/MoizIbnYousaf/marketing-cli/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-10b981" alt="MIT License"></a>
-  <img src="https://img.shields.io/badge/skills-63-10b981" alt="63 Skills">
+  <img src="https://img.shields.io/badge/skills-64-10b981" alt="64 Skills">
   <img src="https://img.shields.io/badge/agents-5-10b981" alt="5 Agents">
   <a href="https://www.npmjs.com/package/marketing-cli"><img src="https://img.shields.io/npm/v/marketing-cli?color=10b981" alt="npm"></a>
   <img src="https://img.shields.io/badge/tests-2,624-10b981" alt="2,624 tests">
@@ -12,7 +12,7 @@
 </p>
 
 <p align="center">
-  <b>One package. One install. CLI for the agent, Studio for the human. 63 skills, 6 research agents, brand memory that compounds.</b>
+  <b>One package. One install. CLI for the agent, Studio for the human. 64 skills, 6 research agents, brand memory that compounds.</b>
 </p>
 
 ---
@@ -25,7 +25,7 @@ One npm package, two surfaces. The CLI is the agent surface, the Studio dashboar
 
 | Surface | What it is | Path |
 |---|---|---|
-| `mktg` CLI | 63 skills, 6 agents, brand memory, `/cmo` orchestration | (root) |
+| `mktg` CLI | 64 skills, 6 agents, brand memory, `/cmo` orchestration | (root) |
 | Studio dashboard | Local Next.js + Bun API: pulse, signals, brand visualizer, publish queue | [`studio/`](studio/) |
 
 `npm i -g marketing-cli` installs both. The repo uses a bun workspace because Studio is a Next.js app with its own build, but at install time it is one package, one tarball.
@@ -34,7 +34,7 @@ One npm package, two surfaces. The CLI is the agent surface, the Studio dashboar
 
 You ask your agent for marketing help. It writes generic copy and forgets your audience by tomorrow. The skills it would use aren't installed; the brand files don't exist; the agent learns this halfway through, when something fails mid-execution. Every session is the first session.
 
-`marketing-cli` fixes that. Install once and your agent inherits 63 skills, 6 research agents, and a brand memory that compounds. Session 10 starts where session 9 ended. Every conversation builds on the last.
+`marketing-cli` fixes that. Install once and your agent inherits 64 skills, 6 research agents, and a brand memory that compounds. Session 10 starts where session 9 ended. Every conversation builds on the last.
 
 ---
 
@@ -57,7 +57,7 @@ You ask your agent for marketing help. It writes generic copy and forgets your a
 | | |
 |---|---|
 | **`mktg` CLI** | 20 commands, 21/21 Agent DX score, JSON-by-default |
-| **63 marketing skills** | The playbook, copied to `~/.claude/skills/` |
+| **64 marketing skills** | The playbook, copied to `~/.claude/skills/` |
 | **5 research + review agents** | Parallel sub-agents in `~/.claude/agents/` |
 | **10 brand memory files** | Persistent marketing memory in your project's `brand/` (10 templates plus `SCHEMA.md`), created by `mktg init` |
 | **`/cmo` orchestrator** | The brain that routes every request to the right skill |
@@ -97,7 +97,7 @@ mktg orchestrates; it doesn't reimplement. When a good tool already exists, we c
 npm i -g marketing-cli
 ```
 
-That's it. The global npm install copies the 63 skills into `~/.claude/skills/` and the 6 agents into `~/.claude/agents/`. No second install command, no `mktg init` to remember.
+That's it. The global npm install copies the 64 skills into `~/.claude/skills/` and the 6 agents into `~/.claude/agents/`. No second install command, no `mktg init` to remember.
 
 Then open Claude Code in your project and run:
 
@@ -232,7 +232,8 @@ Organized by marketing layer. Foundation builds up to distribution.
 
 | Skill | What it does |
 |-------|-------------|
-| **cmo** | Orchestrates all 63 skills. Routing table, disambiguation, guardrails. |
+| **cmo** | Orchestrates all 64 skills. Routing table, disambiguation, guardrails. |
+| **axi** | AXI catalog router — gh-axi, chrome-devtools-axi, principles, AXI vs MCP. |
 | **brand-voice** | Define or extract brand voice from existing content |
 | **audience-research** | Build buyer personas with parallel web research |
 | **competitive-intel** | Analyze competitors with real-time web intelligence |
@@ -347,7 +348,7 @@ The 3 research agents run **in parallel**. Results write back to `brand/` so eve
 | `mktg init` | Scaffold `brand/` plus install skills plus install agents |
 | `mktg status` | Project marketing state snapshot |
 | `mktg doctor` | Health checks: brand files, skills, agents, CLI tools, integrations |
-| `mktg list` | Show all 63 skills with install status and metadata |
+| `mktg list` | Show all 64 skills with install status and metadata |
 | `mktg update` | Re-install skills from latest package version |
 | `mktg schema` | Introspect all commands, flags, and output shapes |
 | `mktg skill` | Inspect, validate, register, analyze, and chain external skills |
@@ -471,7 +472,7 @@ Contributions welcome. The fastest ways to help:
 
 ## Acknowledgments
 
-- [Corey Haines' Marketing Skills](https://github.com/coreyhaines31/marketingskills): the breadth skill collection that inspired many of mktg's 63 skills
+- [Corey Haines' Marketing Skills](https://github.com/coreyhaines31/marketingskills): the breadth skill collection that inspired many of mktg's 64 skills
 - [Postiz](https://github.com/gitroomhq/postiz-app) by [@gitroomhq](https://github.com/gitroomhq): the upstream catalog for 30+ social provider integrations (LinkedIn, Reddit, Bluesky, Mastodon, Threads, Instagram, TikTok, YouTube, Pinterest, Discord, Slack, etc.). mktg connects via REST API; license stays firewalled.
 - [last30days-skill](https://github.com/mvanhorn/last30days-skill) by [@mvanhorn](https://github.com/mvanhorn): live research across Reddit, X, YouTube, Hacker News, GitHub, and the web. `/cmo` chains it before any market claim, so the playbook stays grounded in what's actually happening this month, not training-data folklore.
 - [`@steipete/summarize`](https://github.com/steipete/summarize) by [@steipete](https://github.com/steipete): the text-compression CLI that mktg's `summarize` skill wraps with rules and budgets.

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "marketing-cli",
   "version": "0.6.0",
-  "description": "Agent-native marketing playbook CLI: 63 skills, 5 research/review agents, brand memory, and /cmo orchestration."
+  "description": "Agent-native marketing playbook CLI: 64 skills, 5 research/review agents, brand memory, and /cmo orchestration."
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "marketing-cli",
   "version": "0.6.0",
-  "description": "Agent-native marketing playbook: 63 skills, 5 research agents, brand memory that compounds, plus a local Studio dashboard (beta). One install, then /cmo in Claude Code walks you through a 4-question setup wizard. CLI for the agent, Studio for the human.",
+  "description": "Agent-native marketing playbook: 64 skills, 5 research agents, brand memory that compounds, plus a local Studio dashboard (beta). One install, then /cmo in Claude Code walks you through a 4-question setup wizard. CLI for the agent, Studio for the human.",
   "type": "module",
   "workspaces": [
     "studio"

--- a/skills-manifest.json
+++ b/skills-manifest.json
@@ -47,6 +47,50 @@
         "precedence": "foundation-first"
       }
     },
+    "axi": {
+      "source": "new",
+      "upstream": {
+        "primary": {
+          "repo": "kunchenguid/axi",
+          "path": ".agents/skills/axi",
+          "snapshot_sha": "fbfe6d23f703ab2542d93bd6122846189950767b",
+          "snapshot_at": "2026-07-18T08:00:00Z"
+        }
+      },
+      "category": "knowledge",
+      "layer": "foundation",
+      "tier": "must-have",
+      "reads": [],
+      "writes": [],
+      "depends_on": [],
+      "triggers": [
+        "axi",
+        "gh-axi",
+        "chrome-devtools-axi",
+        "agent ergonomics",
+        "TOON output",
+        "prefer AXI",
+        "agent-facing CLI",
+        "AXI catalog",
+        "quota-axi",
+        "lavish-axi"
+      ],
+      "review_interval_days": 30,
+      "version": "0.1.0",
+      "routing": {
+        "triggers": [
+          "use axi",
+          "which AXI should I use",
+          "prefer axi over mcp",
+          "agent ergonomic cli",
+          "route to gh-axi",
+          "browser automation with axi"
+        ],
+        "requires": [],
+        "unlocks": [],
+        "precedence": "tool-first"
+      }
+    },
     "mktg-setup": {
       "source": "new",
       "category": "foundation",
@@ -2103,6 +2147,15 @@
     "lead-gen": "lead-generation",
     "prospect-list": "lead-generation",
     "exa-sdk": "build-with-exa",
-    "exa-api": "build-with-exa"
+    "exa-api": "build-with-exa",
+    "agent-experience": "axi",
+    "agent ergonomics": "axi",
+    "gh axi": "axi",
+    "chrome axi": "axi",
+    "chrome-devtools-axi": "axi",
+    "gh-axi": "axi",
+    "toon cli": "axi",
+    "axi catalog": "axi",
+    "prefer mcp": "axi"
   }
 }

--- a/skills/axi/SKILL.md
+++ b/skills/axi/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: axi
+description: >
+  Agent eXperience Interface (AXI) router — the main entry point for agent-ergonomic
+  CLIs. Use whenever the agent needs GitHub, browser automation, human review, quota
+  routing, Slack, Notion, AWS/Docker/K8s, databases, or any AXI-catalog tool; when
+  choosing AXI vs MCP vs raw CLI; when building or reviewing an agent-facing CLI; or
+  when the user says axi, gh-axi, chrome-devtools-axi, TOON output, agent ergonomics,
+  or "prefer AXI". When in doubt about which external tool interface to use, start here.
+allowed-tools:
+  - Bash(npx *)
+  - Bash(gh-axi *)
+  - Bash(chrome-devtools-axi *)
+  - Bash(mktg *)
+  - Bash(which *)
+  - Bash(npm *)
+  - Read
+  - Write
+---
+
+# /axi — Agent eXperience Interface Router
+
+AXI is not a protocol. It is **10 design principles** for agent-ergonomic CLIs that beat both raw CLI and MCP on success, cost, duration, and turns ([axi.md](https://axi.md), [kunchenguid/axi](https://github.com/kunchenguid/axi)).
+
+This skill is the **main router** for the AXI catalog (official + community). It picks the right AXI, installs/runs it agent-first (`npx -y <axi>`), and teaches the principles when you build or review agent-facing CLIs.
+
+## North Star
+
+| Depth | File |
+|---|---|
+| 10 principles (full spec) | [rules/principles.md](rules/principles.md) |
+| Official + community catalog | [rules/catalog.md](rules/catalog.md) |
+| AXI vs MCP vs raw CLI vs mktg tools | [rules/prefer-axi.md](rules/prefer-axi.md) |
+| Build / review an AXI | [rules/build.md](rules/build.md) |
+| Benchmark numbers | [rules/benchmarks.md](rules/benchmarks.md) |
+| Upstream build-skill snapshot | [references/upstream-axi-skill.md](references/upstream-axi-skill.md) |
+
+## Workflow (escalation)
+
+0. **Unclear** — User wants "the right tool." Detect domain → route via the table. Explain out loud.
+1. **Use** — An AXI exists for the domain. Prefer `npx -y <axi> …` (zero global install). Fall back to global binary if already on PATH.
+2. **Ambient** — Repeated sessions in one domain → suggest `<axi> setup hooks` (SessionStart) after explicit user opt-in.
+3. **Build / review** — Designing an agent-facing CLI → load [rules/principles.md](rules/principles.md) + [rules/build.md](rules/build.md). Do not invent a parallel MCP server first.
+4. **Missing AXI** — No catalog entry → prefer the least-bad existing path (mktg skill, raw CLI, MCP) per [rules/prefer-axi.md](rules/prefer-axi.md), and offer to scaffold a new AXI.
+
+## On Activation (every time)
+
+1. Restate the domain in one sentence ("You need GitHub PR/CI triage" / "You need live browser extraction").
+2. Probe availability (non-blocking):
+   - `which gh-axi chrome-devtools-axi 2>/dev/null; npx -y gh-axi --version 2>/dev/null | head -1`
+   - Optional: `mktg doctor --json --fields checks` and note `cli-gh`, `cli-gh-axi`, `cli-chrome-devtools-axi`.
+3. Route via the **AXI Routing Table**. Always say why: "I'm using `gh-axi` instead of raw `gh` / GitHub MCP because AXI wins on cost and success for GitHub tasks."
+4. Prefer **content-first** invocation: run the AXI with no args once to see live state + `help[]` next steps, then follow those templates.
+5. If the user is **building** a CLI for agents → skip catalog routing; open principles + build rules.
+6. Never silently fall back to MCP when an AXI exists for that domain.
+
+## AXI Routing Table
+
+| Need | AXI | Install / run | Layer |
+|---|---|---|---|
+| GitHub issues, PRs, CI runs, releases, secrets, projects | `gh-axi` | `npx -y gh-axi` (needs `gh auth login`) | Official |
+| Browse, click, fill, extract, tables, Lighthouse | `chrome-devtools-axi` | `npx -y chrome-devtools-axi` | Official |
+| Human review of HTML artifacts (annotate → agent feedback) | `lavish-axi` | `npx skills add kunchenguid/lavish-axi` / see catalog | Official |
+| Local Claude/Codex/Cursor/Copilot/Grok quota windows | `quota-axi` | see [rules/catalog.md](rules/catalog.md) | Official |
+| Jujutsu history | `jj-axi` | community | VCS |
+| npm registry inspect | `npm-axi` | community | Packages |
+| SQLite inspect / capped queries | `sqlite-axi` | community | Data |
+| Slack read/search/draft | `slack-axi` | community | Comms |
+| Gmail/Calendar/Docs/Drive/Slides (draft-only mail) | `gws-axi` | community | Workspace |
+| Harvest time tracking | `harvest-axi` | community | Ops |
+| Spec-driven agent workflow (AXI-in-skill demo) | `specops` | community | Process |
+| Git-backed record sheets | `gitsheets-axi` | community | Data |
+| Metabase SQL/MBQL | `metabase-axi` | community | Analytics |
+| Otter.ai transcripts | `otter-axi` | community | Meetings |
+| Notion pages/databases | `notion-axi` | community | Docs |
+| ClickUp tasks | `clickup-axi` | community | Tasks |
+| Databricks jobs/runs | `databricks-axi` | community | Data |
+| AWS host/deploy | `aws-axi` | community | Cloud |
+| Docker app lifecycle | `docker-axi` | community | Cloud |
+| DynamoDB | `dynamodb-axi` | community | Data |
+| PostgreSQL | `pg-axi` | community | Data |
+| MongoDB | `mongodb-axi` | community | Data |
+| Elasticsearch | `elasticsearch-axi` | community | Data |
+| Kubernetes workloads | `kubernetes-axi` | community | Cloud |
+| Redis | `redis-axi` | community | Data |
+| Celery queues | `celery-axi` | community | Cloud |
+| Design / review agent CLI ergonomics | (this skill → principles) | read rules | Meta |
+| Marketing playbook (brand, content, publish) | `/cmo` | `mktg` skills | Out of scope |
+
+Full URLs + one-liners: [rules/catalog.md](rules/catalog.md).
+
+## Disambiguation
+
+| User says | Route to | Not | Why |
+|---|---|---|---|
+| "check the PR / CI / issues" | `gh-axi` | raw `gh`, GitHub MCP | AXI: 100% success @ $0.050 vs CLI 86% / MCP ~$0.10–0.15 |
+| "open this page / click / fill form / extract table" | `chrome-devtools-axi` | chrome-devtools-mcp, agent-browser | Combined ops + `--query`; 100% @ $0.074, 4.5 turns |
+| "scrape this URL I already have" (static content) | `firecrawl` / `exa-contents` | `chrome-devtools-axi` | Don't pay for a browser when fetch/crawl is enough |
+| "search the web for X" (unknown URLs) | `exa-search` / Exa MCP | `chrome-devtools-axi` | Semantic search ≠ browser automation |
+| "automate Instagram/TikTok login post" | `/cmo` + browser profile / `mktg publish` | `chrome-devtools-axi` alone | Marketing distribution is `/cmo`'s job |
+| "help me market / write copy / SEO" | `/cmo` | `/axi` | AXI routes tools; CMO routes marketing skills |
+| "build a CLI for my agent" | `/axi` principles + build | MCP-first design | Principled CLI beats MCP on the published benches |
+| "use MCP for GitHub/browser" | Prefer matching AXI first | Eager MCP schemas | MCP schema overhead ~2.3× input tokens in browser bench |
+| "what's my Cursor/Claude quota" | `quota-axi` | guessing from UI | Local-first usage windows for routing-aware agents |
+| "review this HTML with humans" | `lavish-axi` | paste into chat | Annotation loop back to the agent |
+
+## First 5 Minutes (new machine)
+
+1. Confirm Node 20+ for `npx`.
+2. For GitHub work: `gh auth login` once, then `npx -y gh-axi` (home view).
+3. For browser work: `npx -y chrome-devtools-axi open https://example.com --query "Example"`.
+4. Optional ambient context: `npm i -g gh-axi && gh-axi setup hooks` (restart session).
+5. Tell the user which AXI you chose and the one-line why.
+
+## Guardrails
+
+- **Prefer AXI when a catalog entry exists** for that domain. Explain the preference; don't debate protocol religion.
+- **Zero-install first:** `npx -y <axi> …` before asking the user to `npm i -g`.
+- **Follow `help[]`:** AXI outputs next-step command templates — use them; don't invent flags.
+- **Fail loud:** unknown flags must error (exit 2). Never invent flags and trust unscoped output.
+- **No interactive prompts.** If a required value is missing, fail with a structured error + suggested command.
+- **Pipe for tokens:** `| head`, `| rg` on AXI stdout is encouraged; don't dump full snapshots into context when `--query` exists.
+- **Skills never call skills.** `/axi` orchestrates tool choice; leaf AXIs execute. Exception: `/cmo` owns marketing — hand off explicitly.
+- **Hooks are opt-in.** Never run `setup hooks` without clear user intent.
+- **TOON on the wire.** When building AXIs, stdout is TOON; keep internals on JSON. Spec: https://toonformat.dev/
+
+## Anti-Patterns
+
+| Anti-pattern | Why it's wrong | Do this instead |
+|---|---|---|
+| Loading full MCP tool schemas for GitHub/browser when an AXI exists | Schema tax balloons input tokens every turn | Route to `gh-axi` / `chrome-devtools-axi` |
+| `navigate` then separate `snapshot` every click | Doubles turns; AXI combines ops | `open`, `click --query`, `fill … --submit` |
+| Dumping full page snapshots into context | Burns the token budget | `--query "…"`, pipe filters, truncation + `--full` |
+| Silent fallback to raw `gh` because "I know the flags" | Raw CLI loses accuracy on the GitHub bench | Use `gh-axi`; keep `gh` only for gaps AXI doesn't wrap yet |
+| Building a new MCP server before an AXI CLI | Protocol choice ≠ ergonomics | Apply the 10 principles; ship CLI + optional skill + optional hooks |
+| Presenting the entire catalog as a menu | Shifts the decision to the human | Recommend 1 AXI with a one-line why |
+| Using browser AXI for static URL fetch | Overkill cost/latency | `firecrawl` / `exa-contents` / `curl` |
+
+## Error Recovery
+
+| Failure | Fix |
+|---|---|
+| `npx` / network blocked | Install global once: `npm i -g gh-axi` (or the needed AXI); retry |
+| `gh-axi` auth error | `gh auth login` (and `gh auth refresh -s project` when Projects need scope) |
+| `chrome-devtools-axi` bridge stale | `chrome-devtools-axi stop` then retry; or new `CHROME_DEVTOOLS_AXI_SESSION=…` |
+| `STALE_REF` on click | Re-`snapshot` / `open --query` and use the new `@g:…` ref |
+| Unknown command (`navigate`) | Read AXI `help[]` / `--help` — prefer `open`, not MCP verb names |
+| No AXI for domain | Use prefer-axi fallback; offer to scaffold per [rules/build.md](rules/build.md) |
+
+## Progressive Enhancement
+
+| Level | What `/axi` can do |
+|---|---|
+| L0 | Route by domain; run via `npx -y` with no prior setup |
+| L1 | Binaries on PATH; faster cold start |
+| L2 | `setup hooks` ambient home views for Claude Code / Codex / OpenCode |
+| L3 | Multiple community AXIs installed; quota-aware routing via `quota-axi` |
+| L4 | Team ships internal AXIs using principles + contributor catalog workflow |
+
+## Attribution
+
+Principles, catalog, and benchmarks from [AXI](https://axi.md) / [kunchenguid/axi](https://github.com/kunchenguid/axi) (MIT). This mktg skill is the **router + catalog orchestrator** adapted for `/cmo`-style activation; the upstream build-skill snapshot lives in `references/upstream-axi-skill.md`.

--- a/skills/axi/references/upstream-axi-skill.md
+++ b/skills/axi/references/upstream-axi-skill.md
@@ -1,0 +1,247 @@
+---
+name: axi
+description: >
+  Agent eXperience Interface (AXI) — ergonomic standards for building CLI tools that agents
+  use via shell execution. Use when building, modifying, or reviewing any agent-facing CLI.
+---
+
+# Agent eXperience Interface (AXI)
+
+AXI defines ergonomic standards for building CLI tools that autonomous agents interact with through shell execution.
+
+## Before you start
+
+Read the [TOON specification](https://toonformat.dev/reference/spec.html) before building any AXI output.
+
+## 1. Token-efficient output
+
+Use [TOON](https://toonformat.dev/) (Token-Oriented Object Notation) as the output format on stdout.
+TOON provides ~40% token savings over equivalent JSON while remaining readable by agents.
+Convert to TOON at the output boundary — keep internal logic on JSON.
+
+```
+tasks[2]{id,title,status,assignee}:
+  "1",Fix auth bug,open,alice
+  "2",Add pagination,closed,bob
+```
+
+## 2. Minimal default schemas
+
+Every field in stdout costs tokens — multiplied by row count in collections.
+Default to the smallest schema that lets the agent decide what to do next: typically an identifier, a title, and a status.
+
+- Default list schemas: 3-4 fields, not 10
+- Default limits: high enough to cover common cases in one call (if most repos have <100 labels, default to 100, not 30)
+- Long-form content (bodies, descriptions) belongs in detail views, not lists
+- Offer a `--fields` flag to let agents request additional fields explicitly
+
+## 3. Content truncation
+
+Detail views often contain large text fields. Omitting them forces agents to hunt; including them wastes tokens.
+Truncate by default and tell the agent how to get the full version.
+
+```
+task:
+  number: 42
+  title: Fix auth bug
+  state: open
+  body: First 500 chars of the issue body...
+    ... (truncated, 8432 chars total)
+help[1]: Run `tasks view 42 --full` to see complete body
+```
+
+- Never omit large fields entirely — include a truncated preview
+- Show the total size so the agent knows how much it's missing
+- Suggest the escape hatch (`--full`) only when content is actually truncated
+- Choose a truncation limit that covers most use cases (500-1500 chars)
+
+## 4. Pre-computed aggregates
+
+The most expensive token cost is often not a longer response — it's a follow-up call. If your backend has data that agents commonly need as a next step, compute it and include it.
+
+**Aggregate counts**: include the **total count** in list output, not just the page size. Agents need "how many are there?" and will paginate if the answer isn't definitive.
+
+```
+count: 30 of 847 total
+tasks[30]{number,title,state}:
+  1,Fix auth bug,open
+  ...
+```
+
+**Derived status fields**: when the next step almost always involves checking related state, include a lightweight summary inline.
+
+```
+task:
+  number: 42
+  title: Deploy pipeline fix
+  state: open
+  checks: 3/3 passed
+  comments: 7
+```
+
+Only include derived fields your backend can provide cheaply — a summary ("3/3 passed"), not the full data.
+
+## 5. Definitive empty states
+
+When the answer is "nothing", say so explicitly. Ambiguous empty output causes agents to re-run with different flags to verify.
+
+```
+$ tasks list --state closed
+tasks: 0 closed tasks found in this repository
+```
+
+State the zero with context. Make it clear the command succeeded — the absence of results is the answer.
+
+## 6. Structured errors & exit codes
+
+### Idempotent mutations
+
+Don't error when the desired state already exists. If the agent closes something already closed, acknowledge and move on with exit code 0. Reserve non-zero exit codes for situations where the agent's intent genuinely cannot be satisfied.
+
+```
+$ tasks close 42
+task: #42 already closed (no-op)    # exit 0
+```
+
+### Structured errors on stdout
+
+Errors go to **stdout** in the same structured format as normal output, so the agent can read and act on them. Include what went wrong and an actionable suggestion. Never let raw dependency output (API errors, stack traces) leak through.
+
+```
+error: --title is required
+help: tasks create --title "..." [--body "..."]
+```
+
+- Validate required flags before calling any dependency
+- Translate errors — extract actionable meaning, discard noise
+- Never leak dependency names — suggestions reference your CLI's commands, not the underlying tool
+
+### No interactive prompts
+
+Every operation must be completable with flags alone. If a required value is missing, fail immediately with a clear error — don't prompt for it. Suppress prompts from wrapped tools.
+
+### Fail loud on unrecognized input
+
+Reject unknown flags and arguments — never silently ignore them. A dropped flag is worse than an error: the agent gets plausible-looking output it believes is scoped or filtered, then proceeds confidently on wrong data. This is the same guarantee a CLI already owes for an unknown _command_; extend it to flags.
+
+```
+$ tasks list --stat closed
+error: unknown flag --stat for `list`
+help: valid flags for `list`: --state, --assignee, --limit (--help always allowed)
+```
+
+- **Validate before any dependency call**, with exit code 2 — the same as a missing required flag. Each command declares its own known flags; an unrecognized one is rejected by name and the command's valid flags are listed.
+- **`--help` always passes** — it's the one universal flag. Beyond it, a CLI may standardize its own always-allowed globals (e.g. an `--account` selector); whatever the set, those flags pass on every command and are never reported as unknown.
+- **Renamed or removed flags get a targeted hint**, not the generic list — point at what replaced them (`--status was renamed; use --state instead`) so the agent self-corrects in one step.
+- **Per-subcommand flag sets.** For grouped nouns where one command dispatches to subcommands (a `list` vs a `create` under the same noun), validate against the _subcommand's_ flags — they differ, and only the subcommand layer knows which is in play.
+- **Make the error self-correcting in one turn.** The agent's deterministic next move after an unknown-flag error is to run `<command> --help` (e.g. `tasks list --help`) — so fold that lookup into the error: list the valid flags inline, or print the command's concise `--help` block directly beneath it. Per §4 the expensive cost is the follow-up call, and per §10 per-command help is already concise, so inlining it collapses the two-turn correction into one.
+
+### Output channels
+
+- **stdout**: all structured output the agent consumes — data, errors, suggestions
+- **stderr**: debug logging, progress indicators, diagnostics (agents don't read this)
+- **Exit codes**: 0 = success (including no-ops), 1 = error, 2 = usage error
+
+Never mix progress messages into stdout. An agent that reads "Fetching data..." will try to interpret it as data.
+
+## 7. Ambient context via session integrations
+
+Register your tool into the agent's session lifecycle so every conversation starts with relevant state already visible — before the agent takes any action.
+
+**Pattern:**
+
+1. Provide an explicit setup command that installs or repairs a session hook or plugin after user intent is clear
+2. At session start, the integration runs your tool and provides a compact dashboard as context
+3. The agent receives this as initial context and can act immediately
+
+```
+# Agent sees this at session start — no invocation needed:
+specs[2]{id,title,status}:
+  1,Fix auth bug,open
+  2,Add pagination,in-progress
+
+help[2]:
+  Run `mytool specs view 1` for details
+  Run `mytool specs create --title "..."` to add a spec
+```
+
+**Rules:**
+
+- **Default app targets**: by default, support Claude Code, Codex, and OpenCode. Do not hard-code a single agent integration when the tool can reasonably support multiple agents
+- **Explicit opt-in**: register hooks or plugins only from a user-invoked setup command, not from ordinary CLI commands
+- **Portable commands**: hook commands should use a PATH-verified binary name when it resolves to the current executable, and fall back to the full absolute path otherwise. This keeps global installs portable while ensuring hooks do not accidentally run a different binary
+- **Path repair**: setup commands should check existing hooks and update the executable path if it has changed (e.g., after reinstall or relocation)
+- **Idempotent**: repeated installs with the same path are silent no-ops
+- **Directory-scoped**: show only state relevant to the current working directory
+- **Token-budget-aware**: this context loads on _every_ session — ruthlessly minimize it. Include just enough for the agent to orient and act; deep data belongs in explicit invocations
+- **Lifecycle capture**: use session-end hooks to capture what happened (transcripts, files touched, specs referenced) so future session-start context gets richer over time
+
+**How to integrate with each app:**
+
+- **Claude Code**: use native hooks in `~/.claude/settings.json` or project `.claude/settings.json`. Prefer `SessionStart` to inject compact context via stdout
+- **Codex**: use native hooks in `~/.codex/hooks.json` or `<repo>/.codex/hooks.json`, and ensure `[features].hooks = true` in `config.toml`. Prefer `SessionStart` for ambient context via stdout
+- **OpenCode**: use a managed plugin in `~/.config/opencode/plugins/`. Prefer ambient system-context injection for the home view rather than adding a custom tool
+
+**Also ship an installable skill (secondary recommendation):**
+
+The session hook is the primary integration, but it only helps agents whose harness supports hooks, and it loads on _every_ session.
+Offer an installable [Agent Skill](https://agentskills.io) as a secondary discovery path.
+It loads on demand when the agent recognizes a matching task, carries no per-session token cost, and works in any agent that supports the skill format.
+Recommend the hook first (ambient context plus live state) and the skill second (lower overhead, broader agent support) - they are complementary, and a user installs whichever fits, or both.
+
+```sh
+npx skills add <owner>/<repo> --skill <name>
+```
+
+- **Single source of truth**: generate `SKILL.md` from the same content your no-args home view prints, so the skill never drifts from the CLI's own guidance. Add a `--check` build step to CI that fails if the committed skill is stale
+- **Strip live state**: a skill is static, so omit dynamic data (open sessions, current items) that only the hook can show
+- **Non-interactive commands**: rewrite command examples to a form the agent can run without a global install (e.g. `npx -y mytool ...`), since a skill may be installed without the binary on PATH
+- **Trigger-shaped frontmatter**: include `name` and a `description` written as a trigger — terse and outcome-focused so the agent loads it on the right intent
+- **Document both paths**: in your README, present the hook and the skill as two ways to achieve the same thing, and make clear the user only needs one
+
+## 8. Content first
+
+Running your CLI with no arguments should show the most relevant live content — not a usage manual.
+When an agent sees actual state it can act immediately. When it sees help text, it has to make a second call.
+
+```
+$ tasks
+tasks[3]{id,title,status}:
+  1,Fix auth bug,open
+  2,Add pagination,open
+  3,Update docs,closed
+help[2]:
+  Run `tasks view <id>` to see full details
+  Run `tasks create --title "..."` to add a task
+```
+
+## 9. Contextual disclosure
+
+Include **a few next steps** that follow logically from the current output.
+The agent discovers your CLI's surface area organically by using it, not by reading a manual upfront.
+
+Rules:
+
+- **Relevant**: after an open item → suggest closing; after an empty list → suggest creating; after a list → suggest viewing
+- **Actionable**: every suggestion is a complete command (or template) carrying forward any disambiguating flags from the current invocation (e.g., `--repo`, `--source`)
+- **Parameterize dynamic values**: when a suggested command needs a runtime value such as an ID, title, branch, URL, or path, use placeholders like `<id>` or `"<title>"` instead of guessing a concrete value that may mislead the agent
+- **Omit when self-contained**: when the output fully answers the query (a detail view, a count, a confirmation), suggestions are noise — leave them out. Include them on list and mutation responses where the next step isn't obvious.
+- **Guide discovery, not workflows**: suggest a variety of possible next actions, don't prescribe a fixed sequence. An agent that already knows what it wants should never be nudged into an extra step.
+- **Reveal truncated lists**: when a list shows only the most recent N items out of a larger total, add a help hint telling the agent how to see all of them (e.g., `Run 'mytool list' for all 47 items`). Don't encode pagination into TOON array headers — use help hints instead.
+- **Resolve errors**: on errors, suggest the specific command that fixes the problem, not "see `--help`"
+
+## 10. Consistent way to get help
+
+The top-level home view should also identify the tool itself before the live data:
+
+- Include the absolute path of the current executable, with the user's home directory collapsed to `~`
+- Include a one-sentence description of what this AXI does
+
+```
+$ tasks
+bin: ~/.local/bin/tasks
+description: Manage project tasks in the current workspace
+...
+```
+
+Every subcommand should support `--help` with a concise, complete reference: available flags with defaults, required arguments, and 2-3 usage examples. Keep it focused on the requested subcommand — don't dump the entire CLI's manual.

--- a/skills/axi/rules/benchmarks.md
+++ b/skills/axi/rules/benchmarks.md
@@ -1,0 +1,43 @@
+# AXI Benchmark Snapshot
+
+Source: [axi.md](https://axi.md) / [kunchenguid/axi](https://github.com/kunchenguid/axi).
+Agent model in published runs: Claude Sonnet 4.6 (harness accepts `--model`; other models not published).
+
+## Browser automation (490 runs)
+
+14 tasks × 7 conditions × 5 repeats. Backend for MCP conditions: `chrome-devtools-mcp`.
+
+| Condition | Success | Avg Cost | Avg Duration | Avg Turns |
+|---|---|---|---|---|
+| **chrome-devtools-axi** | **100%** | **$0.074** | **21.5s** | **4.5** |
+| dev-browser | 99% | $0.078 | 28.6s | 4.9 |
+| agent-browser | 99% | $0.088 | 24.6s | 4.8 |
+| chrome-devtools-mcp-compressed | 100% | $0.091 | 29.7s | 7.6 |
+| chrome-devtools-mcp-search | 99% | $0.096 | 29.4s | 7.5 |
+| chrome-devtools-mcp | 99% | $0.100 | 26.0s | 6.2 |
+| chrome-devtools-mcp-code | 100% | $0.120 | 36.2s | 6.4 |
+
+Mechanisms: specialized extractors (`tables --url`), combined ops (`open`, `fill --submit`, `click --query`), pipe filtering, TOON metadata.
+
+## GitHub (425 runs)
+
+17 tasks × 5 conditions × 5 repeats.
+
+| Condition | Success | Avg Cost | Avg Duration | Avg Turns |
+|---|---|---|---|---|
+| **gh-axi** | **100%** | **$0.050** | **15.7s** | **3** |
+| gh (raw CLI) | 86% | $0.054 | 17.4s | 3 |
+| GitHub MCP + Code Mode | 84% | $0.101 | 43.4s | 7 |
+| GitHub MCP + ToolSearch | 82% | $0.147 | 41.1s | 8 |
+| GitHub MCP (eager) | 87% | $0.148 | 34.2s | 6 |
+
+Complex tasks widen the gap (e.g. `ci_failure_investigation`: AXI ~$0.065 vs MCP ~$0.758).
+
+## Caveats (from upstream)
+
+- Public sites / read-mostly tasks in the browser suite
+- Single published agent model
+- LLM judge for success
+- Principles are domain-general; evaluation focuses on browser + GitHub
+
+Use these numbers when explaining routing choices to humans — don't invent stats.

--- a/skills/axi/rules/build.md
+++ b/skills/axi/rules/build.md
@@ -1,0 +1,46 @@
+# Build or Review an AXI
+
+Use when the user wants a new agent-facing CLI, or a review of an existing one against AXI.
+
+## Checklist (map to principles.md)
+
+1. **TOON stdout** — lists/detail/errors in TOON; JSON only internally.
+2. **Minimal defaults** — 3–4 list fields; `--fields` escape hatch.
+3. **Truncation** — preview + `(truncated, N chars — use --full)`.
+4. **Aggregates** — `count`/`total`; inline CI/status summaries; combined operations for multi-step actions.
+5. **Empty states** — explicit zero-result lines on success.
+6. **Errors** — stdout structured errors; idempotent mutations; no prompts; unknown flags exit 2 with valid list.
+7. **Ambient** — `setup hooks` for Claude Code + Codex + OpenCode; ship Agent Skill as secondary.
+8. **Content first** — no-args home view with `bin`, `description`, live data, `help[]`.
+9. **Contextual disclosure** — next-step command templates; parameterize runtime values.
+10. **`--help`** — concise per subcommand.
+
+## Scaffold path (upstream)
+
+```sh
+npx skills add kunchenguid/axi
+```
+
+That installs the upstream build skill (snapshot also at `references/upstream-axi-skill.md`). Prefer generating `SKILL.md` from the same source as the no-args home view so skill ↔ CLI never drift (`--check` in CI).
+
+## Packaging patterns
+
+| Pattern | When | Example |
+|---|---|---|
+| npm CLI + `npx -y` | Default for reusable tools | `gh-axi`, `chrome-devtools-axi` |
+| Skill-embedded AXI | Internal / demo without global binary | `specops` |
+| Hooks + skill | Power users want ambient context | `gh-axi setup hooks` |
+
+## Review rubric (agent)
+
+For each principle 1–10, cite a concrete command output from the CLI under review. Fail the review if:
+
+- no-args prints only help text
+- list output lacks total count
+- mutations prompt interactively
+- unknown flags are silently ignored
+- errors dump raw SDK/stack traces to the agent
+
+## Contribute upstream
+
+After your AXI is solid, add it via the [AXI contributor workflow](https://github.com/kunchenguid/axi/blob/main/CONTRIBUTING.md) (`catalog.yaml` + `pnpm run docs:gen`).

--- a/skills/axi/rules/catalog.md
+++ b/skills/axi/rules/catalog.md
@@ -1,0 +1,62 @@
+# AXI Catalog
+
+Synced from [axi.md](https://axi.md) / [`catalog.yaml`](https://github.com/kunchenguid/axi/blob/main/catalog.yaml) at skill snapshot time.
+To add an AXI upstream: follow [CONTRIBUTING.md](https://github.com/kunchenguid/axi/blob/main/CONTRIBUTING.md).
+
+## Official (AXI project)
+
+| AXI | Domain | Repo | Agent run |
+|---|---|---|---|
+| `gh-axi` | GitHub | [kunchenguid/gh-axi](https://github.com/kunchenguid/gh-axi) | `npx -y gh-axi` (requires `gh auth login`) |
+| `chrome-devtools-axi` | Browser automation | [kunchenguid/chrome-devtools-axi](https://github.com/kunchenguid/chrome-devtools-axi) | `npx -y chrome-devtools-axi` |
+| `lavish-axi` | Human review | [kunchenguid/lavish-axi](https://github.com/kunchenguid/lavish-axi) | `npx skills add kunchenguid/lavish-axi` |
+| `quota-axi` | Quota / usage | [kunchenguid/quota-axi](https://github.com/kunchenguid/quota-axi) | `npx skills add kunchenguid/quota-axi` |
+
+Skill install (recommended by upstream for gh / chrome):
+
+```sh
+npx skills add kunchenguid/gh-axi --skill gh-axi -g
+npx skills add kunchenguid/chrome-devtools-axi --skill chrome-devtools-axi -g
+```
+
+Ambient hooks (opt-in, after global install):
+
+```sh
+npm i -g gh-axi && gh-axi setup hooks
+npm i -g chrome-devtools-axi && chrome-devtools-axi setup hooks
+# Restart the agent session after hooks install.
+```
+
+## Community
+
+| AXI | Author | Domain | Repo |
+|---|---|---|---|
+| `jj-axi` | aivv73 | Version control | [aivv73/jj-axi](https://github.com/aivv73/jj-axi) |
+| `npm-axi` | SSBrouhard | npm | [SSBrouhard/npm-axi](https://github.com/SSBrouhard/npm-axi) |
+| `sqlite-axi` | SSBrouhard | SQLite | [SSBrouhard/sqlite-axi](https://github.com/SSBrouhard/sqlite-axi) |
+| `slack-axi` | Jarvus Innovations | Slack | [JarvusInnovations/slack-axi](https://github.com/JarvusInnovations/slack-axi) |
+| `gws-axi` | Jarvus Innovations | Google Workspace | [JarvusInnovations/gws-axi](https://github.com/JarvusInnovations/gws-axi) |
+| `harvest-axi` | Jarvus Innovations | Time tracking | [JarvusInnovations/harvest-axi](https://github.com/JarvusInnovations/harvest-axi) |
+| `specops` | Jarvus Innovations | Spec-driven dev | [JarvusInnovations/specops](https://github.com/JarvusInnovations/specops) |
+| `gitsheets-axi` | Jarvus Innovations | Git-backed data | [gitsheets-axi package](https://github.com/JarvusInnovations/gitsheets/tree/main/packages/gitsheets-axi) |
+| `metabase-axi` | Jarvus Innovations | Analytics / BI | [JarvusInnovations/metabase-axi](https://github.com/JarvusInnovations/metabase-axi) |
+| `otter-axi` | Jarvus Innovations | Meetings | [JarvusInnovations/otter-axi](https://github.com/JarvusInnovations/otter-axi) |
+| `notion-axi` | maximebrmd | Notion | [maximebrmd/notion-axi](https://github.com/maximebrmd/notion-axi) |
+| `clickup-axi` | JanSuthacheeva | ClickUp | [JanSuthacheeva/clickup-axi](https://github.com/JanSuthacheeva/clickup-axi) |
+| `databricks-axi` | p33ves | Databricks | [p33ves/databricks-axi](https://github.com/p33ves/databricks-axi) |
+| `aws-axi` | thatdudealso | AWS | [thatdudealso/aws-axi](https://github.com/thatdudealso/aws-axi) |
+| `docker-axi` | thatdudealso | Docker | [thatdudealso/docker-axi](https://github.com/thatdudealso/docker-axi) |
+| `dynamodb-axi` | thatdudealso | DynamoDB | [thatdudealso/dynamodb-axi](https://github.com/thatdudealso/dynamodb-axi) |
+| `pg-axi` | thatdudealso | PostgreSQL | [thatdudealso/pg-axi](https://github.com/thatdudealso/pg-axi) |
+| `mongodb-axi` | thatdudealso | MongoDB | [thatdudealso/mongodb-axi](https://github.com/thatdudealso/mongodb-axi) |
+| `elasticsearch-axi` | thatdudealso | Elasticsearch | [thatdudealso/elasticsearch-axi](https://github.com/thatdudealso/elasticsearch-axi) |
+| `kubernetes-axi` | thatdudealso | Kubernetes | [thatdudealso/kubernetes-axi](https://github.com/thatdudealso/kubernetes-axi) |
+| `redis-axi` | thatdudealso | Redis | [thatdudealso/redis-axi](https://github.com/thatdudealso/redis-axi) |
+| `celery-axi` | thatdudealso | Celery | [thatdudealso/celery-axi](https://github.com/thatdudealso/celery-axi) |
+
+## Routing notes for /axi
+
+1. Official AXIs are the default for GitHub + browser.
+2. Community AXIs: check the repo README for `npx`/`skills add` entrypoints — patterns match official ones when they ship as AXI SDK CLIs.
+3. `specops` demonstrates an AXI **embedded in a skill** (not only as a global npm binary) — useful when packaging internal tools.
+4. Marketing distribution / brand / SEO stays on `/cmo` even if a community AXI overlaps a channel (e.g. Slack).

--- a/skills/axi/rules/prefer-axi.md
+++ b/skills/axi/rules/prefer-axi.md
@@ -1,0 +1,51 @@
+# Prefer AXI — Decision Tree
+
+The question is not "MCP vs CLI". It is **which interface is agent-ergonomic**. AXI is a principled CLI design that, on the published benches, leads both raw CLI and MCP on success, cost, duration, and turns.
+
+## Decision tree
+
+```
+Is this a marketing / brand / content / publish request?
+  YES → hand off to /cmo (do not invent an AXI path)
+  NO  ↓
+
+Does an AXI exist for this domain? (see catalog.md)
+  YES → use that AXI via npx -y (or PATH binary)
+  NO  ↓
+
+Is the task "fetch a known URL" / open-ended web search?
+  known URL → firecrawl or exa-contents (not browser AXI)
+  open search → exa-search / Exa MCP
+  else ↓
+
+Is there a raw CLI the agent already knows well AND no AXI?
+  YES → use raw CLI; note the ergonomics gap; offer to scaffold an AXI
+  NO  ↓
+
+Is there only an MCP server?
+  Prefer MCP-compressor / Code Mode only if no AXI and no good CLI
+  Otherwise: propose building an AXI wrapper (principles.md + build.md)
+```
+
+## When AXI wins (published evidence)
+
+| Domain | AXI | vs raw CLI | vs MCP |
+|---|---|---|---|
+| Browser (490 runs) | `chrome-devtools-axi` | Lower cost/turns than agent-browser | ~57% fewer input tokens vs eager MCP |
+| GitHub (425 runs) | `gh-axi` | 100% vs 86% success | ~66% cheaper than GitHub MCP |
+
+Details: [benchmarks.md](benchmarks.md).
+
+## mktg-specific forks
+
+| Need | Prefer | Avoid |
+|---|---|---|
+| GitHub release notes for a launch | `gh-axi` (then `/cmo` for copy) | GitHub MCP schemas in-context |
+| Competitor page scrape (URL known) | `firecrawl` | Browser AXI |
+| Live SERP / company discovery | `exa-search` / company-research | Browser AXI |
+| Logged-in social posting | `/cmo` publish adapters / browser profiles | Ad-hoc chrome-devtools-axi posting |
+| Local Studio dashboard | `mktg studio` | Treating Studio as an AXI |
+
+## Anti-default: eager MCP
+
+MCP reliability is real — but schema overhead compounds every turn. If an AXI wraps the same backend (chrome-devtools-mcp, `gh`), **route to the AXI**. Keep MCP for domains with no AXI and no decent CLI.

--- a/skills/axi/rules/principles.md
+++ b/skills/axi/rules/principles.md
@@ -1,0 +1,67 @@
+# The 10 AXI Principles
+
+Source of truth summary: [`principles.yaml`](https://github.com/kunchenguid/axi/blob/main/principles.yaml).
+Full build-oriented specification: [references/upstream-axi-skill.md](../references/upstream-axi-skill.md) (upstream `.agents/skills/axi/SKILL.md`).
+Read the [TOON spec](https://toonformat.dev/reference/spec.html) before implementing principle 1.
+
+## Efficiency
+
+### 1. Token-efficient output
+
+Use [TOON](https://toonformat.dev/) on stdout (~40% savings vs JSON). Convert at the output boundary; keep internals on JSON.
+
+```
+issues[2]{number,title,state}:
+  42,Fix login bug,open
+  43,Add dark mode,open
+```
+
+### 2. Minimal default schemas
+
+Default list items: 3–4 fields, not 10+. Offer `--fields` for expansion. Long bodies belong in detail views.
+
+### 3. Content truncation
+
+Truncate large text with a size hint and `--full` escape hatch. Never omit the field entirely.
+
+```
+body: First 500 chars...
+  ... (truncated, 8432 chars total — use --full)
+```
+
+## Robustness
+
+### 4. Pre-computed aggregates
+
+Include `count` / `total` and cheap derived summaries (e.g. `checks: "27 passed, 0 failed"`) so agents skip follow-up calls. Applied to **actions** too: combined ops (`open`, `fill --submit`, `click --query`) are aggregates over navigate+snapshot+filter.
+
+### 5. Definitive empty states
+
+Say `0 results` with context. Empty stdout is indistinguishable from silent failure.
+
+### 6. Structured errors & exit codes
+
+- Idempotent mutations → exit 0 on no-op
+- Structured errors on **stdout** (not raw dependency leaks)
+- No interactive prompts — flags only
+- Unknown flags → exit 2 with valid-flag list (self-correcting in one turn)
+- stdout = data/errors/suggestions; stderr = debug; exit 0/1/2
+
+## Discoverability
+
+### 7. Ambient context
+
+Primary: opt-in session hooks (`setup hooks`) for Claude Code / Codex / OpenCode that inject a compact directory-scoped home view.
+Secondary: installable Agent Skill generated from the same home-view guidance (`npx skills add …`).
+
+### 8. Content first
+
+No-args shows live state + `bin` + one-line `description`, not a usage manual.
+
+### 9. Contextual disclosure
+
+Append `help[]` next-step **command templates**. Carry fixed disambiguating flags; parameterize runtime values (`<id>`, `"…"`). Omit when the answer is self-contained.
+
+### 10. Consistent way to get help
+
+Every subcommand supports concise `--help` (flags, defaults, 2–3 examples). Do not dump the entire CLI manual.

--- a/skills/axi/scripts/check-upstream.sh
+++ b/skills/axi/scripts/check-upstream.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ----------------------------------------------------------------------
+# check-upstream.sh — drift detector for upstream-mirrored mktg skill
+# ----------------------------------------------------------------------
+# Reads ../upstream.json (the provenance manifest written by /mktg-steal).
+# Fetches current upstream blob SHAs via the GitHub API for each source
+# (scoped to its `upstream_root` subtree). Emits ONE JSON envelope on
+# stdout describing per-source drift.
+#
+# Exit codes:
+#   0  every source in_sync (no real drift; adapted-frontmatter ignored)
+#   1  drift detected (any added/removed file, OR any modified file
+#      that does NOT carry an `adapted-frontmatter` note)
+#   2  preflight failure (missing gh/jq, missing manifest, gh API error)
+#
+# Adapted-frontmatter convention:
+#   The `note: "adapted-frontmatter"` flag on a manifest file marks files
+#   that deliberately diverge from upstream (e.g. a SKILL.md whose
+#   frontmatter was rewritten for mktg). When the live upstream blob SHA
+#   differs from the snapshot, those files appear in `drift.modified` so
+#   the upstream change is still surfaced for manual review — but they
+#   DO NOT flip `in_sync` to false. Real upstream changes (added,
+#   removed, or modified-without-note) DO flip it.
+# ----------------------------------------------------------------------
+
+err() { echo "check-upstream: $*" >&2; }
+
+command -v gh >/dev/null 2>&1 || { err "gh CLI required"; exit 2; }
+command -v jq >/dev/null 2>&1 || { err "jq required"; exit 2; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MANIFEST="$SCRIPT_DIR/../upstream.json"
+[ -f "$MANIFEST" ] || { err "manifest not found: $MANIFEST"; exit 2; }
+jq -e . "$MANIFEST" >/dev/null 2>&1 || { err "manifest not valid JSON: $MANIFEST"; exit 2; }
+
+CHECKED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+SOURCE_COUNT=$(jq '.sources | length' "$MANIFEST")
+
+OVERALL_IN_SYNC=true
+SOURCES_JSON='[]'
+
+for ((i=0; i<SOURCE_COUNT; i++)); do
+  NAME=$(jq -r ".sources[$i].name" "$MANIFEST")
+  REPO=$(jq -r ".sources[$i].repo" "$MANIFEST")
+  BRANCH=$(jq -r ".sources[$i].branch" "$MANIFEST")
+  UROOT=$(jq -r ".sources[$i].upstream_root" "$MANIFEST")
+  SNAPSHOT_SHA=$(jq -r ".sources[$i].snapshot_sha" "$MANIFEST")
+
+  # Live tree scoped to upstream_root via tree-ish "<branch>:<subpath>".
+  # Paths in the response are relative to upstream_root, so we re-prefix
+  # them to match the manifest's `upstream` field shape.
+  if ! TREE_JSON=$(gh api "repos/$REPO/git/trees/$BRANCH:$UROOT?recursive=1" 2>/dev/null); then
+    err "gh api tree fetch failed: $REPO@$BRANCH:$UROOT"
+    exit 2
+  fi
+
+  if ! CURRENT_SHA=$(gh api "repos/$REPO/commits/$BRANCH" --jq .sha 2>/dev/null); then
+    err "gh api commit fetch failed: $REPO@$BRANCH"
+    exit 2
+  fi
+
+  # GitHub may set `truncated: true` for trees > 100k entries. None of
+  # the current upstreams come close, but warn loudly if it ever happens
+  # so future drift checks aren't silently incomplete.
+  if [ "$(echo "$TREE_JSON" | jq '.truncated // false')" = "true" ]; then
+    err "WARNING: tree response truncated for $REPO@$BRANCH:$UROOT — drift may be incomplete"
+  fi
+
+  MANIFEST_FILES=$(jq -c ".sources[$i].files" "$MANIFEST")
+
+  LIVE_FILES=$(echo "$TREE_JSON" | jq --arg root "$UROOT" -c '
+    [.tree[]
+     | select(.type == "blob")
+     | {upstream: ($root + "/" + .path), sha: .sha}]
+  ')
+
+  DRIFT=$(jq -n -c \
+    --arg root "$UROOT" \
+    --argjson manifest "$MANIFEST_FILES" \
+    --argjson live "$LIVE_FILES" '
+    ($live    | map({(.upstream): .sha}) | add // {})                                as $live_by_path |
+    ($manifest | map({(.upstream): {sha: .sha, note: (.note // null)}}) | add // {}) as $man_by_path  |
+    ($root + "/")                                                                    as $prefix       |
+
+    {
+      added: (
+        $live
+        | map(select($man_by_path[.upstream] == null))
+        | map({path: (.upstream | ltrimstr($prefix)), current_sha: .sha})
+      ),
+      modified: (
+        $manifest
+        | map(select(($live_by_path[.upstream] != null) and ($live_by_path[.upstream] != .sha)))
+        | map(
+            {
+              path: (.upstream | ltrimstr($prefix)),
+              snapshot_sha: .sha,
+              current_sha: $live_by_path[.upstream]
+            }
+            + (if .note then {note: .note} else {} end)
+          )
+      ),
+      removed: (
+        $manifest
+        | map(select($live_by_path[.upstream] == null))
+        | map({path: (.upstream | ltrimstr($prefix)), snapshot_sha: .sha})
+      )
+    }
+  ')
+
+  ADDED_N=$(echo "$DRIFT" | jq '.added | length')
+  REMOVED_N=$(echo "$DRIFT" | jq '.removed | length')
+  REAL_MOD_N=$(echo "$DRIFT" | jq '[.modified[] | select(has("note") | not)] | length')
+
+  if [ "$ADDED_N" -ne 0 ] || [ "$REMOVED_N" -ne 0 ] || [ "$REAL_MOD_N" -ne 0 ]; then
+    OVERALL_IN_SYNC=false
+  fi
+
+  SOURCES_JSON=$(jq -n -c \
+    --argjson acc "$SOURCES_JSON" \
+    --arg name "$NAME" \
+    --arg repo "$REPO" \
+    --arg snapshot "$SNAPSHOT_SHA" \
+    --arg current "$CURRENT_SHA" \
+    --argjson drift "$DRIFT" '
+    $acc + [{
+      name: $name,
+      repo: $repo,
+      snapshot_sha: $snapshot,
+      current_sha: $current,
+      drift: $drift
+    }]
+  ')
+done
+
+if [ "$OVERALL_IN_SYNC" = "true" ]; then
+  IN_SYNC_JSON=true
+  EXIT_CODE=0
+else
+  IN_SYNC_JSON=false
+  EXIT_CODE=1
+fi
+
+jq -n \
+  --arg checked_at "$CHECKED_AT" \
+  --argjson in_sync "$IN_SYNC_JSON" \
+  --argjson sources "$SOURCES_JSON" '
+  {
+    ok: true,
+    in_sync: $in_sync,
+    checked_at: $checked_at,
+    sources: $sources
+  }
+'
+
+exit $EXIT_CODE

--- a/skills/axi/upstream.json
+++ b/skills/axi/upstream.json
@@ -1,0 +1,29 @@
+{
+  "version": 1,
+  "fetched_at": "2026-07-18T08:00:00Z",
+  "tool": "/mktg-steal",
+  "sources": [
+    {
+      "name": "primary",
+      "repo": "kunchenguid/axi",
+      "branch": "main",
+      "snapshot_sha": "fbfe6d23f703ab2542d93bd6122846189950767b",
+      "snapshot_at": "2026-07-18T08:00:00Z",
+      "upstream_root": ".agents/skills/axi",
+      "local_root": "skills/axi",
+      "files": [
+        {
+          "local": "references/upstream-axi-skill.md",
+          "upstream": ".agents/skills/axi/SKILL.md",
+          "sha": "b7c5980346482bbb95e2658c8ab9854fe3e73de3"
+        },
+        {
+          "local": "SKILL.md",
+          "upstream": ".agents/skills/axi/SKILL.md",
+          "sha": "b7c5980346482bbb95e2658c8ab9854fe3e73de3",
+          "note": "adapted-frontmatter"
+        }
+      ]
+    }
+  ]
+}

--- a/skills/cmo/SKILL.md
+++ b/skills/cmo/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cmo
 description: |
-  A senior marketing operator for any project. Orchestrates 63 marketing skills to build brands, generate content, and distribute across channels. Use this skill whenever the user wants to do marketing  -  brand voice, copy, SEO, email, social, launches, or anything marketing-related. Also triggers on 'help me market', 'write copy', 'launch strategy', 'brand voice', 'SEO', 'content', 'email sequence', 'social posts', 'landing page', 'grow', 'audience', 'competitors', 'what should I do next for marketing', 'I need more users', 'how do I get people to care', or any marketing request. When in doubt about which marketing skill to use, start here  -  even if the user's request is vague or doesn't explicitly mention marketing.
+  A senior marketing operator for any project. Orchestrates 64 marketing skills to build brands, generate content, and distribute across channels. Use this skill whenever the user wants to do marketing  -  brand voice, copy, SEO, email, social, launches, or anything marketing-related. Also triggers on 'help me market', 'write copy', 'launch strategy', 'brand voice', 'SEO', 'content', 'email sequence', 'social posts', 'landing page', 'grow', 'audience', 'competitors', 'what should I do next for marketing', 'I need more users', 'how do I get people to care', or any marketing request. When in doubt about which marketing skill to use, start here  -  even if the user's request is vague or doesn't explicitly mention marketing.
 allowed-tools:
   - Bash(mktg *)
   - Bash(curl *)
@@ -11,7 +11,6 @@ allowed-tools:
 # /cmo  -  Chief Marketing Officer
 
 ## North Star
-
 For the persona contract  -  who the builder is, what /cmo's job is, and the suggest/ask/discuss/act/teach disciplines  -  see [rules/persona.md](rules/persona.md).
 
 For brand memory protocol, see [rules/brand-memory.md](rules/brand-memory.md).
@@ -55,7 +54,7 @@ Follow this escalation pattern. Always start at the highest applicable level:
 
 1. Run `mktg status --json` (or `mktg status --json --cwd <path>` for other projects)
 2. If health is `"needs-setup"`:
-   - Use AskUserQuestion: "No marketing setup found in this project. Want me to initialize marketing here? This will create a `brand/` directory and install 63 marketing skills."
+   - Use AskUserQuestion: "No marketing setup found in this project. Want me to initialize marketing here? This will create a `brand/` directory and install 64 marketing skills."
    - Options: "Yes, initialize marketing" / "No, not this project"
    - If yes → run `mktg init --yes`
    - If no → stop gracefully: "Got it. Run `/cmo` again when you're ready."
@@ -234,6 +233,7 @@ When a request is ambiguous, use this matrix:
 | "summarize this" / "TL;DR" / "make it shorter" | `summarize` | Direct LLM summary | The `summarize` CLI handles token budgets, length presets, and structured output. Don't reimplement. |
 | "scrape this page" / "fetch this URL" / "crawl this site" | `firecrawl` | `exa-contents` | Firecrawl = deep crawl/browser on known URLs. `exa-contents` = Exa extraction. Open-ended search → `exa-search`. |
 | "search the web for X" / "research a topic" | `exa-search` | `firecrawl` | Open-ended search via Exa. Firecrawl only fetches known URLs. Chain: exa-search → firecrawl/exa-contents. |
+| "GitHub PR/CI" / "browse+click" / "AXI vs MCP" | `/axi` (`gh-axi` / `chrome-devtools-axi`) | raw `gh` / eager MCP / `playwright-cli` alone | `/axi` owns tool-interface routing; static URL fetch still uses firecrawl. |
 | "check if this claim is still true" | `/last30days` | `firecrawl` | last30days aggregates social + community signal with recency guarantees. Firecrawl can't verify a claim on its own  -  it just returns a single page's content. |
 | "research this company" / "company deep dive" | `company-research` | `competitive-intel` | Exa engine for a company/list. competitive-intel owns brand/competitors.md and should call this. |
 | "generate leads" / "prospect list" / "ICP list" | `lead-generation` | `lead-magnet` | Outbound company lists via Exa Agent. lead-magnet = content asset that captures emails. |

--- a/skills/cmo/rules/ecosystem.md
+++ b/skills/cmo/rules/ecosystem.md
@@ -15,9 +15,23 @@
 | `remotion` | Programmatic React video compositions | Polished animated video with precise timing, typography, and brand-calibrated visual system. | `video-content` (tier 3) |
 | `whisper-cli` (whisper.cpp) | Speech-to-text | Transcribe audio/video for atomization. Source for `content-atomizer` on podcasts, videos, voicemails. | `mktg transcribe` |
 | `yt-dlp` | Media download | Pull YouTube/TikTok/podcast sources for transcription. | `mktg transcribe` |
-| `gh` | GitHub CLI | Release notes, launch announcements, open-source project metadata for launch submissions. | `startup-launcher`, `app-store-changelog` |
+| `gh` | GitHub CLI | Fallback when `gh-axi` is unavailable. Prefer AXI for agent GitHub work. | `startup-launcher`, `app-store-changelog` |
+| `gh-axi` | Agent-ergonomic GitHub CLI (AXI) | Issues, PRs, CI runs, releases — prefer over raw `gh` / GitHub MCP. | `/axi` router |
+| `chrome-devtools-axi` | Agent-ergonomic browser CLI (AXI) | Navigate/click/fill/extract with combined ops + `--query`. Prefer over eager chrome-devtools-mcp. | `/axi` router |
 | `summarize` (steipete/summarize) | Token-bounded text compression | Compress long pasted content before passing to downstream skills. | `/summarize` skill directly |
-| `playwright-cli` | Browser automation backend | Whenever a configured browser profile is the distribution path. | Browser profile skills |
+| `playwright-cli` | Browser automation backend | Logged-in marketing distribution profiles. For general browsing/extraction prefer `chrome-devtools-axi` via `/axi`. | Browser profile skills |
+
+### AXI catalog router (`/axi`)
+
+**What it is:** [AXI](https://axi.md) — 10 principles for agent-ergonomic CLIs + an official/community catalog (`gh-axi`, `chrome-devtools-axi`, `lavish-axi`, `quota-axi`, plus Slack/Notion/AWS/… community AXIs).
+
+**CMO routes to `/axi` when:**
+- The request is GitHub ops (PR/CI/issues/releases) — `/axi` → `gh-axi`.
+- The request needs interactive browser automation (not static URL fetch) — `/axi` → `chrome-devtools-axi`.
+- The user asks about AXI, TOON, or "AXI vs MCP".
+- Building/reviewing an agent-facing CLI.
+
+**CMO does NOT route to `/axi` when:** marketing copy/SEO/publish (stay in `/cmo`), known-URL scrape (`firecrawl` / `exa-contents`), or open-ended web search (`exa-search`).
 
 ---
 

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -174,6 +174,8 @@ const checkCLIs = async (): Promise<Check[]> => {
     { name: "yt-dlp", required: false },
     { name: "summarize", required: false },
     { name: "gh", required: false },
+    { name: "gh-axi", required: false },
+    { name: "chrome-devtools-axi", required: false },
     { name: "higgsfield", required: false },
   ] as const;
 
@@ -188,6 +190,8 @@ const checkCLIs = async (): Promise<Check[]> => {
     "yt-dlp": "brew install yt-dlp",
     summarize: "npm i -g @steipete/summarize",
     gh: "brew install gh",
+    "gh-axi": "npm i -g gh-axi   # or: npx -y gh-axi  (see /axi)",
+    "chrome-devtools-axi": "npm i -g chrome-devtools-axi   # or: npx -y chrome-devtools-axi  (see /axi)",
     higgsfield: "npm i -g @higgsfield/cli && higgsfield auth login",
   };
 

--- a/studio/CLAUDE.md
+++ b/studio/CLAUDE.md
@@ -4,7 +4,7 @@
 
 ## Driver/Dashboard Contract
 
-- **Driver:** /cmo (Claude Code) runs in the user's terminal. It reads brand/ files, executes the 62 marketing skills, and calls the studio's HTTP API (POST `/api/activity/log`, `/api/navigate`, `/api/toast`, `/api/brand/refresh`, etc.) to keep the dashboard in sync.
+- **Driver:** /cmo (Claude Code) runs in the user's terminal. It reads brand/ files, executes the 63 marketing skills, and calls the studio's HTTP API (POST `/api/activity/log`, `/api/navigate`, `/api/toast`, `/api/brand/refresh`, etc.) to keep the dashboard in sync.
 - **Dashboard:** Next.js + Bun server. Subscribes to `/api/events` (SSE) for live updates. Renders primary surfaces (Pulse, Signals, Publish, Brand, Settings) + a right-hand Activity panel that shows the /cmo activity stream. Trend radar is a Signals mode; Audience summary and next actions live on Pulse.
 - **Activity panel:** Replaces the old chat slot. Lists skill runs, brand writes, publishes, navigates, and toasts  -  a live log of what /cmo is doing.
 - **AGPL firewall:** Never import `@postiz/*`. Raw fetch only over the network boundary.
@@ -115,7 +115,7 @@ This project follows the same agent-native contract as mktg itself:
 ┌──────────────────┐ ┌──────────────────┐ ┌──────────────────────────┐
 │ Next.js 16 │────▶│ Bun.serve │────▶│ Claude Code (local) │
 │ Dashboard │◀─SSE│ (local server) │ │ ├── /cmo skill │
-│ │ │ SQLite │ │ ├── 62 marketing skills │
+│ │ │ SQLite │ │ ├── 63 marketing skills │
 │ 5 surfaces + │ │ brand/ watcher │ │ ├── mktg CLI (--json) │
 │ Activity panel │ │ Job queue │ │ └── Postiz adapter │
 └──────────────────┘ └──────────────────┘ └──────────────────────────┘
@@ -182,7 +182,7 @@ Tests: 2599 pass / 0 fail / 96 files
 │ └── transcribe.ts  -  whisper.cpp + yt-dlp + ffmpeg orchestration
 ├── skills/  -  50 SKILL.md files (see §Skills below)
 ├── agents/ - 6 agent .md files (see §Agents below)
-├── skills-manifest.json  -  63 skills: triggers, categories, layers, reads, writes, env_vars
+├── skills-manifest.json  -  64 skills: triggers, categories, layers, reads, writes, env_vars
 ├── agents-manifest.json - 6 agents: categories, files, reads, writes, tier
 ├── catalogs-manifest.json  -  1 catalog (postiz): capabilities, auth, transport, license
 ├── brand/SCHEMA.md  -  schema for all 10 brand files
@@ -258,7 +258,7 @@ Rules: ~/projects/mktgmono/marketing-cli/skills/cmo/rules/ (14 files, ~1,900 lin
 ```
 
 **What /cmo knows:**
-- Routes to any of 63 skills based on user intent + brand state
+- Routes to any of 64 skills based on user intent + brand state
 - 10 named orchestration playbooks (Full Product Launch, Content Engine, Founder Voice Rebrand, Conversion Audit, Retention Recovery, Visual Identity, Video Content, Email Infrastructure, SEO Authority Build, Newsletter Launch)
 - L0-L4 progressive enhancement ladder (what's possible at each brand completeness level)
 - Error recovery + degraded-mode playbook (what to do when integrations fail)
@@ -611,7 +611,7 @@ components/workspace/skill-browser/  -  skill browser + execution trigger UI
 - Port signal severity + spike detection from Convex to local TypeScript
 
 ### Phase 5: Skill Browser + Onboarding (2-3 days)
-- Skill browser: `mktg list --json` → browse all 63 skills, one-click trigger
+- Skill browser: `mktg list --json` → browse all 64 skills, one-click trigger
 - Execution progress: running → result → files changed
 - Onboarding: detect fresh install (mktg status → needs-setup) → wizard → mktg init → foundation skills
 - First-run "wow moment": Pulse, Signals, Publish, Brand, and Settings populate as foundation skills complete
@@ -631,7 +631,7 @@ components/workspace/skill-browser/  -  skill browser + execution trigger UI
 >
 > **Dashboard layer (this repo)**: 5 workspace tabs (Pulse, Signals, Publish, Brand, Settings), Activity panel, signal severity scoring. Local-first  -  no cloud dependencies.
 >
-> **mktg** is the marketing brain  -  63 skills, /cmo orchestrator (2,400 lines of routing knowledge), brand memory (10 files that compound), upstream catalogs. This is the engine. Everything runs through `mktg --json` for infrastructure and /cmo for intelligence.
+> **mktg** is the marketing brain  -  64 skills, /cmo orchestrator (2,400 lines of routing knowledge), brand memory (10 files that compound), upstream catalogs. This is the engine. Everything runs through `mktg --json` for infrastructure and /cmo for intelligence.
 >
 > **postiz** is the distribution layer  -  30+ social providers via REST API. AGPL-firewalled. Call it, never fork it.
 >

--- a/studio/README.md
+++ b/studio/README.md
@@ -2,7 +2,7 @@
 
 > The visual layer that ships inside [`marketing-cli`](https://www.npmjs.com/package/marketing-cli). Your brand memory on disk, one agent running the show.
 
-Studio is the dashboard companion to the `mktg` CLI. The CLI ships the brain: 62 marketing skills + the `/cmo` orchestrator. Studio ships the eyes: a Next.js dashboard, a local Bun API, SQLite, live SSE, and a 21/21 agent-DX HTTP surface that `/cmo` drives via Bash + curl. No SDK, no MCP config. Claude Code already has `Bash`; that's the whole contract.
+Studio is the dashboard companion to the `mktg` CLI. The CLI ships the brain: 63 marketing skills + the `/cmo` orchestrator. Studio ships the eyes: a Next.js dashboard, a local Bun API, SQLite, live SSE, and a 21/21 agent-DX HTTP surface that `/cmo` drives via Bash + curl. No SDK, no MCP config. Claude Code already has `Bash`; that's the whole contract.
 
 Studio lives under `studio/` inside the `marketing-cli` repo as a bun-workspace member. It is not a separate package. Installing the CLI brings the launcher with it.
 
@@ -11,7 +11,7 @@ Studio lives under `studio/` inside the `marketing-cli` repo as a bun-workspace 
 ## Quick start
 
 ```bash
-npm i -g marketing-cli         # CLI + /cmo + 63 skills + studio launcher
+npm i -g marketing-cli         # CLI + /cmo + 64 skills + studio launcher
 mktg init                      # seed brand/*.md in the current project
 mktg studio                    # boot API (:3001) + dashboard (:3000)
 ```

--- a/studio/app/layout.tsx
+++ b/studio/app/layout.tsx
@@ -35,7 +35,7 @@ export const metadata: Metadata = {
     template: "%s | mktg studio",
   },
   description:
-    "Local-first marketing studio powered by /cmo -- 63 skills, brand intelligence, and social distribution in one dashboard.",
+    "Local-first marketing studio powered by /cmo -- 64 skills, brand intelligence, and social distribution in one dashboard.",
 }
 
 export default function RootLayout({

--- a/tests/e2e/release/tarball.test.ts
+++ b/tests/e2e/release/tarball.test.ts
@@ -175,18 +175,18 @@ describe("e2e: forbidden paths do not ship", () => {
 // ===========================================================================
 
 describe("e2e: published package.json description carries canonical skill count", () => {
-  test("package.json description references 63 (canonical total)", () => {
+  test("package.json description references 64 (canonical total)", () => {
     // npm pack --json reports the file list but not contents; read the
     // working-tree package.json which the publish would have used.
     const pkg = JSON.parse(readFileSync(join(PROJECT_ROOT, "package.json"), "utf-8")) as {
       description: string;
     };
-    expect(pkg.description).toContain("63");
+    expect(pkg.description).toContain("64");
     expect(pkg.description).not.toContain("51 skills");
     expect(pkg.description).not.toContain("50 skills");
   });
 
-  test("all 4 plugin manifest descriptions reference 63", () => {
+  test("all 4 plugin manifest descriptions reference 64", () => {
     const claude = JSON.parse(readFileSync(join(PROJECT_ROOT, ".claude-plugin/plugin.json"), "utf-8")) as {
       description: string;
     };
@@ -202,10 +202,10 @@ describe("e2e: published package.json description carries canonical skill count"
     };
 
     for (const desc of [claude.description, marketplace.plugins[0]!.description, codex.description, gemini.description]) {
-      expect(desc).toContain("63");
+      expect(desc).toContain("64");
       expect(desc).not.toContain("51 skills");
       expect(desc).not.toContain("50 skills");
     }
-    expect(codex.interface.longDescription).toContain("62 marketing skills");
+    expect(codex.interface.longDescription).toContain("63 marketing skills");
   });
 });

--- a/tests/e2e/skills/all-skills-run.test.ts
+++ b/tests/e2e/skills/all-skills-run.test.ts
@@ -85,8 +85,8 @@ const manifest: SkillsManifest = await Bun.file(manifestPath).json();
 const skillNames = Object.keys(manifest.skills);
 
 describe("E2E: catalog totals", () => {
-  test("manifest contains 63 skills (catalog total)", () => {
-    expect(skillNames.length).toBe(63);
+  test("manifest contains 64 skills (catalog total)", () => {
+    expect(skillNames.length).toBe(64);
   });
 
   test("Tier 2 set is the 12 documented external-API skills", () => {

--- a/tests/e2e/skills/cmo-orchestration.test.ts
+++ b/tests/e2e/skills/cmo-orchestration.test.ts
@@ -186,6 +186,10 @@ describe("E2E: every routing-table skill name resolves to a real skill in the ma
         "learning-loop", "studio-integration", "recency-grounding",
         "persona", "communication", "ideas-library", "analytics-guide",
         "ai-slop-patterns", "exa", "exa-mcp",
+        // AXI catalog binaries / router leaf names (routed via /axi, not mktg skills)
+        "gh-axi", "chrome-devtools-axi", "lavish-axi", "quota-axi",
+        // Ecosystem CLIs named in prose (doctor-detected tools, not skills)
+        "gh", "playwright-cli", "ffmpeg", "whisper-cli", "yt-dlp",
         // Status field names + setup-preference values + platform identifiers
         // that appear in /cmo's prose but are not skill IDs.
         "integrations", "no", "yes", "configured", "suggestions",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds **`/axi`** — a `/cmo`-style main router for the [Agent eXperience Interface](https://axi.md) catalog so agents prefer agent-ergonomic CLIs over raw CLI / eager MCP.

### What `/axi` does

- **Routes** by domain → official AXIs (`gh-axi`, `chrome-devtools-axi`, `lavish-axi`, `quota-axi`) + community catalog (Slack, Notion, AWS/Docker/K8s, DBs, …)
- **On Activation** probes availability, explains routing out loud, prefers `npx -y <axi>`
- **Disambiguation** vs firecrawl / Exa / `/cmo` / MCP
- **Depth in `rules/`**: 10 principles, full catalog, prefer-AXI decision tree, build/review checklist, benchmark snapshot
- **Upstream provenance** from `kunchenguid/axi` (`upstream.json` + `check-upstream.sh` + verbatim build-skill snapshot)

### Wiring

- `skills-manifest.json`: 58 → **59** skills; redirects (`gh-axi` → `axi`, etc.)
- `mktg doctor`: optional `cli-gh-axi` / `cli-chrome-devtools-axi`
- `/cmo` ecosystem + disambiguation hand off GitHub/browser/tool-interface to `/axi`
- `CONTEXT.md` / `CLAUDE.md` / `AGENTS.md` / `CHANGELOG` / derive-counts surfaces

### Verification

- `bun test` → **3105 pass / 0 fail**
- `mktg list` → 59/59; `mktg run axi --dry-run` → prereqs satisfied
- `npx -y gh-axi --help` → live AXI CLI works in this env

### Note on Exa PR

This is based on current `main` (58 skills). The open Exa skills PR (#37) is separate; after both merge, derive-counts will land at 64.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-722e2b84-bec0-40d1-aa38-dbf81c416c0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-722e2b84-bec0-40d1-aa38-dbf81c416c0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

