### PR TITLE
ci(studio): run studio tests + typecheck in CI; fix time-of-day funnel flake

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -25,6 +25,23 @@ jobs:
       - name: Type check
         run: bun x tsc --noEmit
 
+      - name: Build CLI + install mktg shim
+        # Studio server tests bridge to a real `mktg` binary on PATH
+        # (studio/lib/mktg.ts spawns `mktg <cmd> --json`). Build dist and
+        # shim it via bun against the checkout.
+        run: |
+          bun run build
+          mkdir -p "$HOME/.local/bin"
+          printf '#!/bin/sh\nexec "%s/.bun/bin/bun" "%s/src/cli.ts" "$@"\n' "$HOME" "$GITHUB_WORKSPACE" > "$HOME/.local/bin/mktg"
+          chmod +x "$HOME/.local/bin/mktg"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Studio tests
+        run: bun run --cwd studio test
+
+      - name: Studio type check
+        run: bun run --cwd studio typecheck
+
       - name: Studio em-dash lint
         working-directory: studio
         run: bun run lint:em-dash

--- a/studio/lib/dx.ts
+++ b/studio/lib/dx.ts
@@ -255,7 +255,7 @@ export function applyFieldMaskStrict(
 
   // Empty list: no rows means no evidence to invalidate requested fields.
   // Without this guard, fieldHeadResolves() returns false for every head on
-  // an empty array, so any ?fields= probe on an empty list 400s — the mask
+  // an empty array, so any ?fields= probe on an empty list 400s: the mask
   // becomes environment-dependent (fresh DB vs seeded). The CLI-side
   // filterArrayItems already accepts masks on empty arrays; parity here.
   if (Array.isArray(data) && data.length === 0) return { ok: true, data };

--- a/studio/lib/dx.ts
+++ b/studio/lib/dx.ts
@@ -253,6 +253,13 @@ export function applyFieldMaskStrict(
     .filter((p) => p.length > 0 && /^[a-zA-Z0-9_.]+$/.test(p));
   if (paths.length === 0) return { ok: true, data };
 
+  // Empty list: no rows means no evidence to invalidate requested fields.
+  // Without this guard, fieldHeadResolves() returns false for every head on
+  // an empty array, so any ?fields= probe on an empty list 400s — the mask
+  // becomes environment-dependent (fresh DB vs seeded). The CLI-side
+  // filterArrayItems already accepts masks on empty arrays; parity here.
+  if (Array.isArray(data) && data.length === 0) return { ok: true, data };
+
   const missing: string[] = [];
   for (const path of paths) {
     const head = path.split(".")[0]!;

--- a/studio/tests/agent-dx.test.ts
+++ b/studio/tests/agent-dx.test.ts
@@ -15,11 +15,7 @@ import { spawn } from "bun";
 import { join } from "node:path";
 import { parseNdjson } from "../lib/ndjson.ts";
 
-// Port note: must stay unique across studio test files — bun runs files
-// concurrently, and two files sharing a port make each other's fetches hit
-// the wrong server (whichever wins the bind race). 3997 is taken by
-// tests/server/mktg-bridge-routes.test.ts.
-const TEST_PORT = 3993;
+const TEST_PORT = 3997;
 const BASE = `http://127.0.0.1:${TEST_PORT}`;
 const ROOT = join(import.meta.dir, "..");
 
@@ -182,6 +178,11 @@ describe("axis 3 — schema introspection", () => {
 describe("axis 4 — context window discipline", () => {
   test("/api/activity supports ?fields= dot-notation", async () => {
     const res = await fetch(`${BASE}/api/activity?fields=id,kind`);
+    if (!res.ok) {
+      // Diagnostic: the failure mode differs by environment (fresh DB vs
+      // seeded); surface the actual envelope instead of a bare boolean.
+      console.error(`[agent-dx] /api/activity?fields=id,kind -> ${res.status}: ${await res.text()}`);
+    }
     expect(res.ok).toBe(true);
     const body = (await res.json()) as { ok: boolean; data: unknown[] };
     expect(body.ok).toBe(true);

--- a/studio/tests/agent-dx.test.ts
+++ b/studio/tests/agent-dx.test.ts
@@ -15,7 +15,11 @@ import { spawn } from "bun";
 import { join } from "node:path";
 import { parseNdjson } from "../lib/ndjson.ts";
 
-const TEST_PORT = 3997;
+// Port note: must stay unique across studio test files — bun runs files
+// concurrently, and two files sharing a port make each other's fetches hit
+// the wrong server (whichever wins the bind race). 3997 is taken by
+// tests/server/mktg-bridge-routes.test.ts.
+const TEST_PORT = 3993;
 const BASE = `http://127.0.0.1:${TEST_PORT}`;
 const ROOT = join(import.meta.dir, "..");
 

--- a/studio/tests/unit/pulse-snapshot.test.ts
+++ b/studio/tests/unit/pulse-snapshot.test.ts
@@ -34,8 +34,17 @@ function freshDb(): Database {
 // in an INSERT's VALUES clause silently produce NULL created_at. Sidestep by
 // computing the ISO timestamp in JS and binding it as plain TEXT, matching
 // the format SQLite's date()/datetime() returns.
+//
+// Anchor to UTC midnight, NOT Date.now(): the funnel buckets by SQLite
+// date(created_at) calendar day. Seeding "now - N days + H hours" crosses a
+// day boundary whenever the suite runs within H hours of UTC midnight
+// (e.g. daysAgo=0 at 21:00 UTC + 6h lands on TOMORROW's day-key, which falls
+// outside the 14 keys ending today and silently vanishes from counts).
+// Midnight + ≤9h stays on the intended day-key at any wall-clock hour.
 function isoOffset(daysAgo: number, hours = 6): string {
-  const t = Date.now() - daysAgo * 24 * 60 * 60 * 1000 + hours * 60 * 60 * 1000
+  const now = new Date()
+  const utcMidnight = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())
+  const t = utcMidnight - daysAgo * 24 * 60 * 60 * 1000 + hours * 60 * 60 * 1000
   return new Date(t).toISOString().slice(0, 19).replace("T", " ")
 }
 function seedSignal(db: Database, daysAgo: number, hourOffset = 6): void {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Step 0.5 of the end-to-end wiring sequence (audit finding: **Studio's 225 tests were not running in CI** — every Studio-affecting phase flew without a net). Enabling the suite in CI immediately caught **two real latent bugs**, both fixed here.

### Changes

1. **`pr-checks.yml` gains two gates**: `bun run --cwd studio test` (225 tests) and `bun run --cwd studio typecheck`, plus a build step that compiles `dist/` and shims `mktg` onto PATH — the server bridge tests spawn a real `mktg` binary via `studio/lib/mktg.ts`.

2. **Time-of-day flake fix** (`studio/tests/unit/pulse-snapshot.test.ts`): seeds were computed as `Date.now() - N days + H hours`; the funnel buckets by SQLite `date(created_at)` calendar day, so within H hours of UTC midnight seeds crossed a day boundary and silently vanished from the 14-day window (7 failures at 21:00 UTC, 0 before ~18:00). Now anchored to UTC midnight.

3. **Port collision fix** (`studio/tests/agent-dx.test.ts`): shared port 3997 with `tests/server/mktg-bridge-routes.test.ts`. bun runs test files concurrently; the loser of the bind race hit the wrong server. Invisible while CI never ran the suite. Now on unique 3993.

4. **Real server bug fix** (`studio/lib/dx.ts`): `applyFieldMaskStrict` resolved field heads from data — on an **empty array every field misses**, so `?fields=id,kind` on an empty `/api/activity` returned `400 BAD_INPUT`. The mask was environment-dependent: green on seeded DBs, red on fresh ones (exactly why CI caught it and local didn't). Empty list = no evidence to invalidate fields; accept and return `[]`, matching the CLI-side `filterArrayItems` behavior.

### Verification

- `bun run --cwd studio test` → **225 pass / 0 fail** (run at 21:50 UTC — previously 4–7 failures at this hour)
- `bun run --cwd studio typecheck` → pass; em-dash lint → clean
- Root `bun test` unaffected
- CI on this PR: green (Test & Type Check + GitGuardian)

### Sequence context

Next up: M1 honest run lifecycle (#43), M2 activation (#44), M3 publish truth (#45), catalog research capability (#46), M4 portable orchestrate (#47).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d221b2b7-a08b-4b51-a74a-5bb038a8ccd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d221b2b7-a08b-4b51-a74a-5bb038a8ccd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

