### PR TITLE
feat(cli): honest run lifecycle — event loaded|completed, --complete/--writes/--result (M1)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -70,7 +70,18 @@ mktg status --json --fields "brand.populated,skills.installed"
 
 ```bash
 mktg run brand-voice --json
-# Returns skill content + metadata + brand context
+# Returns skill content + prerequisites + prior run context.
+# Logs event:"loaded" — a load is NOT work and never unlocks plan distribute steps.
+# For brand context, call `mktg context` (below) — `run` does not return it.
+```
+
+### 3b. Record the outcome after doing the work
+
+```bash
+mktg run brand-voice --complete --writes brand/voice-profile.md --result success --json
+# --writes paths must exist inside the project (validated, exit 2 otherwise).
+# Only event:"completed" records count as executed work in `mktg plan`.
+# History: mktg skill history <skill> --json (shows loaded vs completed events).
 ```
 
 ### 4. Get token-budgeted brand context
@@ -162,7 +173,9 @@ posting and the native backend is only acting as the local queue.
 | User says "help me with marketing" | `/cmo`; it routes to the right skill |
 | Agent needs project state | `mktg status --json` |
 | Agent needs health check | `mktg doctor --json` |
-| Agent needs a specific skill loaded | `mktg run <skill> --json` |
+| Agent needs a specific skill loaded | `mktg run <skill> --json` (logs `event:"loaded"`) |
+| Agent finished the work and records it | `mktg run <skill> --complete --writes <paths> --result success --json` |
+| Agent needs load vs completion history | `mktg skill history <skill> --json` |
 | Agent needs brand context for a skill | `mktg context --json` |
 | Updating skills after package upgrade | `mktg update --json` |
 | Checking whether a newer marketing-cli is on npm | `mktg update --check --json` |

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ indexes under `skills/cmo/rules/`:
 | [transcribe.md](transcribe.md) | `mktg transcribe` command — usage, flags, pipeline, dependencies |
 | [EXIT_CODES.md](EXIT_CODES.md) | Exit code reference — codes 0-6, constructors, agent usage |
 | [plans/2026-04-25-001-feat-cmo-studio-boot-session-plan.md](plans/2026-04-25-001-feat-cmo-studio-boot-session-plan.md) | CMO Studio boot session plan — command-driven, hook-free startup contract |
+| [cli-improvement-plan.md](cli-improvement-plan.md) | Phased CLI improvement plan — honest run lifecycle, plan/publish truth, portable route |
 
 ## Subdirectories
 

--- a/docs/cli-improvement-plan.md
+++ b/docs/cli-improvement-plan.md
@@ -1,0 +1,494 @@
+# CLI Improvement Plan — marketing-cli (`mktg`)
+
+> Sprint-persistence doc for making the CLI’s orchestration loop trustworthy.
+> Status: `in_progress` (plan authored). Resume by picking the next `pending` phase.
+
+## Reference data (don’t modify without explicit instruction)
+
+| Field | Value |
+|---|---|
+| Product | `marketing-cli` / `mktg` |
+| Package manager | Bun |
+| North star | Agent-native playbook OS — skills are LLM playbooks; CLI owns memory, contracts, prereqs, outcomes, publish truth |
+| Non-goal | Become “AI that writes LinkedIn inside the CLI” / replace the agent |
+| Evidence base | Cloud dogfood 2026-07-18: 64-skill install, offline GTM pack, native publish staging |
+| Related | `CONTEXT.md`, `CLAUDE.md`, `AGENTS.md`, `docs/skill-contract.md` |
+
+### Dogfood findings that drive this plan
+
+1. **`mktg run` ≠ work** — loads `SKILL.md`, logs `result: "success"`, often with empty `brandFilesChanged`.
+2. **`mktg plan` trusts the wrong signal** — can recommend distribute after a load-only “run.”
+3. **Docs oversell the load envelope** — `CONTEXT.md` says run returns brand context; it doesn’t (separate `mktg context`).
+4. **Prereqs are incomplete** — brand/skill deps only; tools/envs/catalogs absent → Tier-2 skills look green then fail mid-playbook.
+5. **Publish status is ambiguous** — `mktg-native --confirm` queues locally; agents read that as “posted.”
+6. **Two human UIs** — `dashboard` vs `studio` confuse agents and humans.
+7. **`mktg cmo` is Claude-Code-coupled** — no portable structured router for Cursor/Codex/CI.
+8. **Catalog sync/status partially stubbed** — advertised behavior ≠ implementation (exit 6 / null health).
+
+---
+
+## Phase Status Tracker
+
+| # | Phase | Status | PR/Commit | Notes |
+|---|---|---|---|---|
+| 0 | Plan authored (this doc) | `completed` | — | 2026-07-18 |
+| 1 | Honest skill lifecycle (`loaded` vs `completed`) | `pending` | | Foundation for everything else |
+| 2 | One-shot activation (`run --with-context`) | `pending` | | Can ship parallel to P1 after log shape lands |
+| 3 | Outcome-aware `plan` / `status` / dashboard | `pending` | | Depends on P1 |
+| 4 | Rich prerequisites + `--strict` | `pending` | | |
+| 5 | Publish truth + promote path | `pending` | | |
+| 6 | Portable `mktg route` (+ CMO runner clarity) | `pending` | | |
+| 7 | Studio vs dashboard consolidation | `pending` | | |
+| 8 | Studio npm resolve + doctor check | `pending` | | Small; can jump ahead |
+| 9 | Catalog sync/probe (or un-advertise) | `pending` | | |
+| 10 | Skill script exec allowlist | `pending` | | Bigger bet |
+| 11 | Strict skill-contract enforcement | `pending` | | |
+| 12 | Docs/CONTEXT/`/cmo` index sync | `pending` | | Continuous; hard gate before each release |
+
+Status values: `pending` → `in_progress` → `completed` | `skipped` (with reason).
+
+---
+
+## Principles (non-negotiable)
+
+1. **Progressive enhancement** — every skill still works at L0; brand enhances, never gates.
+2. **Agent DX 21/21 preserved** — JSON, `--dry-run`, `--fields`, schemas, validators, safety rails.
+3. **Skills never call skills** — CLI + `/cmo`/`route` orchestrate; skills read/write files.
+4. **Honesty over magic** — statuses name what actually happened (`loaded`, `queued-local`, `unimplemented`).
+5. **No mocks in tests** — real temp dirs; no fake “success” without real writes when asserting completion.
+6. **Ship vertical slices** — each phase leaves `bun test` green and CONTEXT accurate.
+
+---
+
+## Target loop (end state)
+
+```text
+doctor → status → route|cmo → run --with-context (loaded)
+  → agent produces files under brand/|marketing/|.mktg/
+  → run --complete --writes … --result … (completed)
+  → plan (artifact-aware next steps)
+  → publish (queued-local | draft-external | sent)
+```
+
+---
+
+## Phase 1 — Honest skill lifecycle
+
+**Problem:** Load is logged as success; agents and `plan` believe work happened.
+
+### Scope
+
+| Change | Detail |
+|---|---|
+| Log events | `loaded` (default) vs `completed` (explicit) |
+| Flags | `--complete`, `--result success\|partial\|failed`, `--writes <paths>`, keep `--learning` |
+| Default | `mktg run X` logs `loaded`, not `success` |
+| History | `mktg run <skill> --history --json` (or `mktg skill history`) returns both event types |
+| Schema | Update `run` responseSchema + examples |
+| Backward compat | Consumers that key on `result: "success"` for loads: document break; prefer alias field `event: "loaded"\|"completed"` and deprecate treating load as success |
+
+### Acceptance criteria
+
+- [ ] Bare `mktg run seo-content --json` → `event: "loaded"`, history entry is not counted as execution by plan
+- [ ] `mktg run seo-content --complete --writes marketing/content/x.md --result success --json` validates writes exist (sandboxPath), logs `completed`
+- [ ] Missing/invalid write paths → exit 2 with fix guidance (no silent success)
+- [ ] Integration tests cover load vs complete; plan fixture proves load alone doesn’t unlock distribute
+- [ ] `CONTEXT.md` §“Load a skill” wording matches reality
+
+### Invasiveness
+
+**M** — `src/commands/run.ts`, history store, plan consumers, schema, a few integration tests.
+
+### Suggested commit series
+
+1. Add `event` field + stop defaulting load to `success` (compat note in changelog)
+2. Add `--complete` / `--writes` / `--result`
+3. Wire plan/status to `completed` only (Phase 3 can finish scoring)
+
+---
+
+## Phase 2 — One-shot activation envelope
+
+**Problem:** Agents need 2–3 calls (`run` + `context` + sometimes claims) before executing a skill.
+
+### Scope
+
+| Change | Detail |
+|---|---|
+| Flag | `mktg run <skill> --with-context [--budget N] --json` |
+| Payload | `{ skill, content, prerequisites, priorRuns, context: { files, layer, claimsBlacklist? } }` |
+| Selection | Use manifest `reads` + `CONTEXT_MATRIX`; respect token budget |
+| Default | Opt-in first; consider default-on after one minor release if payload size OK |
+
+### Acceptance criteria
+
+- [ ] Single call returns skill body + non-template brand slices for declared `reads`
+- [ ] `--fields` can trim `context.files.*` / omit `content`
+- [ ] Budget overflow returns structured warning + truncated file list (no silent drop without signal)
+- [ ] Docs claim in CONTEXT.md becomes true when flag is used
+
+### Invasiveness
+
+**S** — compose existing `context` + `run` handlers.
+
+---
+
+## Phase 3 — Outcome-aware plan / status / dashboard
+
+**Problem:** Detection-order “plan” and existence heuristics recommend the wrong next move.
+
+### Scope
+
+| Change | Detail |
+|---|---|
+| Signals | Count `completed` runs; scan `marketing/` for artifacts; brand template vs populated |
+| Scoring | setup → populate → refresh → execute → distribute (documented weights) |
+| Distribute gate | Require artifacts under `marketing/` **or** completed run with writes — never load-only |
+| Health | `ready` only when foundation non-template thresholds met (define exactly in schema) |
+| Commands on tasks | Prefer `mktg run X --with-context` / `mktg route` / `mktg cmo --dry-run` over bare `mktg run` |
+| Dashboard JSON | Same semantics as CLI plan (no divergent heuristics) |
+
+### Acceptance criteria
+
+- [ ] Fixture: brand templates → plan says populate, not distribute
+- [ ] Fixture: load-only history → plan still recommends execute/content skills
+- [ ] Fixture: `marketing/content/**` present → distribute tasks appear
+- [ ] Schema documents ranking (no more “detection order only” lie)
+- [ ] Agent DX tests updated for new plan fields
+
+### Invasiveness
+
+**M** — `plan.ts`, status summary fields, dashboard contract tests.
+
+---
+
+## Phase 4 — Rich prerequisites + `--strict`
+
+**Problem:** Tier-2 skills pass prereq checks then fail for missing API keys/CLIs.
+
+### Scope
+
+| Check class | Sources |
+|---|---|
+| Skills | `depends_on` (existing) |
+| Brand | `reads` + template detection (existing) |
+| Tools | Ecosystem table / doctor tool registry |
+| Envs | Manifest / skill frontmatter `env_vars` |
+| Catalogs | `catalog info` configured/missing_envs |
+
+| Flag | Behavior |
+|---|---|
+| default | Warn in `prerequisites` object (today’s spirit) |
+| `--strict` | Unsatisfied required prereq → exit 3/4 with `remediation[]` |
+
+### Acceptance criteria
+
+- [ ] `mktg run postiz --json` surfaces `POSTIZ_API_KEY` missing even without `--strict`
+- [ ] `mktg run postiz --strict --json` non-zero exit when key missing
+- [ ] Offline skill (e.g. `content-atomizer`) remains exit 0 with empty envs
+- [ ] Doctor and run remediation strings stay consistent (same install hints)
+
+### Invasiveness
+
+**M** — shared prereq module used by `run` + `doctor`.
+
+---
+
+## Phase 5 — Publish truth + promote path
+
+**Problem:** Local queue and remote send look the same to agents.
+
+### Scope
+
+| Status enum | Meaning |
+|---|---|
+| `queued-local` | Written to `.mktg/native-publish/` |
+| `draft-external` | Created as draft on Typefully/Postiz/etc. |
+| `sent` | Confirmed sent/scheduled on external network |
+| `written-file` | File adapter output under `.mktg/published/` |
+| `failed` | Error with detail |
+
+Additional:
+
+- Result payload always includes `status` per item (not only published counts).
+- Optional: `mktg publish --promote --from native --to postiz --dry-run/--confirm`.
+- Studio labels match CLI enums 1:1 (`studio-api-index.md`).
+
+### Acceptance criteria
+
+- [ ] Native `--confirm` returns `queued-local`, never implies `sent`
+- [ ] Typefully/Postiz success maps to `draft-external` or `sent` based on API response
+- [ ] CONTEXT + publish-index document the enum
+- [ ] Integration tests lock the enum strings
+
+### Invasiveness
+
+**M** — publish adapters + Studio contract + docs.
+
+---
+
+## Phase 6 — Portable routing (`mktg route`)
+
+**Problem:** Orchestration is advertised broadly but `mktg cmo` requires Claude Code CLI.
+
+### Scope
+
+| Command | Behavior |
+|---|---|
+| `mktg route "<prompt>" --json` | Deterministic/table + heuristic route → `{ skill, playbook, confidence, rationale, nextCommand }` — **no LLM** |
+| `mktg cmo` | Keep Claude spawn; document `--runner claude` (default); fail clearly if binary missing |
+| Future (out of phase) | `--runner cursor\|prompt-only` |
+
+Reuse `/cmo` disambiguation tables where possible (single source in code or generated from skill metadata).
+
+### Acceptance criteria
+
+- [ ] `mktg route "write a show hn post" --json` → `startup-launcher` or `launch-strategy` with confidence
+- [ ] Works in CI without `claude` binary
+- [ ] `mktg cmo --dry-run` still previews spawn; live path unchanged
+- [ ] CMO skill docs point agents at `route` when Claude unavailable
+
+### Invasiveness
+
+**S** for `route` table; **L** if multi-runner is pulled in (don’t — keep out of this phase).
+
+---
+
+## Phase 7 — Studio vs dashboard consolidation
+
+**Problem:** Two “open a UI” stories.
+
+### Decision (proposed)
+
+| Surface | Role |
+|---|---|
+| `mktg studio` | **Canonical human UI** (Next + Bun API) |
+| `mktg dashboard` | **JSON command-center only** (no implicit server confusion), or alias → studio with deprecation warning for launcher subcommands |
+
+### Acceptance criteria
+
+- [ ] README / CONTEXT list one “open UI” command
+- [ ] Agents using dashboard get JSON snapshots without being told to open port 4311 as the product UI
+- [ ] Deprecation warning (if any) includes remove-by version
+
+### Invasiveness
+
+**S** (docs + alias) to **M** (code merge). Prefer S first.
+
+---
+
+## Phase 8 — Studio packaging resolve path
+
+**Problem:** Launcher messaging can claim mktg-studio isn’t on npm while the tarball ships `studio/`.
+
+### Scope
+
+- Resolve packaged `studio/bin/mktg-studio.ts` from installed package root first.
+- Rewrite install suggestions for npm users.
+- `mktg doctor` check: `studio-launcher-resolves`.
+
+### Acceptance criteria
+
+- [ ] Fresh `npm i -g marketing-cli` (or bun link) → `mktg studio --dry-run` resolves without sibling checkout
+- [ ] Doctor fails clearly when studio assets missing from install
+
+### Invasiveness
+
+**S**
+
+---
+
+## Phase 9 — Catalog sync / status honesty
+
+**Problem:** Documented GitHub drift checks / health probes aren’t real.
+
+### Option A (prefer): implement thin versions
+
+- `catalog sync --dry-run` — compare `version_pinned` to latest GitHub release tag
+- `catalog status --probe` — optional HTTP readiness (postiz is-connected style)
+
+### Option B: un-advertise
+
+- Schema + CONTEXT mark `unimplemented` until built; exit 6 stays but docs don’t promise drift checks
+
+### Acceptance criteria
+
+- [ ] Either A green with tests, or B with zero docs claiming live sync
+- [ ] No silent `healthy: null` without `status: "unimplemented"` field
+
+### Invasiveness
+
+**M** for A; **S** for B.
+
+---
+
+## Phase 10 — Skill script exec allowlist
+
+**Problem:** Some skills already ship `scripts/`; agents reinvent invocation.
+
+### Scope
+
+```bash
+mktg skill exec <skill> --script <name> --input '{...}' --json
+# or: mktg run <skill> --script <name> -- …
+```
+
+- Resolve install dir; sandbox cwd; allowlist skills that declare scripts in manifest/frontmatter.
+- Return stdout as JSON envelope; never shell unsandboxed paths.
+
+### Acceptance criteria
+
+- [ ] Allowlisted skill script runs under temp project and returns structured result
+- [ ] Unknown skill/script → exit 1/2
+- [ ] Path escape attempts rejected by existing validators
+- [ ] Non-allowlisted skills cannot exec arbitrary files
+
+### Invasiveness
+
+**M–L** — start with 1–2 skills (`mktg-x` or a tiny fixture skill in tests).
+
+---
+
+## Phase 11 — Strict skill-contract enforcement
+
+**Problem:** Drop-in quality drift (missing Anti-Patterns, >500 lines, incomplete frontmatter).
+
+### Scope
+
+- `mktg skill validate --strict` and/or `mktg doctor --check-skills`
+- Fail on: missing Anti-Patterns, line cap, required `reads`/`writes` for foundation tiers, broken `depends_on` DAG
+- Remove e2e exemptions as skills are fixed (separate cleanup PRs OK)
+
+### Acceptance criteria
+
+- [ ] CI job runs strict validate on bundled skills
+- [ ] Intentional exemptions are explicit in manifest, not silent test skips
+
+### Invasiveness
+
+**S** for the gate; skill cleanups vary.
+
+---
+
+## Phase 12 — Docs and runtime-index sync
+
+**Continuous rule:** every phase that changes command semantics updates:
+
+- `CONTEXT.md`
+- `skills/cmo/rules/cli-runtime-index.md`
+- `skills/cmo/rules/publish-index.md` (if publish)
+- `skills/cmo/rules/studio-api-index.md` (if studio)
+- `mktg schema` examples
+- Changelog / release notes bullet
+
+### Acceptance criteria
+
+- [ ] No CONTEXT claim contradicts `mktg schema <cmd> --json`
+- [ ] Dogfood script or CI snapshot: key help strings grep-tested optional
+
+---
+
+## Suggested shipping order (vertical slices)
+
+```text
+P1 lifecycle ─┬─► P3 plan/status
+              └─► P2 --with-context (parallel after event field exists)
+P4 prereqs (parallel with P2)
+P5 publish truth
+P6 route
+P8 studio resolve (anytime)
+P7 UI consolidation (after P8)
+P9 catalogs
+P11 skill contracts
+P10 script exec (last among big bets)
+P12 ongoing
+```
+
+### Milestone bundles (for PRs)
+
+| Milestone | Phases | User-visible win |
+|---|---|---|
+| **M1 — Honest loop** | 1, 3, 12 (partial) | Load ≠ done; plan stops lying |
+| **M2 — Faster activation** | 2, 4 | One-shot context + real prereqs |
+| **M3 — Trustworthy distribute** | 5, 9 | Publish/catalog statuses you can bet on |
+| **M4 — Portable orchestrate** | 6, 7, 8 | Route anywhere; one UI story |
+| **M5 — Execute where scripts exist** | 10, 11 | CLI runs allowlisted engines; contracts enforced |
+
+---
+
+## Testing strategy (per phase)
+
+| Layer | Requirement |
+|---|---|
+| Unit | History event types; prereq matrix; publish status mapping |
+| Integration | Real temp dirs; `run` load/complete; plan fixtures; publish dry-run/confirm |
+| DX axes | Keep 21/21; update tests if envelopes gain fields |
+| Manual dogfood | Repeat offline GTM slice: load → write under `marketing/` → complete → plan → native publish; assert statuses |
+
+---
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Breaking agents that parse `result: "success"` on load | Add `event` field; changelog; keep transitional dual-read in plan for one minor |
+| Context payload blows token budgets | `--budget`, `--fields`, default opt-in for `--with-context` |
+| Over-building script exec into a plugin host | Allowlist + JSON only; no arbitrary shell |
+| Docs drift again | Phase 12 checklist on every PR template checkbox |
+| Scope creep into “CLI writes the blog post” | Reaffirm non-goal; skills remain playbooks |
+
+---
+
+## Explicit non-goals (this plan)
+
+- Vendoring Postiz / scheduling SaaS into the core
+- Replacing `/cmo` skill markdown with a closed proprietary planner
+- Guaranteeing live social posts without BYO credentials
+- Auto-running all 64 skills without an agent
+- Redesigning Studio UI aesthetics (unless blocked by API contract)
+
+---
+
+## Open decisions (resolve before or during the named phase)
+
+| Decision | Options | Needed by |
+|---|---|---|
+| Rename `run` → `load`? | Keep `run` + honest events **(prefer)** vs rename + alias | P1 |
+| `--with-context` default on? | Opt-in → default in next minor | P2 |
+| Dashboard fate | Deprecate launcher / JSON-only / alias to studio | P7 |
+| Catalog stubs | Implement vs un-advertise | P9 |
+| Multi-runner CMO | Defer past P6 | post-M4 |
+
+---
+
+## Resume protocol
+
+1. Read this file’s Phase Status Tracker.
+2. Pick the first `pending` phase in the Suggested shipping order that isn’t blocked.
+3. Open a PR named `feat(cli): <phase title>` against `main`.
+4. Update the tracker row to `in_progress` / `completed` **in the same commit** as the phase work.
+5. Re-dogfood the affected command with `--json` and paste a short evidence blurb in the PR.
+
+---
+
+## Appendix A — Command surface after M4 (sketch)
+
+| Command | Role |
+|---|---|
+| `mktg run` | Load (+ optional context); `--complete` for outcomes |
+| `mktg route` | Portable skill routing |
+| `mktg cmo` | Claude Code orchestrator (optional runner) |
+| `mktg plan` | Outcome-aware queue |
+| `mktg publish` | Distribute with explicit status enum |
+| `mktg studio` | Human UI |
+| `mktg dashboard` | JSON snapshots (no competing product UI) |
+| `mktg catalog` | Honest sync/status |
+| `mktg skill exec` | Allowlisted scripts (M5) |
+
+## Appendix B — Success metrics (qualitative)
+
+- A new agent can complete offline GTM (article → atoms → native queue) without being misled by history.
+- `mktg plan --json` after load-only does **not** recommend publish.
+- `mktg publish --adapter mktg-native --confirm --json` clearly says `queued-local`.
+- `mktg route` works in this cloud VM without `claude`.
+- CONTEXT.md examples match schema on a fresh checkout.

--- a/docs/cli-improvement-plan.md
+++ b/docs/cli-improvement-plan.md
@@ -32,9 +32,9 @@
 | # | Phase | Status | PR/Commit | Notes |
 |---|---|---|---|---|
 | 0 | Plan authored (this doc) | `completed` | — | 2026-07-18 |
-| 1 | Honest skill lifecycle (`loaded` vs `completed`) | `pending` | | Foundation for everything else |
+| 1 | Honest skill lifecycle (`loaded` vs `completed`) | `completed` | cursor/honest-run-lifecycle-ccd8 | 2026-07-27 — `event` field, `--complete/--writes/--result`, dual-read legacy |
 | 2 | One-shot activation (`run --with-context`) | `pending` | | Can ship parallel to P1 after log shape lands |
-| 3 | Outcome-aware `plan` / `status` / dashboard | `pending` | | Depends on P1 |
+| 3 | Outcome-aware `plan` / `status` / dashboard | `completed` | cursor/honest-run-lifecycle-ccd8 | 2026-07-27 — plan reads completed-only; distribute needs artifacts/completed runs; health counts non-template; dashboard readiness completed-only |
 | 4 | Rich prerequisites + `--strict` | `pending` | | |
 | 5 | Publish truth + promote path | `pending` | | |
 | 6 | Portable `mktg route` (+ CMO runner clarity) | `pending` | | |

--- a/docs/cli-improvement-plan.md
+++ b/docs/cli-improvement-plan.md
@@ -32,9 +32,9 @@
 | # | Phase | Status | PR/Commit | Notes |
 |---|---|---|---|---|
 | 0 | Plan authored (this doc) | `completed` | — | 2026-07-18 |
-| 1 | Honest skill lifecycle (`loaded` vs `completed`) | `completed` | cursor/honest-run-lifecycle-ccd8 | 2026-07-27 — `event` field, `--complete/--writes/--result`, dual-read legacy |
+| 1 | Honest skill lifecycle (`loaded` vs `completed`) | `completed` | #43 | 2026-07-27 — `event` field, `--complete/--writes/--result`, dual-read legacy |
 | 2 | One-shot activation (`run --with-context`) | `pending` | | Can ship parallel to P1 after log shape lands |
-| 3 | Outcome-aware `plan` / `status` / dashboard | `completed` | cursor/honest-run-lifecycle-ccd8 | 2026-07-27 — plan reads completed-only; distribute needs artifacts/completed runs; health counts non-template; dashboard readiness completed-only |
+| 3 | Outcome-aware `plan` / `status` / dashboard | `completed` | #43 | 2026-07-27 — plan reads completed-only; distribute needs artifacts/completed runs; health counts non-template; dashboard readiness completed-only |
 | 4 | Rich prerequisites + `--strict` | `pending` | | |
 | 5 | Publish truth + promote path | `pending` | | |
 | 6 | Portable `mktg route` (+ CMO runner clarity) | `pending` | | |

--- a/skills/cmo/rules/command-reference.md
+++ b/skills/cmo/rules/command-reference.md
@@ -50,8 +50,10 @@ routing, see `rules/publish-index.md`.
 | `mktg plan next --json` | Single highest-priority task. Default for "what should I do?" after session start. |
 | `mktg plan complete <id> --json` | After a skill successfully finishes — persists progress across sessions via `.mktg/plan.json`. |
 | `mktg plan --save --json` | Stream-persist the plan for long-running orchestration. |
-| `mktg run <skill> --json` | Direct skill invocation (bypasses the usual Claude Code slash-command flow). Use when the orchestration layer needs programmatic control. |
+| `mktg run <skill> --json` | Direct skill invocation (bypasses the usual Claude Code slash-command flow). Use when the orchestration layer needs programmatic control. Logs `event:"loaded"` — a load is NOT work; `mktg plan` ignores loads for execute/distribute gates. |
+| `mktg run <skill> --complete --writes <paths> --result success --json` | Record a completed run after the agent actually produced files. Writes are validated to exist (exit 2 otherwise). Only `completed` events count as work. |
 | `mktg run <skill> --learning '{...}'` | Run a skill + record the learning atomically. |
+| `mktg skill history <skill> --json` | Load vs completion history for a skill. |
 
 ---
 

--- a/src/commands/dashboard.ts
+++ b/src/commands/dashboard.ts
@@ -40,7 +40,7 @@ import {
 import { handler as doctorHandler } from "./doctor";
 import { handler as planHandler } from "./plan";
 import { handler as statusHandler } from "./status";
-import { getRunHistory, type RunSummaryEntry } from "../core/run-log";
+import { getRunHistory, isCompletedRecord, type RunSummaryEntry } from "../core/run-log";
 import { loadManifest, getInstallStatus } from "../core/skills";
 import { loadAgentManifest, getAgentInstallStatus } from "../core/agents";
 import { invalidArgs, parseJsonInput, validatePathInput } from "../core/errors";
@@ -541,13 +541,18 @@ const buildOutputsResponse = async (flags: GlobalFlags): Promise<DashboardOutput
     id: `${record.skill}-${record.timestamp}-${index}`,
     timestamp: record.timestamp,
     skill: record.skill,
-    result: record.result,
-    summary: `${record.skill} finished with ${record.result}.`,
+    event: isCompletedRecord(record) ? ("completed" as const) : ("loaded" as const),
+    result: record.result ?? null,
+    summary: isCompletedRecord(record)
+      ? `${record.skill} completed with ${record.result ?? "unknown"}.`
+      : `${record.skill} loaded (no outcome recorded).`,
   }));
   const outputs = await discoverOutputs(flags.cwd);
 
-  const hasContentRun = history.some((record) => CONTENT_SKILLS.has(record.skill));
-  const hasDistributionRun = history.some((record) => DISTRIBUTION_SKILLS.has(record.skill));
+  // Readiness keys off completed work only — loads never signal readiness.
+  const completedHistory = history.filter(isCompletedRecord);
+  const hasContentRun = completedHistory.some((record) => CONTENT_SKILLS.has(record.skill));
+  const hasDistributionRun = completedHistory.some((record) => DISTRIBUTION_SKILLS.has(record.skill));
   const publishReadiness: DashboardReadiness = hasDistributionRun
     ? {
         state: "ready",

--- a/src/commands/plan.ts
+++ b/src/commands/plan.ts
@@ -12,9 +12,24 @@ import { getRunSummary, type RunSummaryEntry } from "../core/run-log";
 import { rejectControlChars, validateResourceId } from "../core/errors";
 import { isTTY, writeStderr, bold, dim, green, yellow, red } from "../core/output";
 
+// Content-file extensions that count as distributable artifacts under marketing/
+const MARKETING_ARTIFACT_GLOB = "**/*.{md,mdx,txt,html,json}";
+
+// True when the project has at least one real content artifact under marketing/.
+// Load-only skill runs must never stand in for artifacts (honest distribute gate).
+const hasMarketingArtifacts = async (cwd: string): Promise<boolean> => {
+  try {
+    const glob = new Bun.Glob(MARKETING_ARTIFACT_GLOB);
+    for await (const _file of glob.scan({ cwd: join(cwd, "marketing") })) {
+      return true; // one is enough
+    }
+  } catch { /* marketing/ doesn't exist */ }
+  return false;
+};
+
 export const schema: CommandSchema = {
   name: "plan",
-  description: "Execution loop — reads project state and outputs a prioritized, actionable task queue",
+  description: "Execution loop — reads project state (completed runs only, never load events) and outputs a prioritized, actionable task queue",
   flags: [
     { name: "--save", type: "boolean", required: false, description: "Persist plan to .mktg/plan.json" },
     { name: "--ndjson", type: "boolean", required: false, description: "Stream each task as a NDJSON line to stderr as it is computed" },
@@ -175,7 +190,9 @@ const buildTasks = async (
     }
   }
 
-  // 4. Execution skills not yet run (suggest based on dependency graph)
+  // 4. Execution skills not yet completed (suggest based on dependency graph).
+  // runSummary is completed-only (load events filtered upstream) — a skill
+  // that was merely loaded still counts as never-done.
   try {
     const manifest = await loadManifest();
     const graph = buildGraph(manifest);
@@ -188,33 +205,41 @@ const buildTasks = async (
         emitTask({
           id: `run-${skill}`, order: tasks.length, category: "execute",
           action: `Run /${skill} for the first time`, command: `mktg run ${skill}`,
-          reason: `Must-have execution skill never run — produces marketing assets`, blocked: false,
+          reason: `Must-have execution skill never completed — produces marketing assets`, blocked: false,
         });
       }
     }
   } catch { /* manifest issues handled elsewhere */ }
 
-  // 5. Distribution — check if content exists but hasn't been distributed
-  const executedSkills = Object.keys(runSummary);
-  const hasContent = executedSkills.some(s =>
+  // 5. Distribution — real evidence only: artifacts under marketing/ OR a
+  // completed content-skill run. Load-only history never unlocks distribute.
+  const completedSkills = Object.keys(runSummary);
+  const hasCompletedContent = completedSkills.some(s =>
     ["seo-content", "direct-response-copy", "lead-magnet", "creative"].includes(s),
   );
-  const hasDistributed = executedSkills.some(s =>
+  const contentEvidence = hasCompletedContent || await hasMarketingArtifacts(cwd);
+  const hasDistributed = completedSkills.some(s =>
     ["content-atomizer", "email-sequences", "social-campaign", "typefully"].includes(s),
   );
-  if (hasContent && !hasDistributed) {
+  if (contentEvidence && !hasDistributed) {
     emitTask({
       id: "distribute-content", order: tasks.length, category: "distribute",
       action: "Distribute created content", command: "mktg run content-atomizer",
-      reason: "Content skills have run but no distribution skills yet — 70% of marketing is distribution",
+      reason: "Content artifacts exist but no distribution skill has completed — 70% of marketing is distribution",
       blocked: false,
     });
   }
 
-  const populated = brandStatuses.filter(s => {
-    if (!s.exists) return false;
-    try { return true; } catch { return false; }
-  }).length;
+  // Health counts files with REAL content — templates don't count, so a
+  // fresh scaffold can never report "ready".
+  let populated = 0;
+  for (const status of brandStatuses) {
+    if (!status.exists) continue;
+    try {
+      const content = await Bun.file(join(cwd, "brand", status.file)).text();
+      if (!isTemplateContent(status.file, content)) populated++;
+    } catch { /* unreadable — doesn't count */ }
+  }
   const health: PlanResult["health"] = populated >= 3 ? "ready" : "incomplete";
 
   return { tasks: tasks.filter(t => !completedSet.has(t.id)), health };
@@ -252,8 +277,9 @@ export const handler: CommandHandler<PlanResult | { completed: string } | { task
     return ok({ completed: taskId });
   }
 
-  // Build plan
-  const runSummary = await getRunSummary(cwd);
+  // Build plan — completed runs only. A bare `mktg run` logs event:"loaded"
+  // and must not count as executed work anywhere in this queue.
+  const runSummary = await getRunSummary(cwd, { completedOnly: true });
   const { tasks, health } = await buildTasks(cwd, runSummary, completed, ndjson);
   if (ndjson) writeStderr(JSON.stringify({ type: "summary", data: { health, count: tasks.length } }));
   const summary = buildSummary(tasks, health);

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -99,6 +99,34 @@ export const handler: CommandHandler<RunResult> = async (args, flags) => {
     ], DOCS.skills);
   }
 
+  // Validate --writes BEFORE any dependency lookup (manifest, install dir):
+  // static input errors must precede environment errors, so an agent gets
+  // INVALID_ARGS about its payload whether or not skills are installed.
+  // Every path must pass the sandbox pipeline AND exist — recording work
+  // that didn't happen is the exact lie this command exists to prevent.
+  const validatedWrites: string[] = [];
+  if (wantComplete && writesList.length > 0) {
+    const writeErrors: string[] = [];
+    for (const w of writesList) {
+      const check = validatePathInput(flags.cwd, w);
+      if (!check.ok) {
+        writeErrors.push(`'${w}': ${check.message}`);
+        continue;
+      }
+      if (!(await Bun.file(check.path).exists())) {
+        writeErrors.push(`'${w}': file does not exist`);
+        continue;
+      }
+      validatedWrites.push(w);
+    }
+    if (writeErrors.length > 0) {
+      return invalidArgs(`Invalid --writes: ${writeErrors.join("; ")}`, [
+        "Writes must be existing files inside the project (brand/, marketing/, .mktg/)",
+        "Create the files first, then record completion with the same command",
+      ], DOCS.skills);
+    }
+  }
+
   // Lane 1 / Wave A audit fix: every other resource-name command in the
   // registry validates its positional via these two checks; `mktg run`
   // was the lone gap. Reject control chars + cap length at 128 BEFORE
@@ -153,32 +181,6 @@ export const handler: CommandHandler<RunResult> = async (args, flags) => {
     }));
   }
   const now = new Date().toISOString();
-
-  // Validate --writes: every path must pass the sandbox pipeline AND exist.
-  // Recording work that didn't happen is the exact lie this command now
-  // exists to prevent — invalid writes fail loudly with fix guidance.
-  const validatedWrites: string[] = [];
-  if (wantComplete && writesList.length > 0) {
-    const writeErrors: string[] = [];
-    for (const w of writesList) {
-      const check = validatePathInput(flags.cwd, w);
-      if (!check.ok) {
-        writeErrors.push(`'${w}': ${check.message}`);
-        continue;
-      }
-      if (!(await Bun.file(check.path).exists())) {
-        writeErrors.push(`'${w}': file does not exist`);
-        continue;
-      }
-      validatedWrites.push(w);
-    }
-    if (writeErrors.length > 0) {
-      return invalidArgs(`Invalid --writes: ${writeErrors.join("; ")}`, [
-        "Writes must be existing files inside the project (brand/, marketing/, .mktg/)",
-        "Create the files first, then record completion with the same command",
-      ], DOCS.skills);
-    }
-  }
 
   // Surface prior run context — agent sees usage history with every load
   const lastRun = await getLastRun(flags.cwd, resolved.name);

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -4,39 +4,51 @@
 import { join } from "node:path";
 import type { CommandHandler, CommandSchema, PrerequisiteStatus } from "../types";
 import { ok } from "../types";
-import { invalidArgs, notFound, DOCS, parseJsonInput, rejectControlChars, validateResourceId } from "../core/errors";
+import { invalidArgs, notFound, DOCS, parseJsonInput, rejectControlChars, validateResourceId, validatePathInput } from "../core/errors";
 import { resolveManifest, getSkill, getSkillsInstallDir } from "../core/skills";
 import { checkPrerequisites } from "../core/skill-lifecycle";
-import { logRun, getLastRun, getRunHistory } from "../core/run-log";
+import { logRun, getLastRun, getRunHistory, isCompletedRecord } from "../core/run-log";
 import { appendLearning, type LearningEntry } from "../core/brand";
 import { writeStderr } from "../core/output";
 
+const VALID_RUN_RESULTS = ["success", "partial", "failed"] as const;
+type RunOutcome = typeof VALID_RUN_RESULTS[number];
+
 export const schema: CommandSchema = {
   name: "run",
-  description: "Load a skill for agent consumption — checks prerequisites, surfaces prior run context, and logs execution",
+  description: "Load a skill for agent consumption — logs a 'loaded' event by default; record real outcomes with --complete so plan/status stay honest",
   positional: { name: "skill", description: "Skill name to run", required: true },
   flags: [
     { name: "--learning", type: "string", required: false, description: "JSON learning entry to append to brand/learnings.md after run" },
+    { name: "--complete", type: "boolean", required: false, description: "Record a completed run (work actually happened) instead of a load event" },
+    { name: "--result", type: "string", required: false, description: "Outcome with --complete: success | partial | failed (default success)" },
+    { name: "--writes", type: "string", required: false, description: "Comma-separated files the agent produced (repeatable); each must exist inside the project" },
     { name: "--ndjson", type: "boolean", required: false, description: "Stream prerequisite check, skill-loaded, and complete events as NDJSON lines to stderr" },
   ],
   output: {
     skill: "string — resolved skill name",
     content: "string — full SKILL.md content",
     prerequisites: "PrerequisiteStatus — prerequisite check results",
-    loggedAt: "string — ISO timestamp of logged run",
-    priorRuns: "object — lastRun timestamp, runCount, and lastResult for this skill",
+    loggedAt: "string | null — ISO timestamp of logged run (null on --dry-run)",
+    event: "'loaded' | 'completed' — what was logged: load events never imply work",
+    result: "'success' | 'partial' | 'failed' | null — outcome with --complete; null on loads",
+    writes: "string[] | null — validated files recorded with --complete; null on loads",
+    priorRuns: "object — lastRun timestamp, lastEvent, runCount, and lastResult for this skill",
     learningAppended: "string | null — the table row appended to learnings.md, or null if --learning not provided",
   },
   examples: [
-    { args: "mktg run seo-content --json", description: "Load SEO content skill for agent" },
+    { args: "mktg run seo-content --json", description: "Load SEO content skill for agent (logs event: loaded)" },
     { args: "mktg run brand-voice --dry-run", description: "Preview without logging" },
+    { args: "mktg run seo-content --complete --writes marketing/content/x.md --result success --json", description: "Record completed work with validated writes" },
+    { args: "mktg skill history seo-content --json", description: "See load vs completion events for a skill" },
     { args: "mktg run seo-content --ndjson", description: "Stream prerequisite, load, and complete events to stderr" },
   ],
-  vocabulary: ["run", "execute", "load skill"],
+  vocabulary: ["run", "execute", "load skill", "complete", "record outcome"],
 };
 
 type PriorRunContext = {
   readonly lastRun: string | null;
+  readonly lastEvent: "loaded" | "completed" | null;
   readonly lastResult: string | null;
   readonly runCount: number;
 };
@@ -46,6 +58,9 @@ type RunResult = {
   readonly content: string;
   readonly prerequisites: PrerequisiteStatus;
   readonly loggedAt: string | null;
+  readonly event: "loaded" | "completed";
+  readonly result: "success" | "partial" | "failed" | null;
+  readonly writes: readonly string[] | null;
   readonly priorRuns: PriorRunContext;
   readonly learningAppended: string | null;
 };
@@ -54,9 +69,34 @@ export const handler: CommandHandler<RunResult> = async (args, flags) => {
   const positionalArgs = args.filter(a => !a.startsWith("--"));
   const skillName = positionalArgs[0];
   const ndjson = args.includes("--ndjson");
+  const wantComplete = args.includes("--complete");
 
   if (!skillName) {
     return invalidArgs("Missing skill name", ["Usage: mktg run <skill-name>", "mktg list --json to see available skills"], DOCS.skills);
+  }
+
+  // Parse --result / --writes (completion-only flags)
+  let resultArg: RunOutcome | undefined;
+  const writesRaw: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i]!;
+    if (a === "--result" && args[i + 1]) { resultArg = args[i + 1] as RunOutcome; i++; }
+    else if (a.startsWith("--result=")) { resultArg = a.slice(9) as RunOutcome; }
+    else if (a === "--writes" && args[i + 1]) { writesRaw.push(...args[i + 1]!.split(",")); i++; }
+    else if (a.startsWith("--writes=")) { writesRaw.push(...a.slice(9).split(",")); }
+  }
+  const writesList = writesRaw.map(w => w.trim()).filter(Boolean);
+
+  if (resultArg !== undefined && !VALID_RUN_RESULTS.includes(resultArg)) {
+    return invalidArgs(`Invalid --result '${resultArg}'`, [
+      `Valid values: ${VALID_RUN_RESULTS.join(" | ")}`,
+    ], DOCS.skills);
+  }
+  if (!wantComplete && (resultArg !== undefined || writesList.length > 0)) {
+    return invalidArgs("--result and --writes require --complete", [
+      "Usage: mktg run <skill> --complete [--result success] [--writes path1,path2]",
+      "A bare 'mktg run' logs event: loaded — completions must be explicit",
+    ], DOCS.skills);
   }
 
   // Lane 1 / Wave A audit fix: every other resource-name command in the
@@ -114,11 +154,38 @@ export const handler: CommandHandler<RunResult> = async (args, flags) => {
   }
   const now = new Date().toISOString();
 
+  // Validate --writes: every path must pass the sandbox pipeline AND exist.
+  // Recording work that didn't happen is the exact lie this command now
+  // exists to prevent — invalid writes fail loudly with fix guidance.
+  const validatedWrites: string[] = [];
+  if (wantComplete && writesList.length > 0) {
+    const writeErrors: string[] = [];
+    for (const w of writesList) {
+      const check = validatePathInput(flags.cwd, w);
+      if (!check.ok) {
+        writeErrors.push(`'${w}': ${check.message}`);
+        continue;
+      }
+      if (!(await Bun.file(check.path).exists())) {
+        writeErrors.push(`'${w}': file does not exist`);
+        continue;
+      }
+      validatedWrites.push(w);
+    }
+    if (writeErrors.length > 0) {
+      return invalidArgs(`Invalid --writes: ${writeErrors.join("; ")}`, [
+        "Writes must be existing files inside the project (brand/, marketing/, .mktg/)",
+        "Create the files first, then record completion with the same command",
+      ], DOCS.skills);
+    }
+  }
+
   // Surface prior run context — agent sees usage history with every load
   const lastRun = await getLastRun(flags.cwd, resolved.name);
   const priorHistory = await getRunHistory(flags.cwd, resolved.name, 10000);
   const priorRuns: PriorRunContext = {
     lastRun: lastRun?.timestamp ?? null,
+    lastEvent: lastRun ? (isCompletedRecord(lastRun) ? "completed" : "loaded") : null,
     lastResult: lastRun?.result ?? null,
     runCount: priorHistory.length,
   };
@@ -157,12 +224,16 @@ export const handler: CommandHandler<RunResult> = async (args, flags) => {
     learningAppended = learningResult.row;
   }
 
-  // Log execution (unless dry-run)
+  // Log the event (unless dry-run). A bare run is a LOAD — never an outcome.
+  // Completions carry the explicit result + validated writes.
+  const event = wantComplete ? "completed" : "loaded";
+  const outcome: RunOutcome | null = wantComplete ? (resultArg ?? "success") : null;
   if (!flags.dryRun) {
     await logRun(flags.cwd, {
       skill: resolved.name,
       timestamp: now,
-      result: "success",
+      event,
+      ...(wantComplete ? { result: outcome ?? "success", writes: validatedWrites } : {}),
       brandFilesChanged: learningAppended ? ["learnings.md"] : [],
     });
   }
@@ -172,12 +243,15 @@ export const handler: CommandHandler<RunResult> = async (args, flags) => {
     content,
     prerequisites,
     loggedAt: flags.dryRun ? null : now,
+    event,
+    result: outcome,
+    writes: wantComplete ? validatedWrites : null,
     priorRuns,
     learningAppended,
   };
 
   if (ndjson) {
-    writeStderr(JSON.stringify({ type: "complete", data: { skill: resolved.name, result: "success" } }));
+    writeStderr(JSON.stringify({ type: "complete", data: { skill: resolved.name, event, ...(outcome ? { result: outcome } : {}) } }));
   }
 
   return ok(result);

--- a/src/commands/skill.ts
+++ b/src/commands/skill.ts
@@ -458,9 +458,12 @@ const handleLog = async (args: readonly string[], flags: { cwd: string; dryRun: 
     ? args[1] as typeof VALID_RESULTS[number]
     : "success";
 
+  // `skill log` records an outcome, so it is always a completed event.
+  // Loads are logged exclusively by `mktg run` (event: "loaded").
   const record = {
     skill: name,
     timestamp: new Date().toISOString(),
+    event: "completed" as const,
     result: resultArg as "success" | "partial" | "failed",
     brandFilesChanged: [] as string[],
   };

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -24,7 +24,7 @@ export const schema: CommandSchema = {
     "agents": "{installed, total} — agent counts",
     "content": "{totalFiles, byDir} — content file counts with breakdown",
     "integrations": "Record<string, IntegrationEntry> — env var readiness for third-party skills",
-    "recentActivity": "Record<string, {lastRun, result, daysSince}> — per-skill execution history",
+    "recentActivity": "Record<string, {lastRun, result|null, event: 'loaded'|'completed', daysSince}> — per-skill run history (loads never imply outcomes)",
     "nextActions": "string[] — prioritized suggestions for what the agent should do next",
     "health": "'ready' | 'incomplete' | 'needs-setup' — overall project marketing readiness",
   },
@@ -64,7 +64,8 @@ type ContentSummary = {
 
 type ActivityEntry = {
   readonly lastRun: string;
-  readonly result: string;
+  readonly result: string | null;
+  readonly event: "loaded" | "completed";
   readonly daysSince: number;
 };
 
@@ -337,8 +338,11 @@ export const handler: CommandHandler<StatusResult> = async (_args, flags) => {
   if (activityKeys.length > 0) {
     lines.push(bold("  Recent Activity") + dim(` ${activityKeys.length} skills run`));
     for (const [skill, activity] of Object.entries(recentActivity).slice(0, 5)) {
-      const icon = activity.result === "success" ? green("●") : activity.result === "partial" ? yellow("●") : red("●");
-      lines.push(`    ${icon} ${skill} ${dim(`(${activity.daysSince}d ago, ${activity.result})`)}`);
+      const icon = activity.event === "loaded"
+        ? dim("○")
+        : activity.result === "success" ? green("●") : activity.result === "partial" ? yellow("●") : red("●");
+      const label = activity.event === "loaded" ? "loaded" : activity.result;
+      lines.push(`    ${icon} ${skill} ${dim(`(${activity.daysSince}d ago, ${label})`)}`);
     }
     if (activityKeys.length > 5) {
       lines.push(dim(`    ... and ${activityKeys.length - 5} more`));

--- a/src/core/run-log.ts
+++ b/src/core/run-log.ts
@@ -9,7 +9,8 @@ const LOG_FILE = ".mktg/runs.jsonl";
 
 export type RunSummaryEntry = {
   readonly lastRun: string;
-  readonly result: string;
+  readonly result: string | null;
+  readonly event: "loaded" | "completed";
   readonly runCount: number;
   readonly daysSince: number;
 };
@@ -20,8 +21,25 @@ export type RunStats = {
   readonly successCount: number;
   readonly failedCount: number;
   readonly partialCount: number;
+  readonly loadedCount: number;
+  readonly completedCount: number;
   readonly successRate: number;
 };
+
+export type RunHistoryFilter = {
+  /** Keep only records that represent completed work (see isCompletedRecord). */
+  readonly completedOnly?: boolean;
+};
+
+/**
+ * Dual-read: an explicit event field wins. Pre-event records are legacy —
+ * only those with real brand writes count as completed work; legacy
+ * result:"success" records with empty writes were load-only and must NOT
+ * unlock downstream plan/distribute steps.
+ */
+export const isCompletedRecord = (record: SkillRunRecord): boolean =>
+  record.event === "completed" ||
+  (record.event === undefined && record.brandFilesChanged.length > 0);
 
 export const logRun = async (
   cwd: string,
@@ -50,12 +68,14 @@ export const getRunHistory = async (
   cwd: string,
   skillName?: string,
   limit: number = 50,
+  filter?: RunHistoryFilter,
 ): Promise<SkillRunRecord[]> => {
   const logPath = join(cwd, LOG_FILE);
   try {
     const content = await readFile(logPath, "utf-8");
     let records = parseJsonl(content);
     if (skillName) records = records.filter(r => r.skill === skillName);
+    if (filter?.completedOnly) records = records.filter(isCompletedRecord);
     return records.slice(-limit).reverse(); // Most recent first
   } catch {
     return []; // No log file yet
@@ -72,8 +92,9 @@ export const getLastRun = async (
 
 export const getRunSummary = async (
   cwd: string,
+  filter?: RunHistoryFilter,
 ): Promise<Record<string, RunSummaryEntry>> => {
-  const history = await getRunHistory(cwd, undefined, 1000);
+  const history = await getRunHistory(cwd, undefined, 1000, filter);
   const summary: Record<string, RunSummaryEntry> = {};
   // history is most-recent-first, so count all but only take metadata from first seen
   const counts: Record<string, number> = {};
@@ -81,7 +102,13 @@ export const getRunSummary = async (
     counts[record.skill] = (counts[record.skill] ?? 0) + 1;
     if (!summary[record.skill]) {
       const daysSince = Math.floor((Date.now() - new Date(record.timestamp).getTime()) / (1000 * 60 * 60 * 24));
-      summary[record.skill] = { lastRun: record.timestamp, result: record.result, runCount: 0, daysSince };
+      summary[record.skill] = {
+        lastRun: record.timestamp,
+        result: record.result ?? null,
+        event: isCompletedRecord(record) ? "completed" : "loaded",
+        runCount: 0,
+        daysSince,
+      };
     }
   }
   // Fill in counts
@@ -96,15 +123,21 @@ export const getRunStats = async (
 ): Promise<RunStats> => {
   const history = await getRunHistory(cwd, undefined, 10000);
   const skills = new Set(history.map(r => r.skill));
-  const successCount = history.filter(r => r.result === "success").length;
-  const failedCount = history.filter(r => r.result === "failed").length;
-  const partialCount = history.filter(r => r.result === "partial").length;
+  // Result counts cover only records that carry an outcome (completed runs
+  // and pre-event legacy records). Load events have no result by design.
+  const outcomeRecords = history.filter(r => r.result !== undefined);
+  const successCount = outcomeRecords.filter(r => r.result === "success").length;
+  const failedCount = outcomeRecords.filter(r => r.result === "failed").length;
+  const partialCount = outcomeRecords.filter(r => r.result === "partial").length;
+  const completedCount = history.filter(isCompletedRecord).length;
   return {
     totalRuns: history.length,
     uniqueSkills: skills.size,
     successCount,
     failedCount,
     partialCount,
-    successRate: history.length > 0 ? Math.round((successCount / history.length) * 100) : 0,
+    loadedCount: history.length - completedCount,
+    completedCount,
+    successRate: outcomeRecords.length > 0 ? Math.round((successCount / outcomeRecords.length) * 100) : 0,
   };
 };

--- a/src/dashboard-contract.ts
+++ b/src/dashboard-contract.ts
@@ -226,7 +226,8 @@ export type DashboardRunEvent = {
   readonly id: string;
   readonly timestamp: string;
   readonly skill: string;
-  readonly result: string;
+  readonly event: "loaded" | "completed";
+  readonly result: string | null;
   readonly summary: string;
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -429,10 +429,21 @@ export type SkillEvaluation = {
 };
 
 // Skill execution history
+export type SkillRunEvent = "loaded" | "completed";
+
 export type SkillRunRecord = {
   readonly skill: string;
   readonly timestamp: string; // ISO 8601
-  readonly result: "success" | "partial" | "failed";
+  /**
+   * What actually happened. "loaded" = SKILL.md was read for the agent
+   * (no work implied). "completed" = the agent reported an outcome.
+   * Absent in pre-event records — treat via isCompletedRecord() dual-read.
+   */
+  readonly event?: SkillRunEvent;
+  /** Outcome of a completed run. Absent on load events — a load is not a success. */
+  readonly result?: "success" | "partial" | "failed";
+  /** Files the agent produced, recorded at --complete time (validated to exist). */
+  readonly writes?: readonly string[];
   readonly brandFilesChanged: readonly string[];
   readonly durationMs?: number;
   readonly note?: string;

--- a/tests/plan.test.ts
+++ b/tests/plan.test.ts
@@ -114,3 +114,107 @@ describe("mktg plan", () => {
     await rm(tmp, { recursive: true, force: true });
   });
 });
+
+// ==================== Honesty: loads never unlock execute/distribute ====================
+
+const seedBrandTemplates = async (tmp: string): Promise<void> => {
+  const brandDir = join(tmp, "brand");
+  await mkdir(brandDir, { recursive: true });
+  await writeFile(join(brandDir, "voice-profile.md"), "real voice content — not the template " + "x".repeat(600));
+  await writeFile(join(brandDir, "audience.md"), BRAND_TEMPLATES["audience.md"]);
+};
+
+const seedRunLog = async (tmp: string, records: ReadonlyArray<Record<string, unknown>>): Promise<void> => {
+  await mkdir(join(tmp, ".mktg"), { recursive: true });
+  const lines = records.map(r => JSON.stringify(r)).join("\n") + "\n";
+  await writeFile(join(tmp, ".mktg", "runs.jsonl"), lines);
+};
+
+describe("plan honesty gates", () => {
+  test("load-only content run does NOT produce a distribute task", async () => {
+    const tmp = await mkdtemp(join(tmpdir(), "mktg-plan-honest-"));
+    await seedBrandTemplates(tmp);
+    await seedRunLog(tmp, [
+      { skill: "seo-content", timestamp: "2026-07-20T10:00:00.000Z", event: "loaded", brandFilesChanged: [] },
+    ]);
+    const { stdout } = await run(["plan", "--json", "--cwd", tmp]);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.tasks.some((t: { id: string }) => t.id === "distribute-content")).toBe(false);
+    await rm(tmp, { recursive: true, force: true });
+  });
+
+  test("load-only content run still counts as never-completed for execute suggestions", async () => {
+    const tmp = await mkdtemp(join(tmpdir(), "mktg-plan-honest-"));
+    await seedBrandTemplates(tmp);
+    await seedRunLog(tmp, [
+      { skill: "seo-content", timestamp: "2026-07-20T10:00:00.000Z", event: "loaded", brandFilesChanged: [] },
+    ]);
+    const { stdout } = await run(["plan", "--json", "--cwd", tmp]);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.tasks.some((t: { id: string }) => t.id === "run-seo-content")).toBe(true);
+    await rm(tmp, { recursive: true, force: true });
+  });
+
+  test("completed content run unlocks the distribute task", async () => {
+    const tmp = await mkdtemp(join(tmpdir(), "mktg-plan-honest-"));
+    await seedBrandTemplates(tmp);
+    await seedRunLog(tmp, [
+      { skill: "seo-content", timestamp: "2026-07-20T10:00:00.000Z", event: "completed", result: "success", writes: ["marketing/content/x.md"], brandFilesChanged: [] },
+    ]);
+    const { stdout } = await run(["plan", "--json", "--cwd", tmp]);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.tasks.some((t: { id: string }) => t.id === "distribute-content")).toBe(true);
+    await rm(tmp, { recursive: true, force: true });
+  });
+
+  test("marketing/ artifacts alone (no completed content run) unlock distribute", async () => {
+    const tmp = await mkdtemp(join(tmpdir(), "mktg-plan-honest-"));
+    await seedBrandTemplates(tmp);
+    await mkdir(join(tmp, "marketing", "content"), { recursive: true });
+    await writeFile(join(tmp, "marketing", "content", "article.md"), "# Real artifact");
+    const { stdout } = await run(["plan", "--json", "--cwd", tmp]);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.tasks.some((t: { id: string }) => t.id === "distribute-content")).toBe(true);
+    await rm(tmp, { recursive: true, force: true });
+  });
+
+  test("completed distribution run suppresses the distribute task", async () => {
+    const tmp = await mkdtemp(join(tmpdir(), "mktg-plan-honest-"));
+    await seedBrandTemplates(tmp);
+    await seedRunLog(tmp, [
+      { skill: "seo-content", timestamp: "2026-07-20T10:00:00.000Z", event: "completed", result: "success", writes: ["marketing/content/x.md"], brandFilesChanged: [] },
+      { skill: "content-atomizer", timestamp: "2026-07-20T11:00:00.000Z", event: "completed", result: "success", writes: ["marketing/social/a.md"], brandFilesChanged: [] },
+    ]);
+    const { stdout } = await run(["plan", "--json", "--cwd", tmp]);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.tasks.some((t: { id: string }) => t.id === "distribute-content")).toBe(false);
+    await rm(tmp, { recursive: true, force: true });
+  });
+
+  test("legacy load (result success, no writes) does NOT unlock distribute", async () => {
+    const tmp = await mkdtemp(join(tmpdir(), "mktg-plan-honest-"));
+    await seedBrandTemplates(tmp);
+    await seedRunLog(tmp, [
+      { skill: "seo-content", timestamp: "2026-07-20T10:00:00.000Z", result: "success", brandFilesChanged: [] },
+    ]);
+    const { stdout } = await run(["plan", "--json", "--cwd", tmp]);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.tasks.some((t: { id: string }) => t.id === "distribute-content")).toBe(false);
+    await rm(tmp, { recursive: true, force: true });
+  });
+
+  test("health stays 'incomplete' when brand files exist but are all templates", async () => {
+    const tmp = await mkdtemp(join(tmpdir(), "mktg-plan-honest-"));
+    const brandDir = join(tmp, "brand");
+    await mkdir(brandDir, { recursive: true });
+    await writeFile(join(brandDir, "voice-profile.md"), BRAND_TEMPLATES["voice-profile.md"]);
+    await writeFile(join(brandDir, "audience.md"), BRAND_TEMPLATES["audience.md"]);
+    await writeFile(join(brandDir, "competitors.md"), BRAND_TEMPLATES["competitors.md"]);
+    await writeFile(join(brandDir, "positioning.md"), BRAND_TEMPLATES["positioning.md"]);
+    const { stdout } = await run(["plan", "--json", "--cwd", tmp]);
+    const parsed = JSON.parse(stdout);
+    // 4 files EXIST — the old health check called this "ready". Templates are not population.
+    expect(parsed.health).toBe("incomplete");
+    await rm(tmp, { recursive: true, force: true });
+  });
+});

--- a/tests/run-log.test.ts
+++ b/tests/run-log.test.ts
@@ -5,7 +5,7 @@ import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { join } from "node:path";
 import { mkdtemp, rm, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { logRun, getRunHistory, getLastRun, getRunSummary, getRunStats } from "../src/core/run-log";
+import { logRun, getRunHistory, getLastRun, getRunSummary, getRunStats, isCompletedRecord } from "../src/core/run-log";
 import type { SkillRunRecord } from "../src/types";
 
 const run = async (args: string[]): Promise<{ stdout: string; stderr: string; exitCode: number }> => {
@@ -328,5 +328,72 @@ describe("mktg skill log", () => {
 
     const exists = await Bun.file(join(tmpDir, ".mktg", "runs.jsonl")).exists();
     expect(exists).toBe(false);
+  });
+});
+
+// ==================== Event semantics: loaded vs completed ====================
+
+describe("isCompletedRecord dual-read", () => {
+  test("explicit completed event counts", () => {
+    expect(isCompletedRecord({ skill: "a", timestamp: "t", event: "completed", result: "success", brandFilesChanged: [] })).toBe(true);
+  });
+
+  test("explicit loaded event does NOT count, even if it carried a result", () => {
+    expect(isCompletedRecord({ skill: "a", timestamp: "t", event: "loaded", brandFilesChanged: [] })).toBe(false);
+  });
+
+  test("legacy record with brand writes counts as completed (transitional dual-read)", () => {
+    expect(isCompletedRecord({ skill: "a", timestamp: "t", result: "success", brandFilesChanged: ["voice-profile.md"] })).toBe(true);
+  });
+
+  test("legacy result:'success' with empty writes was a LOAD — must not count", () => {
+    expect(isCompletedRecord({ skill: "a", timestamp: "t", result: "success", brandFilesChanged: [] })).toBe(false);
+  });
+});
+
+describe("completedOnly filtering", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "mktg-runlog-filter-"));
+    await logRun(tmpDir, { skill: "seo-content", timestamp: "2026-03-13T10:00:00.000Z", event: "loaded", brandFilesChanged: [] });
+    await logRun(tmpDir, { skill: "seo-content", timestamp: "2026-03-13T11:00:00.000Z", event: "completed", result: "success", writes: ["marketing/x.md"], brandFilesChanged: [] });
+    await logRun(tmpDir, { skill: "legacy-skill", timestamp: "2026-03-13T12:00:00.000Z", result: "success", brandFilesChanged: ["audience.md"] });
+    await logRun(tmpDir, { skill: "legacy-load", timestamp: "2026-03-13T13:00:00.000Z", result: "success", brandFilesChanged: [] });
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  test("getRunHistory completedOnly keeps completions + legacy-with-writes only", async () => {
+    const completed = await getRunHistory(tmpDir, undefined, 50, { completedOnly: true });
+    const skills = completed.map(r => r.skill).sort();
+    expect(skills).toEqual(["legacy-skill", "seo-content"]);
+    expect(completed.find(r => r.skill === "legacy-load")).toBeUndefined();
+  });
+
+  test("getRunSummary completedOnly drops load-only skills entirely", async () => {
+    const summary = await getRunSummary(tmpDir, { completedOnly: true });
+    expect(Object.keys(summary).sort()).toEqual(["legacy-skill", "seo-content"]);
+    expect(summary["legacy-load"]).toBeUndefined();
+  });
+
+  test("summary entries expose event + nullable result", async () => {
+    const summary = await getRunSummary(tmpDir);
+    expect(summary["seo-content"]!.event).toBe("completed");
+    expect(summary["seo-content"]!.result).toBe("success");
+    expect(summary["legacy-load"]!.event).toBe("loaded");
+  });
+
+  test("stats count loaded vs completed separately; rate uses outcome records only", async () => {
+    const stats = await getRunStats(tmpDir);
+    expect(stats.totalRuns).toBe(4);
+    expect(stats.completedCount).toBe(2);
+    expect(stats.loadedCount).toBe(2);
+    // 3 records carry an outcome field (completed + both legacy records);
+    // only the explicit load event has none.
+    expect(stats.successCount).toBe(3);
+    expect(stats.successRate).toBe(100);
   });
 });

--- a/tests/run.test.ts
+++ b/tests/run.test.ts
@@ -3,7 +3,7 @@
 
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { join } from "node:path";
-import { mkdtemp, rm, readFile } from "node:fs/promises";
+import { mkdtemp, rm, readFile, writeFile, mkdir } from "node:fs/promises";
 import { tmpdir } from "node:os";
 
 const run = async (args: string[]): Promise<{ stdout: string; stderr: string; exitCode: number }> => {
@@ -86,7 +86,7 @@ describe("mktg run", () => {
     }
   });
 
-  test("successful run creates JSONL log entry", async () => {
+  test("bare run logs event 'loaded' with NO result (a load is not a success)", async () => {
     const { exitCode } = await run(["run", "brand-voice", "--json", "--cwd", tmpDir]);
     if (exitCode === 0) {
       const logContent = await readFile(join(tmpDir, ".mktg", "runs.jsonl"), "utf-8");
@@ -94,8 +94,77 @@ describe("mktg run", () => {
       expect(lines.length).toBe(1);
       const record = JSON.parse(lines[0]!);
       expect(record.skill).toBe("brand-voice");
-      expect(record.result).toBe("success");
+      expect(record.event).toBe("loaded");
+      expect(record.result).toBeUndefined();
+      expect(record.writes).toBeUndefined();
       expect(record.timestamp).toBeTruthy();
+    }
+  });
+
+  test("--complete with valid writes logs event 'completed' with result + writes", async () => {
+    await mkdir(join(tmpDir, "marketing", "content"), { recursive: true });
+    await writeFile(join(tmpDir, "marketing", "content", "x.md"), "# Article");
+    const { stdout, exitCode } = await run([
+      "run", "brand-voice", "--complete", "--writes", "marketing/content/x.md", "--result", "success", "--json", "--cwd", tmpDir,
+    ]);
+    if (exitCode === 0) {
+      const parsed = JSON.parse(stdout);
+      expect(parsed.event).toBe("completed");
+      expect(parsed.result).toBe("success");
+      expect(parsed.writes).toEqual(["marketing/content/x.md"]);
+
+      const logContent = await readFile(join(tmpDir, ".mktg", "runs.jsonl"), "utf-8");
+      const record = JSON.parse(logContent.trim().split("\n")[0]!);
+      expect(record.event).toBe("completed");
+      expect(record.result).toBe("success");
+      expect(record.writes).toEqual(["marketing/content/x.md"]);
+    }
+  });
+
+  test("--complete with a missing write path exits 2 with fix guidance (no silent success)", async () => {
+    const { stdout, exitCode } = await run([
+      "run", "brand-voice", "--complete", "--writes", "marketing/content/ghost.md", "--json", "--cwd", tmpDir,
+    ]);
+    expect(exitCode).toBe(2);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.error.code).toBe("INVALID_ARGS");
+    expect(parsed.error.message).toContain("ghost.md");
+    expect(parsed.error.suggestions.join(" ")).toContain("Create the files first");
+    const logExists = await Bun.file(join(tmpDir, ".mktg", "runs.jsonl")).exists();
+    expect(logExists).toBe(false);
+  });
+
+  test("--complete rejects traversal in writes", async () => {
+    const { stdout, exitCode } = await run([
+      "run", "brand-voice", "--complete", "--writes", "../outside.md", "--json", "--cwd", tmpDir,
+    ]);
+    expect(exitCode).toBe(2);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.error.code).toBe("INVALID_ARGS");
+  });
+
+  test("--result without --complete exits 2", async () => {
+    const { stdout, exitCode } = await run(["run", "brand-voice", "--result", "success", "--json", "--cwd", tmpDir]);
+    expect(exitCode).toBe(2);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.error.code).toBe("INVALID_ARGS");
+    expect(parsed.error.message).toContain("--complete");
+  });
+
+  test("--result rejects invalid values", async () => {
+    const { stdout, exitCode } = await run(["run", "brand-voice", "--complete", "--result", "amazing", "--json", "--cwd", tmpDir]);
+    expect(exitCode).toBe(2);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.error.message).toContain("Invalid --result");
+  });
+
+  test("--complete --result failed logs the failure honestly", async () => {
+    const { exitCode } = await run(["run", "brand-voice", "--complete", "--result", "failed", "--json", "--cwd", tmpDir]);
+    if (exitCode === 0) {
+      const logContent = await readFile(join(tmpDir, ".mktg", "runs.jsonl"), "utf-8");
+      const record = JSON.parse(logContent.trim().split("\n")[0]!);
+      expect(record.event).toBe("completed");
+      expect(record.result).toBe("failed");
     }
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **Phases 1 + 3** of the CLI improvement plan (M1 — Honest loop). This PR also carries the plan doc itself (cherry-picked from #40, which can be closed as superseded) with its tracker rows updated in the same branch per the resume protocol.

**The lie being killed:** `mktg run` logged `result:"success"` on a bare SKILL.md load with empty `brandFilesChanged` (`run.ts:162` on main). `plan`/`status`/dashboard trusted that signal and recommended distribute after load-only "runs". Plan health additionally counted template files as populated — 3 templates = "ready".

### What changes

| Surface | Before | After |
|---|---|---|
| `SkillRunRecord` | `{skill, timestamp, result, brandFilesChanged}` | `+ event: "loaded"\|"completed"`, `+ writes[]`; `result` optional — **absent on loads** |
| `mktg run` | logs `success` always | logs `event:"loaded"`; `--complete` records outcomes with `--result` and validated `--writes` |
| `--writes` validation | n/a | Full path pipeline (control chars → double-encoding → sandbox) + must-exist; ghost writes **exit 2** with fix guidance |
| Legacy records | n/a | Dual-read: explicit event wins; pre-event records count as completed **only** with real brand writes |
| `mktg plan` | gates on any run | gates on completed runs only; distribute additionally requires `marketing/` artifacts or a completed content run |
| Plan health | ≥3 files exist = ready | ≥3 **non-template** files = ready |
| `mktg status` | `recentActivity[].result: string` | `+ event`, nullable result; TTY shows loads as dim `○ loaded` |
| `mktg dashboard` | readiness from any run | readiness from completed runs; `recentRuns` entries carry event |
| `mktg skill log` | writes result only | writes `event:"completed"` (it's an outcome logger) |

### Verification

- Root `bun test` → **3223 pass / 0 fail** (incl. new honesty coverage: load-vs-complete logging, ghost-writes exit 2, distribute gates, template health)
- `bun x tsc --noEmit` → clean
- Studio suite → 221/225 (4 failures are the pre-existing time-of-day flake fixed in #42 — no bridge/shape regressions)

### Dogfood evidence (this environment)

```
1. mktg run seo-content            → {"event":"loaded","result":null,"writes":null}
2. mktg plan (load-only history)   → {"health":"incomplete","distribute":false,"runSeoContent":true}
3. mktg run seo-content --complete --writes marketing/content/x.md
                                   → {"event":"completed","result":"success","writes":["marketing/content/x.md"]}
4. mktg plan                       → {"health":"incomplete","distribute":true}
5. --complete --writes ghost.md    → exit=2 INVALID_ARGS (no silent success)
```

### Backward compat

Agents parsing `result:"success"` on load records will see `result` absent — intended break, documented in CONTEXT.md + the envelope now self-describes via `event`. Pre-event history with real brand writes still counts as completed (transitional dual-read); legacy load-only history correctly stops unlocking plan gates.

### Sequence context

Next: M2 — `run --with-context` + rich prereqs + `--strict` (Phase 2 + 4). Tracker rows P1/P3 marked completed on this branch.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d221b2b7-a08b-4b51-a74a-5bb038a8ccd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d221b2b7-a08b-4b51-a74a-5bb038a8ccd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

