### PR TITLE
feat(catalog): research_adapters capability + mcp block + openseo catalog (OpenSEO S1) + sync/status honesty

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "marketing-cli",
-      "description": "Agent-native marketing playbook CLI: 64 skills, 5 research/review agents, brand memory, and /cmo orchestration.",
+      "description": "Agent-native marketing playbook CLI: 65 skills, 5 research/review agents, brand memory, and /cmo orchestration.",
       "version": "0.6.0",
       "source": "./",
       "homepage": "https://github.com/MoizIbnYousaf/marketing-cli",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "marketing-cli",
   "version": "0.6.0",
-  "description": "Agent-native marketing playbook CLI: 64 skills, 5 research/review agents, brand memory, and /cmo orchestration.",
+  "description": "Agent-native marketing playbook CLI: 65 skills, 5 research/review agents, brand memory, and /cmo orchestration.",
   "author": {
     "name": "Moiz Ibn Yousaf",
     "url": "https://github.com/MoizIbnYousaf/marketing-cli"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "marketing-cli",
   "version": "0.6.0",
-  "description": "Agent-native marketing playbook CLI: 64 skills, 5 research/review agents, brand memory, and /cmo orchestration.",
+  "description": "Agent-native marketing playbook CLI: 65 skills, 5 research/review agents, brand memory, and /cmo orchestration.",
   "author": {
     "name": "Moiz Ibn Yousaf",
     "url": "https://github.com/MoizIbnYousaf/marketing-cli"
@@ -21,7 +21,7 @@
   "interface": {
     "displayName": "Marketing CLI",
     "shortDescription": "A CMO for your agent.",
-    "longDescription": "Install one CLI and give your agent 63 marketing skills, 5 research/review agents, persistent brand memory, native publishing workflows, and a local marketing studio.",
+    "longDescription": "Install one CLI and give your agent 64 marketing skills, 5 research/review agents, persistent brand memory, native publishing workflows, and a local marketing studio.",
     "developerName": "Moiz Ibn Yousaf",
     "category": "Productivity",
     "capabilities": [

--- a/.mcp.json
+++ b/.mcp.json
@@ -6,6 +6,13 @@
       "headers": {
         "x-api-key": "${EXA_API_KEY}"
       }
+    },
+    "openseo": {
+      "type": "http",
+      "url": "https://app.openseo.so/mcp",
+      "headers": {
+        "Authorization": "Bearer ${OPENSEO_API_KEY}"
+      }
     }
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,6 +150,7 @@ Add a new upstream catalog without touching CLI code. Catalogs are external OSS 
    - `publish_adapters[]` → add the adapter to `ADAPTERS` and `ADAPTER_ENV_VARS` in `src/commands/publish.ts`.
    - `scheduling_adapters[]` → reserved for cal.com-style catalogs; future.
    - `email_adapters[]` → reserved for listmonk-style catalogs; future.
+   - `research_adapters[]` → research/data-plane catalogs (SEO metrics, SERP, backlinks). Wired via the companion skill + optional `mcp` block, not publish adapters.
    - `skills[]` → create the corresponding `skills/<skill-name>/SKILL.md` and register in `skills-manifest.json`.
 3. Run `mktg catalog list --json` to verify the entry loaded. `loadCatalogManifest` runs here and rejects adapter-name collisions (`CATALOG_COLLISION`), licenses outside the allowlist (`CATALOG_LICENSE_DENIED`), and malformed entries (`CATALOG_MANIFEST_INVALID`) as structured errors. (`mktg catalog sync` is the wrong command for this; it checks upstream version drift against GitHub releases, not manifest validity.)
 4. (Optional) Run `mktg doctor --json` to verify env vars in `auth.credential_envs` are set for the new catalog.
@@ -163,7 +164,8 @@ Add a new upstream catalog without touching CLI code. Catalogs are external OSS 
 | `version_pinned` | An upstream tag (not `main`). `mktg catalog sync` diffs this against latest. |
 | `transport` | `"sdk"` ONLY if the upstream's SDK license permits linking. Otherwise `"http"` and `sdk_reference: null`. |
 | `auth` | Fully declared: `style`, `base_env`, `credential_envs`, `header_format`. Skill and adapter code never hardcodes env names; it reads from the catalog entry. |
-| `capabilities` | At least one non-empty capability array. A catalog with zero capabilities is rejected at load time. |
+| `capabilities` | At least one non-empty capability array (`publish_adapters`, `scheduling_adapters`, `email_adapters`, `research_adapters`). A catalog with zero capabilities is rejected at load time. |
+| `mcp` (optional) | `{ url_env, default_url }` for MCP-served catalogs (e.g. openseo). `default_url` must be https. `transport` stays `"http"` — MCP rides over HTTP; no new transport value. |
 
 ### Security Posture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@
 
 ## What This Is
 
-A TypeScript/Bun agent-native marketing playbook CLI. 64 marketing skills (62 playbook + `/cmo`), 6 agents, 20 commands, 1 upstream catalog. The Studio dashboard (Next.js + Bun API) ships inside the same tarball and is launched via `mktg studio`.
+A TypeScript/Bun agent-native marketing playbook CLI. 65 marketing skills (63 playbook + `/cmo` + `/axi`), 6 agents, 20 commands, 1 upstream catalog. The Studio dashboard (Next.js + Bun API) ships inside the same tarball and is launched via `mktg studio`.
 
 | Component | Count | Purpose |
 |---|---|---|
@@ -48,7 +48,7 @@ src/
 │   ├── skill-add.ts    # External skill chaining (mktg skill add)
 │   ├── agents.ts       # Agent registry, install to ~/.claude/agents/
 │   └── transcribe.ts   # whisper.cpp + yt-dlp + ffmpeg pipeline
-skills/                  # 64 SKILL.md files installed to ~/.claude/skills/
+skills/                  # 65 SKILL.md files installed to ~/.claude/skills/
 skills-manifest.json     # Definitive skill list with metadata
 agents/                  # 6 agent .md files installed to ~/.claude/agents/
 agents-manifest.json     # Definitive agent list with metadata

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -72,7 +72,16 @@ mktg status --json --fields "brand.populated,skills.installed"
 mktg run brand-voice --json
 # Returns skill content + prerequisites + prior run context.
 # Logs event:"loaded" — a load is NOT work and never unlocks plan distribute steps.
-# For brand context, call `mktg context` (below) — `run` does not return it.
+
+mktg run seo-content --with-context --budget 4000 --json
+# One-shot activation: also returns non-template brand context selected from
+# the skill's declared reads (layer matrix fallback). Templates are named in
+# context.templatesSkipped; budget overflow in context.budgetDropped.
+
+mktg run postiz --strict --json
+# Prereqs cover skills, brand files, env vars (manifest env_vars), CLI tools,
+# and backing catalogs. --strict exits 3 (DEPENDENCY_MISSING) when any are
+# unsatisfied; default stays warn-only (progressive enhancement).
 ```
 
 ### 3b. Record the outcome after doing the work
@@ -174,6 +183,8 @@ posting and the native backend is only acting as the local queue.
 | Agent needs project state | `mktg status --json` |
 | Agent needs health check | `mktg doctor --json` |
 | Agent needs a specific skill loaded | `mktg run <skill> --json` (logs `event:"loaded"`) |
+| Agent needs skill + brand context in one call | `mktg run <skill> --with-context --json` |
+| Agent must fail fast on missing prereqs | `mktg run <skill> --strict --json` (exit 3) |
 | Agent finished the work and records it | `mktg run <skill> --complete --writes <paths> --result success --json` |
 | Agent needs load vs completion history | `mktg skill history <skill> --json` |
 | Agent needs brand context for a skill | `mktg context --json` |

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -70,7 +70,18 @@ mktg status --json --fields "brand.populated,skills.installed"
 
 ```bash
 mktg run brand-voice --json
-# Returns skill content + metadata + brand context
+# Returns skill content + prerequisites + prior run context.
+# Logs event:"loaded" — a load is NOT work and never unlocks plan distribute steps.
+# For brand context, call `mktg context` (below) — `run` does not return it.
+```
+
+### 3b. Record the outcome after doing the work
+
+```bash
+mktg run brand-voice --complete --writes brand/voice-profile.md --result success --json
+# --writes paths must exist inside the project (validated, exit 2 otherwise).
+# Only event:"completed" records count as executed work in `mktg plan`.
+# History: mktg skill history <skill> --json (shows loaded vs completed events).
 ```
 
 ### 4. Get token-budgeted brand context
@@ -162,7 +173,9 @@ posting and the native backend is only acting as the local queue.
 | User says "help me with marketing" | `/cmo`; it routes to the right skill |
 | Agent needs project state | `mktg status --json` |
 | Agent needs health check | `mktg doctor --json` |
-| Agent needs a specific skill loaded | `mktg run <skill> --json` |
+| Agent needs a specific skill loaded | `mktg run <skill> --json` (logs `event:"loaded"`) |
+| Agent finished the work and records it | `mktg run <skill> --complete --writes <paths> --result success --json` |
+| Agent needs load vs completion history | `mktg skill history <skill> --json` |
 | Agent needs brand context for a skill | `mktg context --json` |
 | Updating skills after package upgrade | `mktg update --json` |
 | Checking whether a newer marketing-cli is on npm | `mktg update --check --json` |

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -113,14 +113,29 @@ mktg catalog info postiz --json --fields name,license,version_pinned,auth.creden
 # `configured: true` iff every auth.credential_envs entry is set in process.env.
 
 mktg catalog status --json
-# Fleet-wide health check across all registered catalogs.
+# Configured-state across all registered catalogs.
+# healthy is always null — reachability probes are not implemented (never guessed).
 
 mktg catalog sync --dry-run --json
-# Diff local version_pinned against upstream tags. v1 is read-only; --dry-run is parity-only.
+# Reports each catalog's pinned version. Upstream drift detection is NOT
+# implemented: to_version is always null and every item says so in `error`.
 
 mktg catalog add <name> --confirm --json
 # Register a new catalog entry. Mutating, destructive-guarded.
+
+mktg catalog info openseo --json --fields configured,missing_envs,mcp
+# SEO data plane (research_adapters capability). mcp.default_url is the hosted
+# MCP; OPENSEO_MCP_URL overrides for self-host. OPENSEO_API_KEY enables
+# non-interactive automation; without it, SEO metrics are `unknown` (never invented).
 ```
+
+### 5b. Pick the right research backend
+
+| Job | Preferred | Fallback |
+|-----|-----------|----------|
+| KD / volume / SERP / backlinks / rank tracking / GSC | OpenSEO (catalog + MCP) | none — mark metrics `unknown` |
+| Open-web discovery, Reddit/GitHub mining | Exa | — |
+| Fetch known-URL content | Firecrawl | — |
 
 ### 6. Launch the studio dashboard
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -158,6 +158,9 @@ mktg publish --native-upsert-provider --input '{"identifier":"linkedin","name":"
 mktg publish --adapter mktg-native --list-integrations --json
 mktg publish --adapter mktg-native --dry-run --input '<publish-manifest-json>' --json
 mktg publish --adapter mktg-native --confirm --input '<publish-manifest-json>' --json
+# Per-item status truth: queued-local (native) | draft-external (typefully,
+# postiz) | sent (resend) | written-file (file) | failed | skipped.
+# A local queue write is never "sent"; an external draft is never "published".
 mktg publish --native-list-posts --json
 ```
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p align="center">
   <a href="https://github.com/MoizIbnYousaf/marketing-cli/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-10b981" alt="MIT License"></a>
-  <img src="https://img.shields.io/badge/skills-64-10b981" alt="64 Skills">
+  <img src="https://img.shields.io/badge/skills-65-10b981" alt="65 Skills">
   <img src="https://img.shields.io/badge/agents-5-10b981" alt="5 Agents">
   <a href="https://www.npmjs.com/package/marketing-cli"><img src="https://img.shields.io/npm/v/marketing-cli?color=10b981" alt="npm"></a>
   <img src="https://img.shields.io/badge/tests-2,624-10b981" alt="2,624 tests">
@@ -12,7 +12,7 @@
 </p>
 
 <p align="center">
-  <b>One package. One install. CLI for the agent, Studio for the human. 64 skills, 6 research agents, brand memory that compounds.</b>
+  <b>One package. One install. CLI for the agent, Studio for the human. 65 skills, 6 research agents, brand memory that compounds.</b>
 </p>
 
 ---
@@ -25,7 +25,7 @@ One npm package, two surfaces. The CLI is the agent surface, the Studio dashboar
 
 | Surface | What it is | Path |
 |---|---|---|
-| `mktg` CLI | 64 skills, 6 agents, brand memory, `/cmo` orchestration | (root) |
+| `mktg` CLI | 65 skills, 6 agents, brand memory, `/cmo` orchestration | (root) |
 | Studio dashboard | Local Next.js + Bun API: pulse, signals, brand visualizer, publish queue | [`studio/`](studio/) |
 
 `npm i -g marketing-cli` installs both. The repo uses a bun workspace because Studio is a Next.js app with its own build, but at install time it is one package, one tarball.
@@ -34,7 +34,7 @@ One npm package, two surfaces. The CLI is the agent surface, the Studio dashboar
 
 You ask your agent for marketing help. It writes generic copy and forgets your audience by tomorrow. The skills it would use aren't installed; the brand files don't exist; the agent learns this halfway through, when something fails mid-execution. Every session is the first session.
 
-`marketing-cli` fixes that. Install once and your agent inherits 64 skills, 6 research agents, and a brand memory that compounds. Session 10 starts where session 9 ended. Every conversation builds on the last.
+`marketing-cli` fixes that. Install once and your agent inherits 65 skills, 6 research agents, and a brand memory that compounds. Session 10 starts where session 9 ended. Every conversation builds on the last.
 
 ---
 
@@ -57,7 +57,7 @@ You ask your agent for marketing help. It writes generic copy and forgets your a
 | | |
 |---|---|
 | **`mktg` CLI** | 20 commands, 21/21 Agent DX score, JSON-by-default |
-| **64 marketing skills** | The playbook, copied to `~/.claude/skills/` |
+| **65 marketing skills** | The playbook, copied to `~/.claude/skills/` |
 | **5 research + review agents** | Parallel sub-agents in `~/.claude/agents/` |
 | **10 brand memory files** | Persistent marketing memory in your project's `brand/` (10 templates plus `SCHEMA.md`), created by `mktg init` |
 | **`/cmo` orchestrator** | The brain that routes every request to the right skill |
@@ -97,7 +97,7 @@ mktg orchestrates; it doesn't reimplement. When a good tool already exists, we c
 npm i -g marketing-cli
 ```
 
-That's it. The global npm install copies the 64 skills into `~/.claude/skills/` and the 6 agents into `~/.claude/agents/`. No second install command, no `mktg init` to remember.
+That's it. The global npm install copies the 65 skills into `~/.claude/skills/` and the 6 agents into `~/.claude/agents/`. No second install command, no `mktg init` to remember.
 
 Then open Claude Code in your project and run:
 
@@ -232,7 +232,7 @@ Organized by marketing layer. Foundation builds up to distribution.
 
 | Skill | What it does |
 |-------|-------------|
-| **cmo** | Orchestrates all 64 skills. Routing table, disambiguation, guardrails. |
+| **cmo** | Orchestrates all 65 skills. Routing table, disambiguation, guardrails. |
 | **axi** | AXI catalog router — gh-axi, chrome-devtools-axi, principles, AXI vs MCP. |
 | **brand-voice** | Define or extract brand voice from existing content |
 | **audience-research** | Build buyer personas with parallel web research |
@@ -348,7 +348,7 @@ The 3 research agents run **in parallel**. Results write back to `brand/` so eve
 | `mktg init` | Scaffold `brand/` plus install skills plus install agents |
 | `mktg status` | Project marketing state snapshot |
 | `mktg doctor` | Health checks: brand files, skills, agents, CLI tools, integrations |
-| `mktg list` | Show all 64 skills with install status and metadata |
+| `mktg list` | Show all 65 skills with install status and metadata |
 | `mktg update` | Re-install skills from latest package version |
 | `mktg schema` | Introspect all commands, flags, and output shapes |
 | `mktg skill` | Inspect, validate, register, analyze, and chain external skills |
@@ -472,7 +472,7 @@ Contributions welcome. The fastest ways to help:
 
 ## Acknowledgments
 
-- [Corey Haines' Marketing Skills](https://github.com/coreyhaines31/marketingskills): the breadth skill collection that inspired many of mktg's 64 skills
+- [Corey Haines' Marketing Skills](https://github.com/coreyhaines31/marketingskills): the breadth skill collection that inspired many of mktg's 65 skills
 - [Postiz](https://github.com/gitroomhq/postiz-app) by [@gitroomhq](https://github.com/gitroomhq): the upstream catalog for 30+ social provider integrations (LinkedIn, Reddit, Bluesky, Mastodon, Threads, Instagram, TikTok, YouTube, Pinterest, Discord, Slack, etc.). mktg connects via REST API; license stays firewalled.
 - [last30days-skill](https://github.com/mvanhorn/last30days-skill) by [@mvanhorn](https://github.com/mvanhorn): live research across Reddit, X, YouTube, Hacker News, GitHub, and the web. `/cmo` chains it before any market claim, so the playbook stays grounded in what's actually happening this month, not training-data folklore.
 - [`@steipete/summarize`](https://github.com/steipete/summarize) by [@steipete](https://github.com/steipete): the text-compression CLI that mktg's `summarize` skill wraps with rules and budgets.

--- a/catalogs-manifest.json
+++ b/catalogs-manifest.json
@@ -19,6 +19,29 @@
         "header_format": "bare"
       },
       "skills": ["postiz"]
+    },
+    "openseo": {
+      "name": "openseo",
+      "repo_url": "https://github.com/every-app/open-seo",
+      "docs_url": "https://openseo.so/docs/mcp",
+      "license": "MIT",
+      "version_pinned": "v0.1.2",
+      "capabilities": {
+        "research_adapters": ["openseo"]
+      },
+      "transport": "http",
+      "sdk_reference": null,
+      "auth": {
+        "style": "bearer",
+        "base_env": "OPENSEO_API_BASE",
+        "credential_envs": ["OPENSEO_API_KEY"],
+        "header_format": "bearer"
+      },
+      "skills": ["openseo"],
+      "mcp": {
+        "url_env": "OPENSEO_MCP_URL",
+        "default_url": "https://app.openseo.so/mcp"
+      }
     }
   }
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ indexes under `skills/cmo/rules/`:
 | [transcribe.md](transcribe.md) | `mktg transcribe` command — usage, flags, pipeline, dependencies |
 | [EXIT_CODES.md](EXIT_CODES.md) | Exit code reference — codes 0-6, constructors, agent usage |
 | [plans/2026-04-25-001-feat-cmo-studio-boot-session-plan.md](plans/2026-04-25-001-feat-cmo-studio-boot-session-plan.md) | CMO Studio boot session plan — command-driven, hook-free startup contract |
+| [cli-improvement-plan.md](cli-improvement-plan.md) | Phased CLI improvement plan — honest run lifecycle, plan/publish truth, portable route |
 
 ## Subdirectories
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ indexes under `skills/cmo/rules/`:
 | [EXIT_CODES.md](EXIT_CODES.md) | Exit code reference — codes 0-6, constructors, agent usage |
 | [plans/2026-04-25-001-feat-cmo-studio-boot-session-plan.md](plans/2026-04-25-001-feat-cmo-studio-boot-session-plan.md) | CMO Studio boot session plan — command-driven, hook-free startup contract |
 | [cli-improvement-plan.md](cli-improvement-plan.md) | Phased CLI improvement plan — honest run lifecycle, plan/publish truth, portable route |
+| [openseo-integration-plan.md](openseo-integration-plan.md) | Plan to make OpenSEO the first-class SEO data plane inside mktg |
 
 ## Subdirectories
 

--- a/docs/cli-improvement-plan.md
+++ b/docs/cli-improvement-plan.md
@@ -1,0 +1,494 @@
+# CLI Improvement Plan — marketing-cli (`mktg`)
+
+> Sprint-persistence doc for making the CLI’s orchestration loop trustworthy.
+> Status: `in_progress` (plan authored). Resume by picking the next `pending` phase.
+
+## Reference data (don’t modify without explicit instruction)
+
+| Field | Value |
+|---|---|
+| Product | `marketing-cli` / `mktg` |
+| Package manager | Bun |
+| North star | Agent-native playbook OS — skills are LLM playbooks; CLI owns memory, contracts, prereqs, outcomes, publish truth |
+| Non-goal | Become “AI that writes LinkedIn inside the CLI” / replace the agent |
+| Evidence base | Cloud dogfood 2026-07-18: 64-skill install, offline GTM pack, native publish staging |
+| Related | `CONTEXT.md`, `CLAUDE.md`, `AGENTS.md`, `docs/skill-contract.md` |
+
+### Dogfood findings that drive this plan
+
+1. **`mktg run` ≠ work** — loads `SKILL.md`, logs `result: "success"`, often with empty `brandFilesChanged`.
+2. **`mktg plan` trusts the wrong signal** — can recommend distribute after a load-only “run.”
+3. **Docs oversell the load envelope** — `CONTEXT.md` says run returns brand context; it doesn’t (separate `mktg context`).
+4. **Prereqs are incomplete** — brand/skill deps only; tools/envs/catalogs absent → Tier-2 skills look green then fail mid-playbook.
+5. **Publish status is ambiguous** — `mktg-native --confirm` queues locally; agents read that as “posted.”
+6. **Two human UIs** — `dashboard` vs `studio` confuse agents and humans.
+7. **`mktg cmo` is Claude-Code-coupled** — no portable structured router for Cursor/Codex/CI.
+8. **Catalog sync/status partially stubbed** — advertised behavior ≠ implementation (exit 6 / null health).
+
+---
+
+## Phase Status Tracker
+
+| # | Phase | Status | PR/Commit | Notes |
+|---|---|---|---|---|
+| 0 | Plan authored (this doc) | `completed` | — | 2026-07-18 |
+| 1 | Honest skill lifecycle (`loaded` vs `completed`) | `pending` | | Foundation for everything else |
+| 2 | One-shot activation (`run --with-context`) | `pending` | | Can ship parallel to P1 after log shape lands |
+| 3 | Outcome-aware `plan` / `status` / dashboard | `pending` | | Depends on P1 |
+| 4 | Rich prerequisites + `--strict` | `pending` | | |
+| 5 | Publish truth + promote path | `pending` | | |
+| 6 | Portable `mktg route` (+ CMO runner clarity) | `pending` | | |
+| 7 | Studio vs dashboard consolidation | `pending` | | |
+| 8 | Studio npm resolve + doctor check | `pending` | | Small; can jump ahead |
+| 9 | Catalog sync/probe (or un-advertise) | `pending` | | |
+| 10 | Skill script exec allowlist | `pending` | | Bigger bet |
+| 11 | Strict skill-contract enforcement | `pending` | | |
+| 12 | Docs/CONTEXT/`/cmo` index sync | `pending` | | Continuous; hard gate before each release |
+
+Status values: `pending` → `in_progress` → `completed` | `skipped` (with reason).
+
+---
+
+## Principles (non-negotiable)
+
+1. **Progressive enhancement** — every skill still works at L0; brand enhances, never gates.
+2. **Agent DX 21/21 preserved** — JSON, `--dry-run`, `--fields`, schemas, validators, safety rails.
+3. **Skills never call skills** — CLI + `/cmo`/`route` orchestrate; skills read/write files.
+4. **Honesty over magic** — statuses name what actually happened (`loaded`, `queued-local`, `unimplemented`).
+5. **No mocks in tests** — real temp dirs; no fake “success” without real writes when asserting completion.
+6. **Ship vertical slices** — each phase leaves `bun test` green and CONTEXT accurate.
+
+---
+
+## Target loop (end state)
+
+```text
+doctor → status → route|cmo → run --with-context (loaded)
+  → agent produces files under brand/|marketing/|.mktg/
+  → run --complete --writes … --result … (completed)
+  → plan (artifact-aware next steps)
+  → publish (queued-local | draft-external | sent)
+```
+
+---
+
+## Phase 1 — Honest skill lifecycle
+
+**Problem:** Load is logged as success; agents and `plan` believe work happened.
+
+### Scope
+
+| Change | Detail |
+|---|---|
+| Log events | `loaded` (default) vs `completed` (explicit) |
+| Flags | `--complete`, `--result success\|partial\|failed`, `--writes <paths>`, keep `--learning` |
+| Default | `mktg run X` logs `loaded`, not `success` |
+| History | `mktg run <skill> --history --json` (or `mktg skill history`) returns both event types |
+| Schema | Update `run` responseSchema + examples |
+| Backward compat | Consumers that key on `result: "success"` for loads: document break; prefer alias field `event: "loaded"\|"completed"` and deprecate treating load as success |
+
+### Acceptance criteria
+
+- [ ] Bare `mktg run seo-content --json` → `event: "loaded"`, history entry is not counted as execution by plan
+- [ ] `mktg run seo-content --complete --writes marketing/content/x.md --result success --json` validates writes exist (sandboxPath), logs `completed`
+- [ ] Missing/invalid write paths → exit 2 with fix guidance (no silent success)
+- [ ] Integration tests cover load vs complete; plan fixture proves load alone doesn’t unlock distribute
+- [ ] `CONTEXT.md` §“Load a skill” wording matches reality
+
+### Invasiveness
+
+**M** — `src/commands/run.ts`, history store, plan consumers, schema, a few integration tests.
+
+### Suggested commit series
+
+1. Add `event` field + stop defaulting load to `success` (compat note in changelog)
+2. Add `--complete` / `--writes` / `--result`
+3. Wire plan/status to `completed` only (Phase 3 can finish scoring)
+
+---
+
+## Phase 2 — One-shot activation envelope
+
+**Problem:** Agents need 2–3 calls (`run` + `context` + sometimes claims) before executing a skill.
+
+### Scope
+
+| Change | Detail |
+|---|---|
+| Flag | `mktg run <skill> --with-context [--budget N] --json` |
+| Payload | `{ skill, content, prerequisites, priorRuns, context: { files, layer, claimsBlacklist? } }` |
+| Selection | Use manifest `reads` + `CONTEXT_MATRIX`; respect token budget |
+| Default | Opt-in first; consider default-on after one minor release if payload size OK |
+
+### Acceptance criteria
+
+- [ ] Single call returns skill body + non-template brand slices for declared `reads`
+- [ ] `--fields` can trim `context.files.*` / omit `content`
+- [ ] Budget overflow returns structured warning + truncated file list (no silent drop without signal)
+- [ ] Docs claim in CONTEXT.md becomes true when flag is used
+
+### Invasiveness
+
+**S** — compose existing `context` + `run` handlers.
+
+---
+
+## Phase 3 — Outcome-aware plan / status / dashboard
+
+**Problem:** Detection-order “plan” and existence heuristics recommend the wrong next move.
+
+### Scope
+
+| Change | Detail |
+|---|---|
+| Signals | Count `completed` runs; scan `marketing/` for artifacts; brand template vs populated |
+| Scoring | setup → populate → refresh → execute → distribute (documented weights) |
+| Distribute gate | Require artifacts under `marketing/` **or** completed run with writes — never load-only |
+| Health | `ready` only when foundation non-template thresholds met (define exactly in schema) |
+| Commands on tasks | Prefer `mktg run X --with-context` / `mktg route` / `mktg cmo --dry-run` over bare `mktg run` |
+| Dashboard JSON | Same semantics as CLI plan (no divergent heuristics) |
+
+### Acceptance criteria
+
+- [ ] Fixture: brand templates → plan says populate, not distribute
+- [ ] Fixture: load-only history → plan still recommends execute/content skills
+- [ ] Fixture: `marketing/content/**` present → distribute tasks appear
+- [ ] Schema documents ranking (no more “detection order only” lie)
+- [ ] Agent DX tests updated for new plan fields
+
+### Invasiveness
+
+**M** — `plan.ts`, status summary fields, dashboard contract tests.
+
+---
+
+## Phase 4 — Rich prerequisites + `--strict`
+
+**Problem:** Tier-2 skills pass prereq checks then fail for missing API keys/CLIs.
+
+### Scope
+
+| Check class | Sources |
+|---|---|
+| Skills | `depends_on` (existing) |
+| Brand | `reads` + template detection (existing) |
+| Tools | Ecosystem table / doctor tool registry |
+| Envs | Manifest / skill frontmatter `env_vars` |
+| Catalogs | `catalog info` configured/missing_envs |
+
+| Flag | Behavior |
+|---|---|
+| default | Warn in `prerequisites` object (today’s spirit) |
+| `--strict` | Unsatisfied required prereq → exit 3/4 with `remediation[]` |
+
+### Acceptance criteria
+
+- [ ] `mktg run postiz --json` surfaces `POSTIZ_API_KEY` missing even without `--strict`
+- [ ] `mktg run postiz --strict --json` non-zero exit when key missing
+- [ ] Offline skill (e.g. `content-atomizer`) remains exit 0 with empty envs
+- [ ] Doctor and run remediation strings stay consistent (same install hints)
+
+### Invasiveness
+
+**M** — shared prereq module used by `run` + `doctor`.
+
+---
+
+## Phase 5 — Publish truth + promote path
+
+**Problem:** Local queue and remote send look the same to agents.
+
+### Scope
+
+| Status enum | Meaning |
+|---|---|
+| `queued-local` | Written to `.mktg/native-publish/` |
+| `draft-external` | Created as draft on Typefully/Postiz/etc. |
+| `sent` | Confirmed sent/scheduled on external network |
+| `written-file` | File adapter output under `.mktg/published/` |
+| `failed` | Error with detail |
+
+Additional:
+
+- Result payload always includes `status` per item (not only published counts).
+- Optional: `mktg publish --promote --from native --to postiz --dry-run/--confirm`.
+- Studio labels match CLI enums 1:1 (`studio-api-index.md`).
+
+### Acceptance criteria
+
+- [ ] Native `--confirm` returns `queued-local`, never implies `sent`
+- [ ] Typefully/Postiz success maps to `draft-external` or `sent` based on API response
+- [ ] CONTEXT + publish-index document the enum
+- [ ] Integration tests lock the enum strings
+
+### Invasiveness
+
+**M** — publish adapters + Studio contract + docs.
+
+---
+
+## Phase 6 — Portable routing (`mktg route`)
+
+**Problem:** Orchestration is advertised broadly but `mktg cmo` requires Claude Code CLI.
+
+### Scope
+
+| Command | Behavior |
+|---|---|
+| `mktg route "<prompt>" --json` | Deterministic/table + heuristic route → `{ skill, playbook, confidence, rationale, nextCommand }` — **no LLM** |
+| `mktg cmo` | Keep Claude spawn; document `--runner claude` (default); fail clearly if binary missing |
+| Future (out of phase) | `--runner cursor\|prompt-only` |
+
+Reuse `/cmo` disambiguation tables where possible (single source in code or generated from skill metadata).
+
+### Acceptance criteria
+
+- [ ] `mktg route "write a show hn post" --json` → `startup-launcher` or `launch-strategy` with confidence
+- [ ] Works in CI without `claude` binary
+- [ ] `mktg cmo --dry-run` still previews spawn; live path unchanged
+- [ ] CMO skill docs point agents at `route` when Claude unavailable
+
+### Invasiveness
+
+**S** for `route` table; **L** if multi-runner is pulled in (don’t — keep out of this phase).
+
+---
+
+## Phase 7 — Studio vs dashboard consolidation
+
+**Problem:** Two “open a UI” stories.
+
+### Decision (proposed)
+
+| Surface | Role |
+|---|---|
+| `mktg studio` | **Canonical human UI** (Next + Bun API) |
+| `mktg dashboard` | **JSON command-center only** (no implicit server confusion), or alias → studio with deprecation warning for launcher subcommands |
+
+### Acceptance criteria
+
+- [ ] README / CONTEXT list one “open UI” command
+- [ ] Agents using dashboard get JSON snapshots without being told to open port 4311 as the product UI
+- [ ] Deprecation warning (if any) includes remove-by version
+
+### Invasiveness
+
+**S** (docs + alias) to **M** (code merge). Prefer S first.
+
+---
+
+## Phase 8 — Studio packaging resolve path
+
+**Problem:** Launcher messaging can claim mktg-studio isn’t on npm while the tarball ships `studio/`.
+
+### Scope
+
+- Resolve packaged `studio/bin/mktg-studio.ts` from installed package root first.
+- Rewrite install suggestions for npm users.
+- `mktg doctor` check: `studio-launcher-resolves`.
+
+### Acceptance criteria
+
+- [ ] Fresh `npm i -g marketing-cli` (or bun link) → `mktg studio --dry-run` resolves without sibling checkout
+- [ ] Doctor fails clearly when studio assets missing from install
+
+### Invasiveness
+
+**S**
+
+---
+
+## Phase 9 — Catalog sync / status honesty
+
+**Problem:** Documented GitHub drift checks / health probes aren’t real.
+
+### Option A (prefer): implement thin versions
+
+- `catalog sync --dry-run` — compare `version_pinned` to latest GitHub release tag
+- `catalog status --probe` — optional HTTP readiness (postiz is-connected style)
+
+### Option B: un-advertise
+
+- Schema + CONTEXT mark `unimplemented` until built; exit 6 stays but docs don’t promise drift checks
+
+### Acceptance criteria
+
+- [ ] Either A green with tests, or B with zero docs claiming live sync
+- [ ] No silent `healthy: null` without `status: "unimplemented"` field
+
+### Invasiveness
+
+**M** for A; **S** for B.
+
+---
+
+## Phase 10 — Skill script exec allowlist
+
+**Problem:** Some skills already ship `scripts/`; agents reinvent invocation.
+
+### Scope
+
+```bash
+mktg skill exec <skill> --script <name> --input '{...}' --json
+# or: mktg run <skill> --script <name> -- …
+```
+
+- Resolve install dir; sandbox cwd; allowlist skills that declare scripts in manifest/frontmatter.
+- Return stdout as JSON envelope; never shell unsandboxed paths.
+
+### Acceptance criteria
+
+- [ ] Allowlisted skill script runs under temp project and returns structured result
+- [ ] Unknown skill/script → exit 1/2
+- [ ] Path escape attempts rejected by existing validators
+- [ ] Non-allowlisted skills cannot exec arbitrary files
+
+### Invasiveness
+
+**M–L** — start with 1–2 skills (`mktg-x` or a tiny fixture skill in tests).
+
+---
+
+## Phase 11 — Strict skill-contract enforcement
+
+**Problem:** Drop-in quality drift (missing Anti-Patterns, >500 lines, incomplete frontmatter).
+
+### Scope
+
+- `mktg skill validate --strict` and/or `mktg doctor --check-skills`
+- Fail on: missing Anti-Patterns, line cap, required `reads`/`writes` for foundation tiers, broken `depends_on` DAG
+- Remove e2e exemptions as skills are fixed (separate cleanup PRs OK)
+
+### Acceptance criteria
+
+- [ ] CI job runs strict validate on bundled skills
+- [ ] Intentional exemptions are explicit in manifest, not silent test skips
+
+### Invasiveness
+
+**S** for the gate; skill cleanups vary.
+
+---
+
+## Phase 12 — Docs and runtime-index sync
+
+**Continuous rule:** every phase that changes command semantics updates:
+
+- `CONTEXT.md`
+- `skills/cmo/rules/cli-runtime-index.md`
+- `skills/cmo/rules/publish-index.md` (if publish)
+- `skills/cmo/rules/studio-api-index.md` (if studio)
+- `mktg schema` examples
+- Changelog / release notes bullet
+
+### Acceptance criteria
+
+- [ ] No CONTEXT claim contradicts `mktg schema <cmd> --json`
+- [ ] Dogfood script or CI snapshot: key help strings grep-tested optional
+
+---
+
+## Suggested shipping order (vertical slices)
+
+```text
+P1 lifecycle ─┬─► P3 plan/status
+              └─► P2 --with-context (parallel after event field exists)
+P4 prereqs (parallel with P2)
+P5 publish truth
+P6 route
+P8 studio resolve (anytime)
+P7 UI consolidation (after P8)
+P9 catalogs
+P11 skill contracts
+P10 script exec (last among big bets)
+P12 ongoing
+```
+
+### Milestone bundles (for PRs)
+
+| Milestone | Phases | User-visible win |
+|---|---|---|
+| **M1 — Honest loop** | 1, 3, 12 (partial) | Load ≠ done; plan stops lying |
+| **M2 — Faster activation** | 2, 4 | One-shot context + real prereqs |
+| **M3 — Trustworthy distribute** | 5, 9 | Publish/catalog statuses you can bet on |
+| **M4 — Portable orchestrate** | 6, 7, 8 | Route anywhere; one UI story |
+| **M5 — Execute where scripts exist** | 10, 11 | CLI runs allowlisted engines; contracts enforced |
+
+---
+
+## Testing strategy (per phase)
+
+| Layer | Requirement |
+|---|---|
+| Unit | History event types; prereq matrix; publish status mapping |
+| Integration | Real temp dirs; `run` load/complete; plan fixtures; publish dry-run/confirm |
+| DX axes | Keep 21/21; update tests if envelopes gain fields |
+| Manual dogfood | Repeat offline GTM slice: load → write under `marketing/` → complete → plan → native publish; assert statuses |
+
+---
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Breaking agents that parse `result: "success"` on load | Add `event` field; changelog; keep transitional dual-read in plan for one minor |
+| Context payload blows token budgets | `--budget`, `--fields`, default opt-in for `--with-context` |
+| Over-building script exec into a plugin host | Allowlist + JSON only; no arbitrary shell |
+| Docs drift again | Phase 12 checklist on every PR template checkbox |
+| Scope creep into “CLI writes the blog post” | Reaffirm non-goal; skills remain playbooks |
+
+---
+
+## Explicit non-goals (this plan)
+
+- Vendoring Postiz / scheduling SaaS into the core
+- Replacing `/cmo` skill markdown with a closed proprietary planner
+- Guaranteeing live social posts without BYO credentials
+- Auto-running all 64 skills without an agent
+- Redesigning Studio UI aesthetics (unless blocked by API contract)
+
+---
+
+## Open decisions (resolve before or during the named phase)
+
+| Decision | Options | Needed by |
+|---|---|---|
+| Rename `run` → `load`? | Keep `run` + honest events **(prefer)** vs rename + alias | P1 |
+| `--with-context` default on? | Opt-in → default in next minor | P2 |
+| Dashboard fate | Deprecate launcher / JSON-only / alias to studio | P7 |
+| Catalog stubs | Implement vs un-advertise | P9 |
+| Multi-runner CMO | Defer past P6 | post-M4 |
+
+---
+
+## Resume protocol
+
+1. Read this file’s Phase Status Tracker.
+2. Pick the first `pending` phase in the Suggested shipping order that isn’t blocked.
+3. Open a PR named `feat(cli): <phase title>` against `main`.
+4. Update the tracker row to `in_progress` / `completed` **in the same commit** as the phase work.
+5. Re-dogfood the affected command with `--json` and paste a short evidence blurb in the PR.
+
+---
+
+## Appendix A — Command surface after M4 (sketch)
+
+| Command | Role |
+|---|---|
+| `mktg run` | Load (+ optional context); `--complete` for outcomes |
+| `mktg route` | Portable skill routing |
+| `mktg cmo` | Claude Code orchestrator (optional runner) |
+| `mktg plan` | Outcome-aware queue |
+| `mktg publish` | Distribute with explicit status enum |
+| `mktg studio` | Human UI |
+| `mktg dashboard` | JSON snapshots (no competing product UI) |
+| `mktg catalog` | Honest sync/status |
+| `mktg skill exec` | Allowlisted scripts (M5) |
+
+## Appendix B — Success metrics (qualitative)
+
+- A new agent can complete offline GTM (article → atoms → native queue) without being misled by history.
+- `mktg plan --json` after load-only does **not** recommend publish.
+- `mktg publish --adapter mktg-native --confirm --json` clearly says `queued-local`.
+- `mktg route` works in this cloud VM without `claude`.
+- CONTEXT.md examples match schema on a fresh checkout.

--- a/docs/cli-improvement-plan.md
+++ b/docs/cli-improvement-plan.md
@@ -32,9 +32,9 @@
 | # | Phase | Status | PR/Commit | Notes |
 |---|---|---|---|---|
 | 0 | Plan authored (this doc) | `completed` | — | 2026-07-18 |
-| 1 | Honest skill lifecycle (`loaded` vs `completed`) | `pending` | | Foundation for everything else |
+| 1 | Honest skill lifecycle (`loaded` vs `completed`) | `completed` | cursor/honest-run-lifecycle-ccd8 | 2026-07-27 — `event` field, `--complete/--writes/--result`, dual-read legacy |
 | 2 | One-shot activation (`run --with-context`) | `pending` | | Can ship parallel to P1 after log shape lands |
-| 3 | Outcome-aware `plan` / `status` / dashboard | `pending` | | Depends on P1 |
+| 3 | Outcome-aware `plan` / `status` / dashboard | `completed` | cursor/honest-run-lifecycle-ccd8 | 2026-07-27 — plan reads completed-only; distribute needs artifacts/completed runs; health counts non-template; dashboard readiness completed-only |
 | 4 | Rich prerequisites + `--strict` | `pending` | | |
 | 5 | Publish truth + promote path | `pending` | | |
 | 6 | Portable `mktg route` (+ CMO runner clarity) | `pending` | | |

--- a/docs/cli-improvement-plan.md
+++ b/docs/cli-improvement-plan.md
@@ -33,9 +33,9 @@
 |---|---|---|---|---|
 | 0 | Plan authored (this doc) | `completed` | — | 2026-07-18 |
 | 1 | Honest skill lifecycle (`loaded` vs `completed`) | `completed` | #43 | 2026-07-27 — `event` field, `--complete/--writes/--result`, dual-read legacy |
-| 2 | One-shot activation (`run --with-context`) | `completed` | cursor/run-with-context-ccd8 | 2026-07-27 — shared context-compiler; reads-first selection; templatesSkipped/budgetDropped signals |
+| 2 | One-shot activation (`run --with-context`) | `completed` | #44 | 2026-07-27 — shared context-compiler; reads-first selection; templatesSkipped/budgetDropped signals |
 | 3 | Outcome-aware `plan` / `status` / dashboard | `completed` | #43 | 2026-07-27 — plan reads completed-only; distribute needs artifacts/completed runs; health counts non-template; dashboard readiness completed-only |
-| 4 | Rich prerequisites + `--strict` | `completed` | cursor/run-with-context-ccd8 | 2026-07-27 — envs/tools/catalogs in `missing`; shared tool registry with doctor; strict exits 3 |
+| 4 | Rich prerequisites + `--strict` | `completed` | #44 | 2026-07-27 — envs/tools/catalogs in `missing`; shared tool registry with doctor; strict exits 3 |
 | 5 | Publish truth + promote path | `pending` | | |
 | 6 | Portable `mktg route` (+ CMO runner clarity) | `pending` | | |
 | 7 | Studio vs dashboard consolidation | `pending` | | |

--- a/docs/cli-improvement-plan.md
+++ b/docs/cli-improvement-plan.md
@@ -36,7 +36,7 @@
 | 2 | One-shot activation (`run --with-context`) | `completed` | #44 | 2026-07-27 — shared context-compiler; reads-first selection; templatesSkipped/budgetDropped signals |
 | 3 | Outcome-aware `plan` / `status` / dashboard | `completed` | #43 | 2026-07-27 — plan reads completed-only; distribute needs artifacts/completed runs; health counts non-template; dashboard readiness completed-only |
 | 4 | Rich prerequisites + `--strict` | `completed` | #44 | 2026-07-27 — envs/tools/catalogs in `missing`; shared tool registry with doctor; strict exits 3 |
-| 5 | Publish truth + promote path | `completed` | cursor/publish-truth-enum-ccd8 | 2026-07-27 — per-item status enum across 5 adapters + Studio chip parity; promote path deferred (separate PR) |
+| 5 | Publish truth + promote path | `completed` | #45 | 2026-07-27 — per-item status enum across 5 adapters + Studio chip parity; promote path deferred (separate PR) |
 | 6 | Portable `mktg route` (+ CMO runner clarity) | `pending` | | |
 | 7 | Studio vs dashboard consolidation | `pending` | | |
 | 8 | Studio npm resolve + doctor check | `pending` | | Small; can jump ahead |

--- a/docs/cli-improvement-plan.md
+++ b/docs/cli-improvement-plan.md
@@ -36,7 +36,7 @@
 | 2 | One-shot activation (`run --with-context`) | `completed` | #44 | 2026-07-27 — shared context-compiler; reads-first selection; templatesSkipped/budgetDropped signals |
 | 3 | Outcome-aware `plan` / `status` / dashboard | `completed` | #43 | 2026-07-27 — plan reads completed-only; distribute needs artifacts/completed runs; health counts non-template; dashboard readiness completed-only |
 | 4 | Rich prerequisites + `--strict` | `completed` | #44 | 2026-07-27 — envs/tools/catalogs in `missing`; shared tool registry with doctor; strict exits 3 |
-| 5 | Publish truth + promote path | `pending` | | |
+| 5 | Publish truth + promote path | `completed` | cursor/publish-truth-enum-ccd8 | 2026-07-27 — per-item status enum across 5 adapters + Studio chip parity; promote path deferred (separate PR) |
 | 6 | Portable `mktg route` (+ CMO runner clarity) | `pending` | | |
 | 7 | Studio vs dashboard consolidation | `pending` | | |
 | 8 | Studio npm resolve + doctor check | `pending` | | Small; can jump ahead |

--- a/docs/cli-improvement-plan.md
+++ b/docs/cli-improvement-plan.md
@@ -32,9 +32,9 @@
 | # | Phase | Status | PR/Commit | Notes |
 |---|---|---|---|---|
 | 0 | Plan authored (this doc) | `completed` | — | 2026-07-18 |
-| 1 | Honest skill lifecycle (`loaded` vs `completed`) | `completed` | cursor/honest-run-lifecycle-ccd8 | 2026-07-27 — `event` field, `--complete/--writes/--result`, dual-read legacy |
+| 1 | Honest skill lifecycle (`loaded` vs `completed`) | `completed` | #43 | 2026-07-27 — `event` field, `--complete/--writes/--result`, dual-read legacy |
 | 2 | One-shot activation (`run --with-context`) | `pending` | | Can ship parallel to P1 after log shape lands |
-| 3 | Outcome-aware `plan` / `status` / dashboard | `completed` | cursor/honest-run-lifecycle-ccd8 | 2026-07-27 — plan reads completed-only; distribute needs artifacts/completed runs; health counts non-template; dashboard readiness completed-only |
+| 3 | Outcome-aware `plan` / `status` / dashboard | `completed` | #43 | 2026-07-27 — plan reads completed-only; distribute needs artifacts/completed runs; health counts non-template; dashboard readiness completed-only |
 | 4 | Rich prerequisites + `--strict` | `pending` | | |
 | 5 | Publish truth + promote path | `pending` | | |
 | 6 | Portable `mktg route` (+ CMO runner clarity) | `pending` | | |

--- a/docs/cli-improvement-plan.md
+++ b/docs/cli-improvement-plan.md
@@ -33,9 +33,9 @@
 |---|---|---|---|---|
 | 0 | Plan authored (this doc) | `completed` | — | 2026-07-18 |
 | 1 | Honest skill lifecycle (`loaded` vs `completed`) | `completed` | #43 | 2026-07-27 — `event` field, `--complete/--writes/--result`, dual-read legacy |
-| 2 | One-shot activation (`run --with-context`) | `pending` | | Can ship parallel to P1 after log shape lands |
+| 2 | One-shot activation (`run --with-context`) | `completed` | cursor/run-with-context-ccd8 | 2026-07-27 — shared context-compiler; reads-first selection; templatesSkipped/budgetDropped signals |
 | 3 | Outcome-aware `plan` / `status` / dashboard | `completed` | #43 | 2026-07-27 — plan reads completed-only; distribute needs artifacts/completed runs; health counts non-template; dashboard readiness completed-only |
-| 4 | Rich prerequisites + `--strict` | `pending` | | |
+| 4 | Rich prerequisites + `--strict` | `completed` | cursor/run-with-context-ccd8 | 2026-07-27 — envs/tools/catalogs in `missing`; shared tool registry with doctor; strict exits 3 |
 | 5 | Publish truth + promote path | `pending` | | |
 | 6 | Portable `mktg route` (+ CMO runner clarity) | `pending` | | |
 | 7 | Studio vs dashboard consolidation | `pending` | | |

--- a/docs/openseo-integration-plan.md
+++ b/docs/openseo-integration-plan.md
@@ -1,0 +1,544 @@
+# OpenSEO → marketing-cli Integration Plan
+
+> Ultimate goal: make [every-app/open-seo](https://github.com/every-app/open-seo) the **first-class SEO data + workflow plane** inside `mktg`, while keeping mktg’s playbook/orchestration model (`/cmo`, brand memory, progressive enhancement).
+>
+> **This document is plan-only.** No implementation in this PR.
+> Status: `pending` (plan authored 2026-07-20). Resume by taking the next `pending` phase.
+
+## Reference data (don’t modify without explicit instruction)
+
+| Field | Value |
+|---|---|
+| Upstream | https://github.com/every-app/open-seo |
+| Upstream product | OpenSEO — open-source Semrush/Ahrefs alternative |
+| Upstream license | **MIT** (compatible with mktg MIT; no AGPL firewall required) |
+| Hosted product | https://openseo.so · MCP `https://app.openseo.so/mcp` |
+| Data vendor | DataForSEO (BYO when self-hosting; hosted meters differently) |
+| Upstream skills | `.agents/skills/{seo-project-setup,seo-coach,keyword-research,keyword-clustering,competitive-landscape,competitor-analysis,link-prospecting}` (+ internal maintainer skills — **do not steal**) |
+| mktg SEO today | Playbook skills: `keyword-research`, `seo-content`, `seo-audit`, `ai-seo`, `off-page-seo`, `seo-machine`, `competitor-alternatives` + agent `mktg-seo-analyst` |
+| Closest mktg patterns | **postiz catalog** (remote service), **Exa skill pack** (MCP + HTTP), **firecrawl** (CLI chain), **studio** (bundled UI — last resort) |
+| Non-goal | Vendoring OpenSEO’s Cloudflare/Vite/Workers monolith into the `marketing-cli` npm tarball |
+
+---
+
+## Why this belongs in mktg
+
+| Layer | Today (mktg) | Gap OpenSEO fills |
+|---|---|---|
+| Playbooks | Strong: CMO Path A/B, seo-machine sprint, content/alternatives | Still methodology-first |
+| Live SEO metrics | Weak: Exa/Firecrawl SERP scrape, no KD/volume/backlinks/rank tracking | DataForSEO-backed KD, volume, SERP, ranked keywords, backlinks, rank tracker, GSC |
+| Agent interface | Skills dump markdown; research via Exa MCP | First-class MCP tool surface designed for agents |
+| Human UI | Studio (marketing ops), not SEO suite | Focused SEO UI (hosted or Docker self-host) |
+
+**North star architecture**
+
+```text
+                 /cmo  (orchestration — unchanged principle)
+                      │
+        ┌─────────────┼─────────────┐
+        ▼             ▼             ▼
+   Playbook skills   Brand memory   Distribution
+   (seo-content,     brand/         publish / native
+    seo-machine,…)   keyword-plan
+        │                  ▲
+        │   writes plans   │
+        ▼                  │
+ ┌─────────────────────────┴──────────┐
+ │  OpenSEO data plane (first-class)  │
+ │  MCP tools + optional hosted/UI    │
+ │  catalog: openseo                  │
+ └────────────────────────────────────┘
+              │
+              ▼
+         DataForSEO / GSC
+```
+
+Playbooks stay in mktg. **Metrics, SERP truth, rank tracking, backlinks, GSC** come from OpenSEO when configured. Exa/Firecrawl remain progressive-enhancement fallbacks (L0 / no OpenSEO).
+
+---
+
+## Critical constraints
+
+1. **Name collisions** — OpenSEO ships skills named `keyword-research`, overlapping mktg’s `keyword-research`. Never install upstream names as-is into `skills-manifest.json`. Namespace as `openseo-*` **or** absorb workflows into existing skills with an OpenSEO backend section.
+2. **Two planes** — OpenSEO app ≠ mktg CLI. Do not merge repos. Integrate via catalog + MCP + adapted skills + doctor.
+3. **Auth models differ** — Hosted MCP uses OAuth login flow; self-host uses `DATAFORSEO_API_KEY` (+ local_noauth Docker). mktg must document both; agents prefer non-interactive creds where possible.
+4. **Cost surface** — Every OpenSEO call can spend DataForSEO credit. Skills must keep dry-run / confirm discipline for expensive bulk calls and `save_keywords`.
+5. **State directories** — mktg uses `.seo/` + `docs/seo-machine.md` + `brand/keyword-plan.md`. OpenSEO has its own projects/saved keywords. Plan for **sync contracts**, not competing OSes.
+6. **Catalog schema today** — `CatalogCapabilities` only knows publish/scheduling/email. First-class SEO needs a new capability family (see Phase 1).
+7. **Agent DX 21/21** — any new commands keep JSON, `--dry-run`, `--fields`, validators, schema entries.
+
+---
+
+## Decision record (resolve before coding the named phase)
+
+| ID | Decision | Options | Recommendation |
+|---|---|---|---|
+| D1 | Integration shape | (A) Catalog+MCP (B) Workspace-vendored app (C) Skills-only steal | **A** — catalog + MCP + adapted skills. B only if Studio later embeds an iframe/link, not a code merge. |
+| D2 | Skill identity | (A) New `openseo-*` skills (B) Teach existing SEO skills to call OpenSEO (C) Both | **C** — thin `openseo` catalog skill + upgrade Path A/B skills to prefer OpenSEO tools when catalog configured. |
+| D3 | Default research backend when OpenSEO configured | OpenSEO always / prompt / Exa still default | **OpenSEO for metrics-heavy SEO**; Exa for open-web discovery & content mining; Firecrawl for known-URL fetch. Document matrix in CMO ecosystem. |
+| D4 | Hosted vs self-host default | Hosted MCP first / Docker first | **Hosted MCP first** (matches postiz “hosted default”); Docker documented as advanced BYO DataForSEO. |
+| D5 | Ultimate “fully combine” meaning | Bundle UI in tarball / deep product coupling without vendoring | **Deep coupling without vendoring**: `mktg doctor`/`catalog`/`seo`/`studio` treat OpenSEO as the SEO system of record; optional `mktg openseo` launcher for Docker/hosted deep links. |
+
+---
+
+## Phase Status Tracker
+
+| # | Phase | Status | PR | Notes |
+|---|---|---|---|---|
+| 0 | Plan authored (this doc) | `completed` | — | 2026-07-20 |
+| 1 | Catalog model: `openseo` + SEO/MCP capabilities | `pending` | | Schema/types foundation |
+| 2 | Doctor + env/MCP readiness | `pending` | | |
+| 3 | Root MCP wiring + agent install docs | `pending` | | `.mcp.json` / CONTEXT |
+| 4 | First-class `openseo` skill (adapter / coach) | `pending` | | Namespace-safe |
+| 5 | Steal & adapt OpenSEO workflow skills (`openseo-*`) | `pending` | | Upstream provenance |
+| 6 | Rewire existing SEO skills + `/cmo` Path A/B | `pending` | | Prefer OpenSEO when configured |
+| 7 | Brand / `.seo` / OpenSEO project sync contract | `pending` | | |
+| 8 | CLI surface: `mktg catalog` / optional `mktg seo` | `pending` | | |
+| 9 | Studio: SEO panel / deep links / status | `pending` | | |
+| 10 | Self-host launcher + compose helper | `pending` | | Advanced path |
+| 11 | Tests, counts, release packaging | `pending` | | |
+| 12 | Ultimate hardening: single SEO OS UX | `pending` | | End-state polish |
+
+---
+
+## Target end state (“fully combined”)
+
+When this plan is done, a user/agent should experience:
+
+1. `mktg init` / `mktg update` installs OpenSEO-aware skills.
+2. `mktg doctor --json` reports OpenSEO catalog readiness (hosted token/MCP **or** self-host base + DataForSEO).
+3. `mktg catalog info openseo --json` shows configured/missing, transport, docs, pinned version.
+4. `/cmo` “do SEO” routes through OpenSEO-backed workflows when ready; otherwise falls back to Exa/Firecrawl playbooks with an explicit gap note.
+5. `keyword-research` / `seo-audit` / `off-page-seo` / `ai-seo` / `seo-machine` **read live OpenSEO MCP data** into `brand/keyword-plan.md` and `.seo/*` without inventing metrics.
+6. OpenSEO-native workflows available as `openseo-keyword-clustering`, `openseo-competitive-landscape`, etc., orchestrated by `/cmo` or `mktg route`.
+7. Studio shows SEO readiness + deep link to OpenSEO project (hosted URL or local Docker).
+8. Expensive mutations (`save_keywords`, bulk research) respect `--dry-run` / confirm norms.
+9. No second conflicting “SEO machine” — one resume protocol, OpenSEO as measurement backend.
+
+---
+
+## Phase 1 — Catalog model extension
+
+**Problem:** Catalogs only express publish/email/scheduling. OpenSEO is a research/MCP service.
+
+### Scope
+
+- Add capability family, e.g. `research_adapters: ["openseo"]` and/or `mcp: { url_env, default_url }`.
+- Extend `CatalogEntry` / loader / collision rules / allowlist (MIT + `transport: "http"` or new `transport: "mcp"`).
+- Add `catalogs-manifest.json` entry:
+
+```json
+"openseo": {
+  "name": "openseo",
+  "repo_url": "https://github.com/every-app/open-seo",
+  "docs_url": "https://openseo.so/docs/mcp",
+  "license": "MIT",
+  "version_pinned": "<tag or commit>",
+  "capabilities": {
+    "research_adapters": ["openseo"]
+  },
+  "transport": "http",
+  "sdk_reference": null,
+  "auth": {
+    "style": "bearer",
+    "base_env": "OPENSEO_API_BASE",
+    "credential_envs": ["OPENSEO_API_KEY"],
+    "header_format": "bearer"
+  },
+  "skills": ["openseo"]
+}
+```
+
+**Auth note:** Hosted MCP today is OAuth-in-client. Phase 1 should define the **agent-stable** env contract even if first slice only documents MCP URL + “connected in client”:
+
+| Env | Purpose |
+|---|---|
+| `OPENSEO_MCP_URL` | Default `https://app.openseo.so/mcp`; self-host override |
+| `OPENSEO_API_BASE` | REST/base if/when used beyond MCP |
+| `OPENSEO_API_KEY` / project token | Non-interactive automation (may require upstream support — track as dependency) |
+| `DATAFORSEO_API_KEY` | Self-host path only (document; usually set in OpenSEO’s env, not mktg’s) |
+
+If upstream lacks a non-interactive API key for MCP, Phase 1 documents **MCP-connected** as the readiness signal (doctor checks config file / explicit `OPENSEO_MCP_CONFIGURED=1` / catalog status probe) and files an upstream ask for token auth.
+
+### Acceptance
+
+- [ ] `mktg catalog list --json` includes `openseo`
+- [ ] License/transport validation green (MIT)
+- [ ] Schema + AGENTS Drop-in Catalog Contract updated for research/MCP capabilities
+- [ ] No publish-adapter collision with postiz
+
+### Invasiveness
+
+**M** — types, catalogs loader, tests, manifest, docs.
+
+---
+
+## Phase 2 — Doctor + readiness
+
+### Scope
+
+- Doctor checks: catalog configured, MCP URL present, optional probe.
+- Remediation strings: hosted signup + MCP add commands (Cursor/Claude/Codex), Docker self-host link, DataForSEO docs.
+- Distinguish: `not_configured` | `mcp_client_only` | `api_ready` | `selfhost_ready`.
+
+### Acceptance
+
+- [ ] `mktg doctor --json` surfaces OpenSEO in integrations/catalogs
+- [ ] Missing OpenSEO does **not** fail core doctor (optional, like Typefully)
+- [ ] `--strict` SEO flows (later) can require it
+
+### Invasiveness
+
+**S–M**
+
+---
+
+## Phase 3 — MCP wiring in mktg agent surface
+
+### Scope
+
+- Document OpenSEO MCP in root `.mcp.json` (commented or optional block — don’t break machines without auth).
+- CONTEXT.md + `/cmo` `ecosystem.md` + `cli-runtime-index.md`: when to use OpenSEO vs Exa vs Firecrawl.
+- Matrix:
+
+| Job | Preferred | Fallback |
+|---|---|---|
+| KD / volume / CPC / intent | OpenSEO MCP | none (mark `unknown`) |
+| Live SERP for a keyword | OpenSEO MCP | Firecrawl/Exa scrape (weaker) |
+| Domain ranked keywords / backlinks | OpenSEO MCP | competitive-intel qualitative |
+| Open web discovery / Reddit / GitHub | Exa | — |
+| Fetch known URL content | Firecrawl | — |
+| GSC performance | OpenSEO (connected) | manual export |
+
+### Acceptance
+
+- [ ] Agent reading CONTEXT knows setup order: OpenSEO MCP → skills → `/cmo` SEO
+- [ ] No instruction to invent KD/volume
+
+### Invasiveness
+
+**S**
+
+---
+
+## Phase 4 — First-class `openseo` skill
+
+### Scope
+
+Add `skills/openseo/SKILL.md` (catalog companion, like `postiz`):
+
+- On Activation: check catalog readiness; explain hosted vs self-host; never call DataForSEO directly from mktg.
+- Routes to workflow skills / existing SEO skills.
+- Anti-patterns: inventing metrics; saving keywords without confirm; treating OpenSEO UI as optional if agent has MCP.
+- Progressive enhancement: without OpenSEO, point to Exa-backed `keyword-research` and state the gap.
+
+### Acceptance
+
+- [ ] Manifest entry + `mktg list` shows `openseo`
+- [ ] `mktg run openseo --json` loads; prereqs mention env/MCP
+- [ ] Counts/derive-counts updated
+
+### Invasiveness
+
+**S**
+
+---
+
+## Phase 5 — Adapt OpenSEO workflow skills (`openseo-*`)
+
+Steal **product** skills only (not `papercuts`, `merge-ready`, `webapp-testing`, release-notes):
+
+| Upstream | mktg name | Writes into |
+|---|---|---|
+| `seo-project-setup` | `openseo-project-setup` | `.seo/openseo-project.md` + links `brand/` |
+| `seo-coach` | `openseo-coach` | none (coach) |
+| `keyword-research` | `openseo-keyword-research` | feeds `brand/keyword-plan.md` |
+| `keyword-clustering` | `openseo-keyword-clustering` | `marketing/seo/clusters/*.md` |
+| `competitive-landscape` | `openseo-competitive-landscape` | `brand/landscape.md` / competitors section |
+| `competitor-analysis` | `openseo-competitor-analysis` | `brand/competitors.md` |
+| `link-prospecting` | `openseo-link-prospecting` | `.seo/backlink-targets.json` (align with off-page-seo) |
+
+### Adaptation requirements (mktg drop-in contract)
+
+- Frontmatter: `name`, pushy `description`, `reads`/`writes` with `brand/` prefix, On Activation, Anti-Patterns with WHY.
+- Prefer OpenSEO MCP tool names from upstream; add mktg output paths.
+- Provenance: light Exa-style `upstream` in manifest **or** full `upstream.json` + `check-upstream.sh` if we vendor substantial text.
+- **Do not** register upstream names that collide with existing skills.
+
+### Acceptance
+
+- [ ] All seven adapted skills install via `mktg update`
+- [ ] `/cmo` can route “cluster these keywords” → `openseo-keyword-clustering`
+- [ ] Drift strategy documented (manual sync cadence or check-upstream)
+
+### Invasiveness
+
+**M**
+
+---
+
+## Phase 6 — Rewire existing SEO skills + CMO playbooks
+
+**Problem:** Leaving two parallel SEO stacks (`keyword-research` vs `openseo-keyword-research`) confuses agents.
+
+### Scope
+
+For each existing skill, add **Backend selection** section:
+
+1. If OpenSEO catalog ready → call OpenSEO MCP tools; write mktg artifacts.
+2. Else → existing Exa/Firecrawl/L0 path; note metrics may be `unknown`.
+
+Update:
+
+- `skills/cmo/rules/playbooks.md` SEO Authority Build (Path A/B)
+- `skills/cmo/rules/ecosystem.md`
+- `keyword-research`, `seo-audit`, `off-page-seo`, `ai-seo`, `seo-machine`, `competitor-alternatives`
+- Disambiguation: “SEO” → check OpenSEO readiness → coach or project-setup if new
+
+### Acceptance
+
+- [ ] Single `/cmo` SEO path; OpenSEO is default data plane when configured
+- [ ] Offline/no-key path still works (progressive enhancement)
+- [ ] No skill calls another skill; `/cmo` orchestrates
+
+### Invasiveness
+
+**M–L** (playbook edits + tests for routing copy)
+
+---
+
+## Phase 7 — State sync contract
+
+### Scope
+
+Define canonical mapping:
+
+| OpenSEO concept | mktg home |
+|---|---|
+| Project id / domain | `.seo/openseo.json` `{ projectId, domain, mcpUrl, updatedAt }` |
+| Saved keywords | → merge into `brand/keyword-plan.md` (+ optional `.seo/keywords-sync.json`) |
+| Rank tracker snapshot | `.seo/rank-snapshots/{date}.json` + summary md |
+| Backlink overview | `.seo/backlink-overview.json` for off-page-seo |
+| GSC striking distance | input to keyword-research / seo-machine phases |
+
+Commands (sketch):
+
+```bash
+mktg seo status --json
+mktg seo sync-keywords --dry-run|--confirm --json
+mktg seo link-project --input '{"projectId":"..."}' --json
+```
+
+(Exact command home: `mktg seo …` vs `mktg catalog …` — prefer `mktg seo` as user-facing SEO namespace once catalog exists.)
+
+### Acceptance
+
+- [ ] Agent can bind a repo to an OpenSEO project idempotently
+- [ ] Sync never overwrites brand files without `--confirm`
+- [ ] seo-machine resume protocol remains single tracker (`docs/seo-machine.md`)
+
+### Invasiveness
+
+**M**
+
+---
+
+## Phase 8 — CLI surface polish
+
+### Scope
+
+- `mktg catalog info openseo` rich fields: mcp url, auth mode, skills, cost warnings.
+- Optional `mktg seo` command group: `status`, `doctor`, `open` (print hosted/self-host URL), `sync-*`.
+- Align with CLI improvement plan: `run --with-context`, honest prereqs including OpenSEO envs.
+
+### Acceptance
+
+- [ ] Schema complete; exit codes correct
+- [ ] Dry-run on all mutating seo sync commands
+
+### Invasiveness
+
+**M**
+
+---
+
+## Phase 9 — Studio integration
+
+### Scope
+
+- Studio API: SEO readiness card (catalog + last sync).
+- Deep link button: hosted project URL or `http://localhost:3001` self-host.
+- Do **not** embed OpenSEO’s React app inside Studio in v1.
+- Optional later: iframe only if CSP/auth allow (explicit follow-up).
+
+### Acceptance
+
+- [ ] `mktg studio` shows OpenSEO configured/missing with remediation
+- [ ] studio-api-index.md updated
+
+### Invasiveness
+
+**M**
+
+---
+
+## Phase 10 — Self-host launcher (advanced)
+
+### Scope
+
+- Document Docker compose path (`ghcr.io/every-app/open-seo`).
+- Optional helper: `mktg openseo up --dry-run|--confirm` wrapping compose in project or XDG data dir — **only if** we accept Docker-in-doctor complexity.
+- Telemetry: pass through `OPENSEO_TELEMETRY_DISABLED` guidance.
+- Auth warning: Docker `local_noauth` must not be exposed publicly.
+
+### Acceptance
+
+- [ ] Advanced docs path works without helper; helper is optional sugar
+- [ ] Doctor distinguishes hosted vs self-host readiness
+
+### Invasiveness
+
+**M** (docs-only **S** if no launcher)
+
+---
+
+## Phase 11 — Tests, counts, packaging
+
+### Scope
+
+- Manifest counts / derive-counts / CMO indexes
+- Integration: catalog load, doctor optional check, skill frontmatter↔catalog env drift test (like postiz)
+- Package.json banned-deps unchanged (still don’t install AGPL SDKs; OpenSEO MIT doesn’t force SDK)
+- No bundling of OpenSEO app into npm `files` array
+- E2E dogfood script: with mocked MCP or skip-without-creds pattern (like Exa live tests)
+
+### Acceptance
+
+- [ ] `bun test` green; skill counts consistent
+- [ ] CI skips live OpenSEO without secrets
+
+### Invasiveness
+
+**S–M**
+
+---
+
+## Phase 12 — Ultimate hardening (“feels native”)
+
+### Scope
+
+- `mktg plan` SEO tasks aware of OpenSEO readiness + artifact sync state.
+- `mktg route "keyword research"` → OpenSEO-backed skill when configured.
+- Single onboarding: `mktg-setup` / `openseo-project-setup` handoff.
+- Cost guardrails: default result limits; confirm on save; learnings log for spend surprises.
+- Positioning: mktg = agent marketing OS; OpenSEO = SEO system of record inside that OS.
+- Consider upstream collaboration: token auth for agents, stable MCP tool schema versioning, “mktg brand export” partnership — track as external deps, not blockers for Phases 1–6.
+
+### Acceptance
+
+- [ ] Dogfood: new project → doctor → MCP → keyword research → keyword-plan.md → seo-content → seo-machine phase, all without inventing metrics
+- [ ] CONTEXT one-pager “SEO with mktg” matches reality
+
+### Invasiveness
+
+**M** (product polish across surfaces)
+
+---
+
+## Suggested shipping milestones
+
+| Milestone | Phases | User-visible win |
+|---|---|---|
+| **S1 — Catalog foothold** | 1–4 | `openseo` in catalog/doctor/skills; docs for MCP |
+| **S2 — Workflow parity** | 5–6 | OpenSEO workflows + CMO prefers OpenSEO data |
+| **S3 — System of record** | 7–8 | Project link + keyword sync CLI |
+| **S4 — Productized** | 9–11 | Studio card, tests, optional self-host sugar |
+| **S5 — Native feel** | 12 | Plan/route/onboarding treat OpenSEO as default SEO backend |
+
+---
+
+## Mapping: OpenSEO workflows ↔ mktg skills (end state)
+
+| OpenSEO workflow | Primary mktg entry | Data backend |
+|---|---|---|
+| Project setup | `openseo-project-setup` → brand foundation | OpenSEO projects + GSC |
+| Coach | `openseo-coach` / `/cmo` | — |
+| Keyword research | `keyword-research` (OpenSEO path) + `openseo-keyword-research` | MCP `research_keywords`, metrics, GSC |
+| Clustering | `openseo-keyword-clustering` → seo-content / seo-machine | MCP + brand plan |
+| Competitive landscape | `landscape-scan` / `openseo-competitive-landscape` | MCP domain/SERP tools; Exa for narrative |
+| Competitor analysis | `competitive-intel` + `openseo-competitor-analysis` | MCP ranked keywords/backlinks |
+| Link prospecting | `off-page-seo` + `openseo-link-prospecting` | MCP backlinks + Exa outreach research |
+| Site audits | `seo-audit` / seo-machine scripts | OpenSEO where APIs exist; local crawl remains |
+| AI visibility | `ai-seo` | OpenSEO AI search features when exposed via MCP |
+| Rank tracking | new `.seo/rank-*` via sync | OpenSEO rank tracker |
+| Content production | `seo-content`, `competitor-alternatives` | unchanged playbooks, better inputs |
+| Programmatic SEO | `seo-machine` | OpenSEO validates KD/DR-style inputs before page gen |
+
+---
+
+## Explicit non-goals
+
+- Merging OpenSEO’s Cloudflare Workers app into `studio/` or the npm tarball
+- Replacing `/cmo` with OpenSEO’s seo-coach
+- Calling DataForSEO **directly** from mktg (always via OpenSEO)
+- Dropping Exa/Firecrawl (they cover non-SEO and fallback paths)
+- Auto-spending DataForSEO budget without confirms on saves/bulk
+- Stealing OpenSEO maintainer-only skills (`papercuts`, greptile, release-notes)
+
+---
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Skill name collision confuses agents | Namespace `openseo-*`; rewrite CMO routes carefully |
+| OAuth MCP hard for headless cloud agents | Document client login; pursue API token with upstream; skip-live tests |
+| Dual SEO state drift | Phase 7 sync contract; single resume doc for seo-machine |
+| Cost blowups | Confirm on save; limit defaults; doctor cost warning |
+| Upstream MCP tool rename | Pin version; optional check-upstream on adapted skills |
+| Scope creep to “rebuild Semrush in Studio” | Deep link + status only until S5 |
+
+---
+
+## Upstream dependencies / asks (external)
+
+Track separately; do not block S1:
+
+1. Stable non-interactive auth for MCP/API (agent automation).
+2. Documented MCP tool schema version / changelog.
+3. Clear self-host MCP URL pattern parity with hosted.
+4. Optional: webhook or export API for saved keywords ↔ `brand/keyword-plan.md`.
+
+---
+
+## Resume protocol
+
+1. Read Phase Status Tracker.
+2. Implement next `pending` phase as its own PR (`feat(openseo): …`).
+3. Update tracker row in the **same commit**.
+4. Dogfood with `--json`; if no OpenSEO creds, prove skip/remediation paths.
+5. Keep this plan’s north-star diagram accurate — if architecture changes, edit Reference/Decision sections deliberately.
+
+---
+
+## Appendix A — Upstream skill inventory (product)
+
+| Skill | Role |
+|---|---|
+| `seo-project-setup` | Workspace + MCP verify + GSC |
+| `seo-coach` | Beginner routing / coaching |
+| `keyword-research` | Opportunity discovery via MCP |
+| `keyword-clustering` | Intent clusters → pages |
+| `competitive-landscape` | Market map |
+| `competitor-analysis` | Single competitor teardown |
+| `link-prospecting` | Outreach prospects |
+
+## Appendix B — Why not workspace-vendoring
+
+OpenSEO is a pnpm + Vite + Cloudflare Workers + Drizzle (D1/Postgres) product with its own auth, billing metering, and UI. mktg is a Bun CLI + optional Studio. Vendoring would:
+
+- Explode package size and security surface
+- Fork divergence from a fast-moving upstream (5k+ stars)
+- Fight Studio’s port/auth model
+
+**First-class** means productized integration, not a git submodule of their monolith.

--- a/docs/openseo-integration-plan.md
+++ b/docs/openseo-integration-plan.md
@@ -86,10 +86,10 @@ Playbooks stay in mktg. **Metrics, SERP truth, rank tracking, backlinks, GSC** c
 | # | Phase | Status | PR | Notes |
 |---|---|---|---|---|
 | 0 | Plan authored (this doc) | `completed` | — | 2026-07-20 |
-| 1 | Catalog model: `openseo` + SEO/MCP capabilities | `pending` | | Schema/types foundation |
-| 2 | Doctor + env/MCP readiness | `pending` | | |
-| 3 | Root MCP wiring + agent install docs | `pending` | | `.mcp.json` / CONTEXT |
-| 4 | First-class `openseo` skill (adapter / coach) | `pending` | | Namespace-safe |
+| 1 | Catalog model: `openseo` + SEO/MCP capabilities | `completed` | cursor/catalog-research-capability-ccd8 | 2026-07-27 — `research_adapters` + `mcp` block; openseo pinned v0.1.2 |
+| 2 | Doctor + env/MCP readiness | `in_progress` | cursor/catalog-research-capability-ccd8 | envs surface via doctor catalog checks + prereqs; named readiness states (mcp_client_only etc.) deferred |
+| 3 | Root MCP wiring + agent install docs | `completed` | cursor/catalog-research-capability-ccd8 | 2026-07-27 — `.mcp.json` openseo server + CONTEXT backend matrix |
+| 4 | First-class `openseo` skill (adapter / coach) | `completed` | cursor/catalog-research-capability-ccd8 | 2026-07-27 — `skills/openseo/SKILL.md` (65 skills); drift-locked envs |
 | 5 | Steal & adapt OpenSEO workflow skills (`openseo-*`) | `pending` | | Upstream provenance |
 | 6 | Rewire existing SEO skills + `/cmo` Path A/B | `pending` | | Prefer OpenSEO when configured |
 | 7 | Brand / `.seo` / OpenSEO project sync contract | `pending` | | |

--- a/docs/openseo-integration-plan.md
+++ b/docs/openseo-integration-plan.md
@@ -86,10 +86,10 @@ Playbooks stay in mktg. **Metrics, SERP truth, rank tracking, backlinks, GSC** c
 | # | Phase | Status | PR | Notes |
 |---|---|---|---|---|
 | 0 | Plan authored (this doc) | `completed` | — | 2026-07-20 |
-| 1 | Catalog model: `openseo` + SEO/MCP capabilities | `completed` | cursor/catalog-research-capability-ccd8 | 2026-07-27 — `research_adapters` + `mcp` block; openseo pinned v0.1.2 |
-| 2 | Doctor + env/MCP readiness | `in_progress` | cursor/catalog-research-capability-ccd8 | envs surface via doctor catalog checks + prereqs; named readiness states (mcp_client_only etc.) deferred |
-| 3 | Root MCP wiring + agent install docs | `completed` | cursor/catalog-research-capability-ccd8 | 2026-07-27 — `.mcp.json` openseo server + CONTEXT backend matrix |
-| 4 | First-class `openseo` skill (adapter / coach) | `completed` | cursor/catalog-research-capability-ccd8 | 2026-07-27 — `skills/openseo/SKILL.md` (65 skills); drift-locked envs |
+| 1 | Catalog model: `openseo` + SEO/MCP capabilities | `completed` | #46 | 2026-07-27 — `research_adapters` + `mcp` block; openseo pinned v0.1.2 |
+| 2 | Doctor + env/MCP readiness | `in_progress` | #46 | envs surface via doctor catalog checks + prereqs; named readiness states (mcp_client_only etc.) deferred |
+| 3 | Root MCP wiring + agent install docs | `completed` | #46 | 2026-07-27 — `.mcp.json` openseo server + CONTEXT backend matrix |
+| 4 | First-class `openseo` skill (adapter / coach) | `completed` | #46 | 2026-07-27 — `skills/openseo/SKILL.md` (65 skills); drift-locked envs |
 | 5 | Steal & adapt OpenSEO workflow skills (`openseo-*`) | `pending` | | Upstream provenance |
 | 6 | Rewire existing SEO skills + `/cmo` Path A/B | `pending` | | Prefer OpenSEO when configured |
 | 7 | Brand / `.seo` / OpenSEO project sync contract | `pending` | | |

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "marketing-cli",
   "version": "0.6.0",
-  "description": "Agent-native marketing playbook CLI: 64 skills, 5 research/review agents, brand memory, and /cmo orchestration."
+  "description": "Agent-native marketing playbook CLI: 65 skills, 5 research/review agents, brand memory, and /cmo orchestration."
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "marketing-cli",
   "version": "0.6.0",
-  "description": "Agent-native marketing playbook: 64 skills, 5 research agents, brand memory that compounds, plus a local Studio dashboard (beta). One install, then /cmo in Claude Code walks you through a 4-question setup wizard. CLI for the agent, Studio for the human.",
+  "description": "Agent-native marketing playbook: 65 skills, 5 research agents, brand memory that compounds, plus a local Studio dashboard (beta). One install, then /cmo in Claude Code walks you through a 4-question setup wizard. CLI for the agent, Studio for the human.",
   "type": "module",
   "workspaces": [
     "studio"

--- a/skills-manifest.json
+++ b/skills-manifest.json
@@ -2095,6 +2095,34 @@
       "env_vars": [
         "EXA_API_KEY"
       ]
+    },
+    "openseo": {
+      "source": "new",
+      "category": "seo",
+      "layer": "strategy",
+      "tier": "nice-to-have",
+      "reads": [
+        "keyword-plan.md"
+      ],
+      "writes": [
+        "keyword-plan.md"
+      ],
+      "depends_on": [],
+      "triggers": [
+        "keyword difficulty",
+        "search volume",
+        "serp results",
+        "ranked keywords",
+        "backlinks",
+        "rank tracker",
+        "gsc performance"
+      ],
+      "review_interval_days": 60,
+      "version": "1.0.0",
+      "env_vars": [
+        "OPENSEO_API_KEY",
+        "OPENSEO_API_BASE"
+      ]
     }
   },
   "redirects": {

--- a/skills-manifest.json
+++ b/skills-manifest.json
@@ -1128,7 +1128,10 @@
         "product tour"
       ],
       "review_interval_days": 90,
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "tools": [
+        "ffmpeg"
+      ]
     },
     "paper-marketing": {
       "source": "new",
@@ -1215,7 +1218,10 @@
         "remotion render"
       ],
       "review_interval_days": 60,
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "tools": [
+        "ffmpeg"
+      ]
     },
     "social-campaign": {
       "source": "new",
@@ -1279,7 +1285,10 @@
         "end-to-end video"
       ],
       "review_interval_days": 60,
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "tools": [
+        "ffmpeg"
+      ]
     },
     "frontend-slides": {
       "source": "new",
@@ -1638,6 +1647,9 @@
       "version": "1.0.0",
       "env_vars": [
         "FIRECRAWL_API_KEY"
+      ],
+      "tools": [
+        "firecrawl"
       ]
     },
     "mktg-x": {
@@ -1700,7 +1712,10 @@
         "shorten this"
       ],
       "review_interval_days": 180,
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "tools": [
+        "summarize"
+      ]
     },
     "remotion-best-practices": {
       "source": "new",
@@ -1744,7 +1759,11 @@
           "repo": "remotion-dev/remotion",
           "path": ".claude"
         }
-      }
+      },
+      "tools": [
+        "remotion",
+        "ffmpeg"
+      ]
     },
     "cmo-remotion": {
       "source": "new",
@@ -1774,7 +1793,11 @@
         "video shader pipeline"
       ],
       "review_interval_days": 30,
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "tools": [
+        "remotion",
+        "ffmpeg"
+      ]
     },
     "higgsfield-generate": {
       "source": "new",
@@ -1814,7 +1837,10 @@
         "Marketing Studio"
       ],
       "review_interval_days": 30,
-      "version": "0.3.0"
+      "version": "0.3.0",
+      "tools": [
+        "higgsfield"
+      ]
     },
     "higgsfield-soul-id": {
       "source": "new",
@@ -1849,7 +1875,10 @@
         "soul-id create"
       ],
       "review_interval_days": 30,
-      "version": "0.3.0"
+      "version": "0.3.0",
+      "tools": [
+        "higgsfield"
+      ]
     },
     "higgsfield-product-photoshoot": {
       "source": "new",
@@ -1885,7 +1914,10 @@
         "brand campaign visual"
       ],
       "review_interval_days": 30,
-      "version": "0.3.0"
+      "version": "0.3.0",
+      "tools": [
+        "higgsfield"
+      ]
     },
     "exa-search": {
       "source": "new",

--- a/skills/cmo/SKILL.md
+++ b/skills/cmo/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cmo
 description: |
-  A senior marketing operator for any project. Orchestrates 64 marketing skills to build brands, generate content, and distribute across channels. Use this skill whenever the user wants to do marketing  -  brand voice, copy, SEO, email, social, launches, or anything marketing-related. Also triggers on 'help me market', 'write copy', 'launch strategy', 'brand voice', 'SEO', 'content', 'email sequence', 'social posts', 'landing page', 'grow', 'audience', 'competitors', 'what should I do next for marketing', 'I need more users', 'how do I get people to care', or any marketing request. When in doubt about which marketing skill to use, start here  -  even if the user's request is vague or doesn't explicitly mention marketing.
+  A senior marketing operator for any project. Orchestrates 65 marketing skills to build brands, generate content, and distribute across channels. Use this skill whenever the user wants to do marketing  -  brand voice, copy, SEO, email, social, launches, or anything marketing-related. Also triggers on 'help me market', 'write copy', 'launch strategy', 'brand voice', 'SEO', 'content', 'email sequence', 'social posts', 'landing page', 'grow', 'audience', 'competitors', 'what should I do next for marketing', 'I need more users', 'how do I get people to care', or any marketing request. When in doubt about which marketing skill to use, start here  -  even if the user's request is vague or doesn't explicitly mention marketing.
 allowed-tools:
   - Bash(mktg *)
   - Bash(curl *)
@@ -54,7 +54,7 @@ Follow this escalation pattern. Always start at the highest applicable level:
 
 1. Run `mktg status --json` (or `mktg status --json --cwd <path>` for other projects)
 2. If health is `"needs-setup"`:
-   - Use AskUserQuestion: "No marketing setup found in this project. Want me to initialize marketing here? This will create a `brand/` directory and install 64 marketing skills."
+   - Use AskUserQuestion: "No marketing setup found in this project. Want me to initialize marketing here? This will create a `brand/` directory and install 65 marketing skills."
    - Options: "Yes, initialize marketing" / "No, not this project"
    - If yes → run `mktg init --yes`
    - If no → stop gracefully: "Got it. Run `/cmo` again when you're ready."

--- a/skills/cmo/rules/command-reference.md
+++ b/skills/cmo/rules/command-reference.md
@@ -51,6 +51,8 @@ routing, see `rules/publish-index.md`.
 | `mktg plan complete <id> --json` | After a skill successfully finishes — persists progress across sessions via `.mktg/plan.json`. |
 | `mktg plan --save --json` | Stream-persist the plan for long-running orchestration. |
 | `mktg run <skill> --json` | Direct skill invocation (bypasses the usual Claude Code slash-command flow). Use when the orchestration layer needs programmatic control. Logs `event:"loaded"` — a load is NOT work; `mktg plan` ignores loads for execute/distribute gates. |
+| `mktg run <skill> --with-context --budget 4000 --json` | One-shot activation: skill body + non-template brand context (declared reads win, layer matrix fallback) in a single call. Prefer this over separate `run` + `context` calls. |
+| `mktg run <skill> --strict --json` | Fail fast (exit 3 DEPENDENCY_MISSING) when skills/brand/envs/tools/catalogs are unsatisfied. Default is warn-only. |
 | `mktg run <skill> --complete --writes <paths> --result success --json` | Record a completed run after the agent actually produced files. Writes are validated to exist (exit 2 otherwise). Only `completed` events count as work. |
 | `mktg run <skill> --learning '{...}'` | Run a skill + record the learning atomically. |
 | `mktg skill history <skill> --json` | Load vs completion history for a skill. |

--- a/skills/cmo/rules/command-reference.md
+++ b/skills/cmo/rules/command-reference.md
@@ -50,8 +50,10 @@ routing, see `rules/publish-index.md`.
 | `mktg plan next --json` | Single highest-priority task. Default for "what should I do?" after session start. |
 | `mktg plan complete <id> --json` | After a skill successfully finishes — persists progress across sessions via `.mktg/plan.json`. |
 | `mktg plan --save --json` | Stream-persist the plan for long-running orchestration. |
-| `mktg run <skill> --json` | Direct skill invocation (bypasses the usual Claude Code slash-command flow). Use when the orchestration layer needs programmatic control. |
+| `mktg run <skill> --json` | Direct skill invocation (bypasses the usual Claude Code slash-command flow). Use when the orchestration layer needs programmatic control. Logs `event:"loaded"` — a load is NOT work; `mktg plan` ignores loads for execute/distribute gates. |
+| `mktg run <skill> --complete --writes <paths> --result success --json` | Record a completed run after the agent actually produced files. Writes are validated to exist (exit 2 otherwise). Only `completed` events count as work. |
 | `mktg run <skill> --learning '{...}'` | Run a skill + record the learning atomically. |
+| `mktg skill history <skill> --json` | Load vs completion history for a skill. |
 
 ---
 

--- a/skills/cmo/rules/publish-index.md
+++ b/skills/cmo/rules/publish-index.md
@@ -24,6 +24,24 @@ mktg catalog info postiz --json --fields configured,missing_envs,resolved_base
 | `resend` | Email send path | `RESEND_API_KEY` | Transactional/email distribution. |
 | `file` | Always-on local export | None | Writes publish artifacts to disk for manual or later posting. |
 
+## Per-Item Status Truth (read this before reporting outcomes)
+
+Every item in `adapters[].results[]` carries a `status` from this enum —
+**never** paraphrase it into something stronger:
+
+| Status | Meaning | Adapters |
+|---|---|---|
+| `queued-local` | Written to the local `.mktg/native-publish/` queue. NOT posted anywhere. | `mktg-native` |
+| `draft-external` | Draft created on an external service. NOT scheduled/sent. | `typefully`, `postiz` |
+| `sent` | Confirmed sent/scheduled on an external network. | `resend` |
+| `written-file` | Exported to `.mktg/published/` on disk. | `file` |
+| `failed` | Adapter rejected the item (see `detail`). | all |
+| `skipped` | Dry-run preview or idempotency skip. | all |
+
+Anti-pattern: telling the user a post "went out" when the status is
+`queued-local` or `draft-external`. Say "queued locally" or "draft created"
+instead — promotion to a live network is a separate step.
+
 ## Native Backend
 
 Initial native provider rollout is deliberately small:
@@ -64,7 +82,8 @@ Native publish manifest shape:
 Important: `mktg-native` is local-first. It records drafts, scheduled
 items, published-local state, and queue history. It does not magically own
 third-party OAuth yet; use Postiz or browser automation when real external
-network posting is required.
+network posting is required. Studio renders these states as `queued-local`
+chips (CLI enum parity), never as network-published.
 
 ## Platform Routing
 

--- a/skills/cmo/rules/studio-api-index.md
+++ b/skills/cmo/rules/studio-api-index.md
@@ -115,7 +115,7 @@ Navigate to Trend radar:
 
 - Skill runs that produce user-visible artifacts.
 - Brand file writes and refreshes.
-- Native, Postiz, Typefully, Resend, or file publish actions.
+- Native, Postiz, Typefully, Resend, or file publish actions. Report them with the CLI's per-item status vocabulary (`queued-local`, `draft-external`, `sent`, `written-file`, `failed`, `skipped`) — Studio labels match the CLI enum 1:1, so a native queue write shows as `queued-local`, never as network-published.
 - Recommended next actions that should appear on Pulse.
 - One navigation event when the user's attention should move.
 

--- a/skills/openseo/SKILL.md
+++ b/skills/openseo/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: openseo
+description: >-
+  Use OpenSEO (open-source Semrush/Ahrefs alternative) as the SEO data plane —
+  keyword difficulty, search volume, SERP results, ranked keywords, backlinks,
+  rank tracking, and Google Search Console. Use this skill whenever someone
+  asks for keyword difficulty, KD, search volume, SERP positions, domain
+  rankings, backlink data, rank tracking, or GSC performance. ALWAYS prefer
+  OpenSEO's measured data over estimated metrics when the catalog is
+  configured; fall back to Exa-backed keyword-research (with an explicit gap
+  note) when it is not. Triggers: "keyword difficulty", "search volume",
+  "SERP results", "ranked keywords", "backlinks", "rank tracker", "GSC".
+category: seo
+tier: nice-to-have
+layer: strategy
+reads:
+  - brand/keyword-plan.md
+writes:
+  - brand/keyword-plan.md
+env_vars:
+  - OPENSEO_API_KEY
+  - OPENSEO_API_BASE
+triggers:
+  - keyword difficulty
+  - search volume
+  - serp results
+  - ranked keywords
+  - backlinks
+  - rank tracker
+  - gsc performance
+allowed-tools:
+  - Bash(mktg catalog *)
+  - Bash(mktg doctor *)
+  - Bash(mktg run *)
+---
+
+# OpenSEO — SEO Data Plane
+
+You connect mktg's SEO playbooks to a running OpenSEO instance (hosted at openseo.so or self-hosted Docker). You do NOT invent metrics. You do NOT call DataForSEO directly. You route measured data (KD, volume, SERP, ranked keywords, backlinks, rank tracking, GSC) into mktg artifacts like `brand/keyword-plan.md`.
+
+OpenSEO is a **data plane**, not a playbook. The SEO methodology lives in `keyword-research`, `seo-content`, `seo-audit`, `off-page-seo`, `ai-seo`, and `seo-machine` — this skill is how those playbooks stop guessing.
+
+## North Star
+
+1. Measured data beats estimated data. When OpenSEO is configured, metrics come from OpenSEO's MCP tools. When it is not, you say so explicitly and fall back to Exa-backed qualitative research — metrics marked `unknown`.
+2. mktg never calls DataForSEO directly. OpenSEO owns the vendor relationship; mktg talks to OpenSEO only.
+3. Expensive calls (bulk research, `save_keywords`) follow dry-run/confirm discipline — DataForSEO credit is real money.
+4. OpenSEO project state syncs into `.seo/` and `brand/keyword-plan.md`; it never becomes a competing second source of truth.
+
+## On Activation
+
+Run these steps before anything else. Each has a fallback that keeps the skill useful when OpenSEO is absent.
+
+### Step 1 — Verify the catalog is registered and configured
+
+```bash
+mktg catalog info openseo --json --fields configured,missing_envs,auth.credential_envs,mcp
+```
+
+- Exit code 1 → the openseo catalog is not registered (upgrade marketing-cli). Stop.
+- `configured: false` → env vars are missing. Build the fix string from `missing_envs`. Canonical envs: `OPENSEO_API_KEY` (required for non-interactive automation) and `OPENSEO_API_BASE` (REST base; self-host override). The MCP URL is `mcp.default_url` (`https://app.openseo.so/mcp`) unless `OPENSEO_MCP_URL` overrides it for self-host.
+- `configured: true` → proceed. If only the MCP client is connected (OAuth login in the user's agent client) but no API key exists, treat readiness as `mcp_client_only`: MCP tools work interactively, headless automation does not.
+
+### Step 2 — Establish the data-plane connection
+
+Preferred: OpenSEO MCP tools via the agent's MCP client (root `.mcp.json` ships an `openseo` server entry — the user connects it once in their client). Hosted MCP uses OAuth login; self-host uses its own base URL via `OPENSEO_MCP_URL`.
+
+If no MCP connection and no `OPENSEO_API_KEY`: state the gap and downgrade to the Exa/Firecrawl path (Step 3 fallback). Do not fabricate a connection.
+
+### Step 3 — Route to the playbook with measured inputs
+
+Hand the measured data to the SEO playbooks instead of running parallel research:
+
+| Job | Route | Data you supply |
+|---|---|---|
+| Keyword opportunity discovery | `keyword-research` | KD, volume, intent from OpenSEO research tools |
+| Programmatic SEO inputs | `seo-machine` | Validate KD/competition before page generation |
+| Backlink gaps | `off-page-seo` | OpenSEO backlink overview for the domain |
+| Rank drops / striking distance | `ai-seo`, `seo-audit` | Rank tracker + GSC snapshots |
+
+**Fallback (no OpenSEO):** run the Exa-backed `keyword-research` path and mark every metric `unknown`. Say plainly: "OpenSEO is not configured — these are qualitative findings, not measured KD/volume. Set `OPENSEO_API_KEY` (or connect the MCP) to upgrade this run."
+
+## Cost Discipline
+
+- Research calls in small batches are fine. Bulk pulls (hundreds of keywords) and `save_keywords` writes REQUIRE user confirmation first — say the estimated call count out loud.
+- Default to conservative result limits; widen only when asked.
+- Log surprises (unexpected credit spend, rate limits) to `brand/learnings.md` via `mktg run openseo --learning '{...}'`.
+
+## State Contract
+
+| OpenSEO concept | mktg home |
+|---|---|
+| Project id / domain | `.seo/openseo.json` (`{ projectId, domain, mcpUrl, updatedAt }`) — create on first link |
+| Saved keywords | Merge into `brand/keyword-plan.md` (confirm before overwriting) |
+| Rank snapshots | `.seo/rank-snapshots/<date>.json` + short summary md |
+| Backlink overview | `.seo/backlink-overview.json` (input for off-page-seo) |
+
+One resume protocol per long-arc SEO effort: `docs/seo-machine.md` stays the single tracker; OpenSEO data feeds it, it does not fork it.
+
+## Anti-Patterns
+
+- **Inventing KD/volume numbers** — because agents hallucinate plausible metrics and downstream decisions (content priorities, page generation) get built on fiction. If OpenSEO is not configured, the metric is `unknown`, full stop.
+- **Calling DataForSEO directly from mktg** — because it bypasses OpenSEO's project state, caching, and cost controls, and duplicates the vendor integration mktg deliberately does not own. Always go through OpenSEO.
+- **Saving keywords or running bulk research without confirmation** — because every call can spend DataForSEO credit; silent bulk spends are how budgets blow up. Confirm first, state the call count.
+- **Treating the OpenSEO web UI as required** — because the MCP/API surface is the agent path; the UI is a human convenience. Never block an agent run waiting for a human to click something in a dashboard.
+- **Forking SEO state into a second system of record** — because two keyword lists drift and agents stop trusting both. Sync INTO `.seo/` + `brand/keyword-plan.md`; OpenSEO stays the measurement backend, mktg stays the playbook brain.
+
+## Progressive Enhancement
+
+| Level | Behavior |
+|---|---|
+| L0 (no envs, no MCP) | Gap note + Exa-backed `keyword-research` fallback; metrics `unknown` |
+| L1 (`OPENSEO_API_KEY` set) | Non-interactive research calls where REST exists; MCP still preferred |
+| L2 (MCP connected) | Full tool surface: research, SERP, ranked keywords, backlinks, GSC |
+| L3 (project linked + synced) | `.seo/` snapshots feed `seo-machine` and `off-page-seo` automatically |
+
+---
+
+*Integration shape follows the postiz catalog pattern: raw HTTP/MCP over the network boundary, never vendored code. OpenSEO is MIT-licensed ([every-app/open-seo](https://github.com/every-app/open-seo)).*

--- a/src/commands/catalog.ts
+++ b/src/commands/catalog.ts
@@ -146,21 +146,21 @@ export const infoSchema: CommandSchema = {
 
 export const syncSchema: CommandSchema = {
   name: "sync",
-  description: "Check each catalog's pinned version against upstream (v1: read-only, reports drift without mutating)",
+  description: "Report each catalog's pinned version. NOTE: upstream drift detection is NOT yet implemented — to_version is always null and every item carries an explicit 'unimplemented' error string",
   flags: [
-    { name: "--dry-run", type: "boolean", required: false, default: false, description: "Preview version diffs without writing (v1 is always read-only — flag accepted for forward-compat)" },
-    { name: "--catalog", type: "string", required: false, description: "Limit sync to a single catalog" },
+    { name: "--dry-run", type: "boolean", required: false, default: false, description: "No-op today — sync never mutates" },
+    { name: "--catalog", type: "string", required: false, description: "Limit to a single catalog" },
   ],
   output: {
-    "catalogs": "Array<{name, from_version, to_version, changed}> — per-catalog diff",
+    "catalogs": "Array<{name, from_version, to_version, changed, error}> — per-catalog pinned version (drift check unimplemented)",
     "catalogs.*.name": "string",
     "catalogs.*.from_version": "string — currently pinned version",
-    "catalogs.*.to_version": "string | null — latest upstream tag, or null on network error",
-    "catalogs.*.changed": "boolean — true if from_version !== to_version",
-    "catalogs.*.error": "string | undefined — present when upstream check failed",
+    "catalogs.*.to_version": "null — always null until upstream drift detection is implemented",
+    "catalogs.*.changed": "false — always false until drift detection is implemented",
+    "catalogs.*.error": "string — always present: 'upstream version check not yet implemented'",
     "summary.total": "number",
-    "summary.changed": "number — catalogs with pending bumps",
-    "summary.errors": "number — upstream check failures",
+    "summary.changed": "number — always 0 until drift detection is implemented",
+    "summary.errors": "number — equals total (every item reports unimplemented)",
     "dryRun": "boolean",
   },
   examples: [
@@ -172,17 +172,17 @@ export const syncSchema: CommandSchema = {
 
 export const statusSchema: CommandSchema = {
   name: "status",
-  description: "Health snapshot across all catalogs: configured + reachable",
+  description: "Configured-state snapshot across all catalogs. Health probes are NOT implemented — healthy is always null rather than guessed",
   flags: [],
   output: {
     "catalogs": "Array<{name, configured, healthy, detail}>",
     "catalogs.*.name": "string",
     "catalogs.*.configured": "boolean — all auth env vars set",
-    "catalogs.*.healthy": "boolean | null — reachable + auth ok (null when unconfigured or read-only path)",
+    "catalogs.*.healthy": "null — always null until reachability probes are implemented (never guessed)",
     "catalogs.*.detail": "string — human-readable status message",
     "summary.total": "number",
     "summary.configured": "number",
-    "summary.healthy": "number",
+    "summary.healthy": "number — always 0 until probes are implemented",
   },
   examples: [
     { args: "mktg catalog status --json", description: "All catalog health at a glance" },
@@ -325,7 +325,7 @@ const handleSync = async (args: readonly string[]): Promise<CommandResult<SyncRe
     from_version: c.version_pinned,
     to_version: null,
     changed: false,
-    error: "upstream version check not yet implemented — see plan v2 §Phase A-prime",
+    error: "upstream version check not yet implemented",
   }));
 
   return ok({

--- a/src/commands/context.ts
+++ b/src/commands/context.ts
@@ -3,34 +3,13 @@
 
 import { join } from "node:path";
 import { mkdir } from "node:fs/promises";
-import { ok, err, BRAND_FILES, type CommandHandler, type CommandSchema, type BrandFile } from "../types";
-import { isTemplateContent, getBrandStatus, CONTEXT_MATRIX } from "../core/brand";
+import { ok, err, type CommandHandler, type CommandSchema } from "../types";
 import { rejectControlChars, validateResourceId } from "../core/errors";
+import { compileBrandContext, CONTEXT_LAYERS, type ContextFileEntry } from "../core/context-compiler";
 import { writeStderr, isTTY, bold, dim, green, yellow, red } from "../core/output";
 
-// Token estimation: ~4 chars per token
-const estimateTokens = (text: string): number => Math.ceil(text.length / 4);
-
-// Truncate content to fit a token budget, preserving leading lines
-const truncateToTokens = (content: string, maxTokens: number): { text: string; truncated: boolean } => {
-  if (estimateTokens(content) <= maxTokens) return { text: content, truncated: false };
-  const charBudget = maxTokens * 4;
-  const truncated = content.slice(0, charBudget);
-  // Cut at last newline to avoid mid-line truncation
-  const lastNewline = truncated.lastIndexOf("\n");
-  const text = lastNewline > 0 ? truncated.slice(0, lastNewline) + "\n[...truncated]" : truncated + "\n[...truncated]";
-  return { text, truncated: true };
-};
-
 // Valid layer names (keys of CONTEXT_MATRIX)
-const VALID_LAYERS = Object.keys(CONTEXT_MATRIX) as (keyof typeof CONTEXT_MATRIX)[];
-
-type ContextFileEntry = {
-  readonly content: string;
-  readonly tokens: number;
-  readonly truncated: boolean;
-  readonly freshness: string;
-};
+const VALID_LAYERS = CONTEXT_LAYERS;
 
 type ContextSummary = {
   readonly totalFiles: number;
@@ -45,6 +24,7 @@ type ContextResult = {
   readonly tokenEstimate: number;
   readonly layer?: string;
   readonly files: Record<string, ContextFileEntry>;
+  readonly budgetDropped: readonly string[];
   readonly summary: ContextSummary;
 };
 
@@ -66,6 +46,7 @@ export const schema: CommandSchema = {
     "files.*.tokens": "number — estimated tokens for this file",
     "files.*.truncated": "boolean — true if content was truncated by --budget",
     "files.*.freshness": "'current' | 'stale' | 'template' | 'missing' — file freshness state",
+    "budgetDropped": "string[] — files dropped entirely when --budget ran out (structured overflow signal)",
     "summary": "{totalFiles, populatedFiles, templateFiles, staleFiles} — counts",
   },
   examples: [
@@ -78,20 +59,6 @@ export const schema: CommandSchema = {
   ],
   vocabulary: ["context", "compile", "brand-context", "token-budget"],
 };
-
-// Priority order for truncation — most important files first
-const FILE_PRIORITY: readonly BrandFile[] = [
-  "voice-profile.md",
-  "positioning.md",
-  "audience.md",
-  "competitors.md",
-  "landscape.md",
-  "keyword-plan.md",
-  "creative-kit.md",
-  "stack.md",
-  "assets.md",
-  "learnings.md",
-];
 
 // Get project name from package.json or dir name
 const getProjectName = async (cwd: string): Promise<string> => {
@@ -149,7 +116,7 @@ export const handler: CommandHandler<ContextResult> = async (args, flags) => {
     if (!idCheck.ok) return err("INVALID_ARGS", idCheck.message, [`Valid layers: ${VALID_LAYERS.join(", ")}`], 2);
     const ctrlCheck = rejectControlChars(layer, "layer");
     if (!ctrlCheck.ok) return err("INVALID_ARGS", ctrlCheck.message, [], 2);
-    if (!VALID_LAYERS.includes(layer as keyof typeof CONTEXT_MATRIX)) {
+    if (!(VALID_LAYERS as readonly string[]).includes(layer)) {
       return err("INVALID_ARGS", `Unknown layer: '${layer}'`, [`Valid layers: ${VALID_LAYERS.join(", ")}`], 2);
     }
   }
@@ -159,90 +126,32 @@ export const handler: CommandHandler<ContextResult> = async (args, flags) => {
     return err("INVALID_ARGS", "Budget must be a positive integer", ["Example: mktg context --budget 2000"], 2);
   }
 
-  // Determine which files to include
-  const targetFiles: readonly BrandFile[] = layer
-    ? CONTEXT_MATRIX[layer as keyof typeof CONTEXT_MATRIX]
-    : BRAND_FILES;
+  const compiled = await compileBrandContext(cwd, {
+    ...(layer !== undefined ? { layer } : {}),
+    ...(budget !== undefined ? { budget } : {}),
+  });
 
-  // Read brand statuses and file contents in parallel
-  const brandStatuses = await getBrandStatus(cwd);
-  const statusMap = new Map(brandStatuses.map(s => [s.file, s]));
-
-  const brandDir = join(cwd, "brand");
-  const fileEntries: [string, ContextFileEntry][] = [];
-  let totalPopulated = 0;
-  let totalTemplate = 0;
-  let totalStale = 0;
-
-  // Read all target files
-  for (const file of targetFiles) {
-    const status = statusMap.get(file);
-    if (!status || !status.exists) continue;
-
-    const filePath = join(brandDir, file);
-    try {
-      const content = await Bun.file(filePath).text();
-      const isTemplate = isTemplateContent(file, content);
-      const freshness = isTemplate ? "template" : status.freshness;
-
-      if (isTemplate) totalTemplate++;
-      else totalPopulated++;
-      if (status.freshness === "stale") totalStale++;
-
-      const entry: ContextFileEntry = {
-        content,
-        tokens: estimateTokens(content),
-        truncated: false,
-        freshness,
-      };
-      fileEntries.push([file, entry]);
-      if (ndjson) {
-        writeStderr(JSON.stringify({ type: "brand-file", data: { file, status: freshness, tokens: entry.tokens } }));
-      }
-    } catch { /* skip unreadable files */ }
-  }
-
-  // Apply budget truncation if requested
-  if (budget !== undefined && budget > 0) {
-    // Sort by priority (FILE_PRIORITY order)
-    const priorityOrder = new Map(FILE_PRIORITY.map((f, i) => [f, i]));
-    fileEntries.sort((a, b) => (priorityOrder.get(a[0] as BrandFile) ?? 99) - (priorityOrder.get(b[0] as BrandFile) ?? 99));
-
-    let remainingTokens = budget;
-    for (let i = 0; i < fileEntries.length; i++) {
-      const [name, entry] = fileEntries[i]!;
-      if (remainingTokens <= 0) {
-        // No budget left — truncate to nothing
-        fileEntries[i] = [name, { content: "[...truncated — budget exceeded]", tokens: 0, truncated: true, freshness: entry.freshness }];
-        continue;
-      }
-      const { text, truncated } = truncateToTokens(entry.content, remainingTokens);
-      const tokens = estimateTokens(text);
-      remainingTokens -= tokens;
-      fileEntries[i] = [name, { content: text, tokens, truncated, freshness: entry.freshness }];
+  if (ndjson) {
+    for (const [file, entry] of Object.entries(compiled.files)) {
+      writeStderr(JSON.stringify({ type: "brand-file", data: { file, status: entry.freshness, tokens: entry.tokens } }));
     }
   }
 
-  const files = Object.fromEntries(fileEntries);
-  const tokenEstimate = fileEntries.reduce((sum, [, e]) => sum + e.tokens, 0);
+  const fileEntries = Object.entries(compiled.files);
   const projectName = await getProjectName(cwd);
 
   const result: ContextResult = {
     compiledAt: new Date().toISOString(),
     project: projectName,
-    tokenEstimate,
+    tokenEstimate: compiled.tokenEstimate,
     ...(layer && { layer }),
-    files,
-    summary: {
-      totalFiles: fileEntries.length,
-      populatedFiles: totalPopulated,
-      templateFiles: totalTemplate,
-      staleFiles: totalStale,
-    },
+    files: compiled.files,
+    budgetDropped: compiled.budgetDropped,
+    summary: compiled.summary,
   };
 
   if (ndjson) {
-    writeStderr(JSON.stringify({ type: "complete", data: { totalTokens: tokenEstimate, filesIncluded: fileEntries.length } }));
+    writeStderr(JSON.stringify({ type: "complete", data: { totalTokens: compiled.tokenEstimate, filesIncluded: fileEntries.length } }));
   }
 
   // Save to .mktg/context.json
@@ -262,7 +171,7 @@ export const handler: CommandHandler<ContextResult> = async (args, flags) => {
     const lines: string[] = [];
     lines.push(bold(`mktg context — ${projectName}`));
     lines.push("");
-    lines.push(`  Token estimate: ${tokenEstimate}${budget ? ` (budget: ${budget})` : ""}`);
+    lines.push(`  Token estimate: ${compiled.tokenEstimate}${budget ? ` (budget: ${budget})` : ""}`);
     if (layer) lines.push(`  Layer: ${layer}`);
     lines.push("");
     lines.push(bold("  Files"));

--- a/src/commands/dashboard.ts
+++ b/src/commands/dashboard.ts
@@ -40,7 +40,7 @@ import {
 import { handler as doctorHandler } from "./doctor";
 import { handler as planHandler } from "./plan";
 import { handler as statusHandler } from "./status";
-import { getRunHistory, type RunSummaryEntry } from "../core/run-log";
+import { getRunHistory, isCompletedRecord, type RunSummaryEntry } from "../core/run-log";
 import { loadManifest, getInstallStatus } from "../core/skills";
 import { loadAgentManifest, getAgentInstallStatus } from "../core/agents";
 import { invalidArgs, parseJsonInput, validatePathInput } from "../core/errors";
@@ -541,13 +541,18 @@ const buildOutputsResponse = async (flags: GlobalFlags): Promise<DashboardOutput
     id: `${record.skill}-${record.timestamp}-${index}`,
     timestamp: record.timestamp,
     skill: record.skill,
-    result: record.result,
-    summary: `${record.skill} finished with ${record.result}.`,
+    event: isCompletedRecord(record) ? ("completed" as const) : ("loaded" as const),
+    result: record.result ?? null,
+    summary: isCompletedRecord(record)
+      ? `${record.skill} completed with ${record.result ?? "unknown"}.`
+      : `${record.skill} loaded (no outcome recorded).`,
   }));
   const outputs = await discoverOutputs(flags.cwd);
 
-  const hasContentRun = history.some((record) => CONTENT_SKILLS.has(record.skill));
-  const hasDistributionRun = history.some((record) => DISTRIBUTION_SKILLS.has(record.skill));
+  // Readiness keys off completed work only — loads never signal readiness.
+  const completedHistory = history.filter(isCompletedRecord);
+  const hasContentRun = completedHistory.some((record) => CONTENT_SKILLS.has(record.skill));
+  const hasDistributionRun = completedHistory.some((record) => DISTRIBUTION_SKILLS.has(record.skill));
   const publishReadiness: DashboardReadiness = hasDistributionRun
     ? {
         state: "ready",

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -13,6 +13,7 @@ import { loadManifest, getInstallStatus, getSkillNames, readExternalSkills } fro
 import { loadAgentManifest, getAgentInstallStatus, getAgentNames } from "../core/agents";
 import { buildGraph } from "../core/skill-lifecycle";
 import { getIntegrationStatus, INTEGRATION_CONFIG } from "../core/integrations";
+import { TOOL_REGISTRY, toolAvailable } from "../core/tool-registry";
 import { isTTY, writeStderr, green, red, yellow, dim, bold } from "../core/output";
 import { executeDoctor, type FixEntry } from "../core/doctor-fix";
 
@@ -161,43 +162,12 @@ const checkGraph = async (): Promise<Check[]> => {
   }
 };
 
-// Check CLI tool availability
+// Check CLI tool availability — registry lives in core/tool-registry.ts so
+// doctor and skill prerequisites share the same names + install hints.
 const checkCLIs = async (): Promise<Check[]> => {
-  const tools = [
-    { name: "bun", required: true },
-    { name: "gws", required: false },
-    { name: "playwright-cli", required: false },
-    { name: "ffmpeg", required: false },
-    { name: "remotion", required: false },
-    { name: "firecrawl", required: false },
-    { name: "whisper-cpp", required: false },
-    { name: "yt-dlp", required: false },
-    { name: "summarize", required: false },
-    { name: "gh", required: false },
-    { name: "gh-axi", required: false },
-    { name: "chrome-devtools-axi", required: false },
-    { name: "higgsfield", required: false },
-  ] as const;
-
-  const CLI_INSTALL_HINTS: Record<string, string> = {
-    bun: "curl -fsSL https://bun.sh/install | bash",
-    ffmpeg: "brew install ffmpeg",
-    remotion: "npm i -g @remotion/cli",
-    firecrawl: "npm i -g firecrawl",
-    "playwright-cli": "npm i -g @playwright/cli",
-    gws: "npm i -g gws",
-    "whisper-cpp": "brew install whisper-cpp",
-    "yt-dlp": "brew install yt-dlp",
-    summarize: "npm i -g @steipete/summarize",
-    gh: "brew install gh",
-    "gh-axi": "npm i -g gh-axi   # or: npx -y gh-axi  (see /axi)",
-    "chrome-devtools-axi": "npm i -g chrome-devtools-axi   # or: npx -y chrome-devtools-axi  (see /axi)",
-    higgsfield: "npm i -g @higgsfield/cli && higgsfield auth login",
-  };
-
-  return tools.map(tool => {
-    const found = Bun.which(tool.name) !== null;
-    const hint = CLI_INSTALL_HINTS[tool.name];
+  return TOOL_REGISTRY.map(tool => {
+    const found = toolAvailable(tool.name);
+    const hint = tool.installHint;
     if (found) return { name: `cli-${tool.name}`, status: "pass" as const, detail: `${tool.name} found` };
     if (tool.required) return hint
       ? { name: `cli-${tool.name}`, status: "fail" as const, detail: `${tool.name} not found (required)`, fix: hint }

--- a/src/commands/plan.ts
+++ b/src/commands/plan.ts
@@ -12,9 +12,24 @@ import { getRunSummary, type RunSummaryEntry } from "../core/run-log";
 import { rejectControlChars, validateResourceId } from "../core/errors";
 import { isTTY, writeStderr, bold, dim, green, yellow, red } from "../core/output";
 
+// Content-file extensions that count as distributable artifacts under marketing/
+const MARKETING_ARTIFACT_GLOB = "**/*.{md,mdx,txt,html,json}";
+
+// True when the project has at least one real content artifact under marketing/.
+// Load-only skill runs must never stand in for artifacts (honest distribute gate).
+const hasMarketingArtifacts = async (cwd: string): Promise<boolean> => {
+  try {
+    const glob = new Bun.Glob(MARKETING_ARTIFACT_GLOB);
+    for await (const _file of glob.scan({ cwd: join(cwd, "marketing") })) {
+      return true; // one is enough
+    }
+  } catch { /* marketing/ doesn't exist */ }
+  return false;
+};
+
 export const schema: CommandSchema = {
   name: "plan",
-  description: "Execution loop — reads project state and outputs a prioritized, actionable task queue",
+  description: "Execution loop — reads project state (completed runs only, never load events) and outputs a prioritized, actionable task queue",
   flags: [
     { name: "--save", type: "boolean", required: false, description: "Persist plan to .mktg/plan.json" },
     { name: "--ndjson", type: "boolean", required: false, description: "Stream each task as a NDJSON line to stderr as it is computed" },
@@ -175,7 +190,9 @@ const buildTasks = async (
     }
   }
 
-  // 4. Execution skills not yet run (suggest based on dependency graph)
+  // 4. Execution skills not yet completed (suggest based on dependency graph).
+  // runSummary is completed-only (load events filtered upstream) — a skill
+  // that was merely loaded still counts as never-done.
   try {
     const manifest = await loadManifest();
     const graph = buildGraph(manifest);
@@ -188,33 +205,41 @@ const buildTasks = async (
         emitTask({
           id: `run-${skill}`, order: tasks.length, category: "execute",
           action: `Run /${skill} for the first time`, command: `mktg run ${skill}`,
-          reason: `Must-have execution skill never run — produces marketing assets`, blocked: false,
+          reason: `Must-have execution skill never completed — produces marketing assets`, blocked: false,
         });
       }
     }
   } catch { /* manifest issues handled elsewhere */ }
 
-  // 5. Distribution — check if content exists but hasn't been distributed
-  const executedSkills = Object.keys(runSummary);
-  const hasContent = executedSkills.some(s =>
+  // 5. Distribution — real evidence only: artifacts under marketing/ OR a
+  // completed content-skill run. Load-only history never unlocks distribute.
+  const completedSkills = Object.keys(runSummary);
+  const hasCompletedContent = completedSkills.some(s =>
     ["seo-content", "direct-response-copy", "lead-magnet", "creative"].includes(s),
   );
-  const hasDistributed = executedSkills.some(s =>
+  const contentEvidence = hasCompletedContent || await hasMarketingArtifacts(cwd);
+  const hasDistributed = completedSkills.some(s =>
     ["content-atomizer", "email-sequences", "social-campaign", "typefully"].includes(s),
   );
-  if (hasContent && !hasDistributed) {
+  if (contentEvidence && !hasDistributed) {
     emitTask({
       id: "distribute-content", order: tasks.length, category: "distribute",
       action: "Distribute created content", command: "mktg run content-atomizer",
-      reason: "Content skills have run but no distribution skills yet — 70% of marketing is distribution",
+      reason: "Content artifacts exist but no distribution skill has completed — 70% of marketing is distribution",
       blocked: false,
     });
   }
 
-  const populated = brandStatuses.filter(s => {
-    if (!s.exists) return false;
-    try { return true; } catch { return false; }
-  }).length;
+  // Health counts files with REAL content — templates don't count, so a
+  // fresh scaffold can never report "ready".
+  let populated = 0;
+  for (const status of brandStatuses) {
+    if (!status.exists) continue;
+    try {
+      const content = await Bun.file(join(cwd, "brand", status.file)).text();
+      if (!isTemplateContent(status.file, content)) populated++;
+    } catch { /* unreadable — doesn't count */ }
+  }
   const health: PlanResult["health"] = populated >= 3 ? "ready" : "incomplete";
 
   return { tasks: tasks.filter(t => !completedSet.has(t.id)), health };
@@ -252,8 +277,9 @@ export const handler: CommandHandler<PlanResult | { completed: string } | { task
     return ok({ completed: taskId });
   }
 
-  // Build plan
-  const runSummary = await getRunSummary(cwd);
+  // Build plan — completed runs only. A bare `mktg run` logs event:"loaded"
+  // and must not count as executed work anywhere in this queue.
+  const runSummary = await getRunSummary(cwd, { completedOnly: true });
   const { tasks, health } = await buildTasks(cwd, runSummary, completed, ndjson);
   if (ndjson) writeStderr(JSON.stringify({ type: "summary", data: { health, count: tasks.length } }));
   const summary = buildSummary(tasks, health);

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -5,7 +5,7 @@
 import { basename, extname, join } from "node:path";
 import { createHash } from "node:crypto";
 import { mkdir, rename, writeFile } from "node:fs/promises";
-import { ok, err, type CommandHandler, type CommandSchema, type PublishPostType } from "../types";
+import { ok, err, type CommandHandler, type CommandSchema, type PublishPostType, type PublishItemStatus, TERMINAL_PUBLISH_STATUSES } from "../types";
 import { rejectControlChars, validatePathInput, parseJsonInput } from "../core/errors";
 import { validatePublicUrl } from "../core/url-validation";
 import { isTTY, writeStderr, bold, dim, green, yellow, red } from "../core/output";
@@ -37,8 +37,9 @@ export const schema: CommandSchema = {
   output: {
     campaign: "string — campaign name from manifest",
     adapters: "AdapterResult[] — per-adapter publish results",
+    "adapters[].results[].status": "PublishItemStatus — per-item truth: queued-local (mktg-native) | draft-external (typefully, postiz) | sent (resend) | written-file (file) | failed | skipped",
     totalItems: "number — total content items processed",
-    published: "number — items successfully published",
+    published: "number — items reaching a terminal adapter status (queued-local/draft-external/sent/written-file)",
     failed: "number — items that failed",
     dryRun: "boolean — true if this was a validation-only run",
   },
@@ -76,8 +77,11 @@ type AdapterResult = {
   readonly published: number;
   readonly failed: number;
   readonly errors: readonly string[];
-  readonly results: readonly { readonly item: number; readonly status: "published" | "failed" | "skipped"; readonly detail: string; readonly postType?: PublishPostType }[];
+  readonly results: readonly { readonly item: number; readonly status: PublishItemStatus; readonly detail: string; readonly postType?: PublishPostType }[];
 };
+
+const countTerminal = (results: readonly { readonly status: PublishItemStatus }[]): number =>
+  results.filter(r => (TERMINAL_PUBLISH_STATUSES as readonly PublishItemStatus[]).includes(r.status)).length;
 
 type NativeAccountResult = Awaited<ReturnType<typeof getNativePublishAccountSummary>>;
 type NativeListPostsResult = { readonly adapter: "mktg-native"; readonly posts: Awaited<ReturnType<typeof listNativePublishPosts>> };
@@ -131,7 +135,8 @@ const publishTypefully = async (
         signal: AbortSignal.timeout(10000),
       });
       if (resp.ok) {
-        results.push({ item: i, status: "published", detail: "Draft created" });
+        // Typefully's API creates DRAFTS — never imply a send happened.
+        results.push({ item: i, status: "draft-external", detail: "Draft created on Typefully" });
       } else {
         results.push({ item: i, status: "failed", detail: `HTTP ${resp.status}` });
       }
@@ -144,7 +149,7 @@ const publishTypefully = async (
   return {
     adapter: "typefully",
     items: items.length,
-    published: results.filter(r => r.status === "published").length,
+    published: countTerminal(results),
     failed: results.filter(r => r.status === "failed").length,
     errors: results.filter(r => r.status === "failed").map(r => r.detail),
     results,
@@ -189,7 +194,7 @@ const publishResend = async (
         signal: AbortSignal.timeout(10000),
       });
       if (resp.ok) {
-        results.push({ item: i, status: "published", detail: "Email sent" });
+        results.push({ item: i, status: "sent", detail: "Email sent via Resend" });
       } else {
         results.push({ item: i, status: "failed", detail: `HTTP ${resp.status}` });
       }
@@ -202,7 +207,7 @@ const publishResend = async (
   return {
     adapter: "resend",
     items: items.length,
-    published: results.filter(r => r.status === "published").length,
+    published: countTerminal(results),
     failed: results.filter(r => r.status === "failed").length,
     errors: results.filter(r => r.status === "failed").map(r => r.detail),
     results,
@@ -234,7 +239,7 @@ const publishFile = async (
       const { mkdir: mkdirFs } = await import("node:fs/promises");
       await mkdirFs(outDir, { recursive: true });
       await Bun.write(join(outDir, filename), item.content);
-      results.push({ item: i, status: "published", detail: `Written to ${filename}` });
+      results.push({ item: i, status: "written-file", detail: `Written to .mktg/published/${filename}` });
     } catch (e) {
       results.push({ item: i, status: "failed", detail: e instanceof Error ? e.message : "Unknown error" });
     }
@@ -244,7 +249,7 @@ const publishFile = async (
   return {
     adapter: "file",
     items: items.length,
-    published: results.filter(r => r.status === "published").length,
+    published: countTerminal(results),
     failed: results.filter(r => r.status === "failed").length,
     errors: results.filter(r => r.status === "failed").map(r => r.detail),
     results,
@@ -290,15 +295,18 @@ const publishNative = async (
       ...(metadata ? { metadata } : {}),
       targets: targetResolution.targets,
     });
-    const detail = `${stored.status} → ${targetResolution.targets.map((target) => target.identifier).join(", ")}`;
-    results.push({ item: i, status: "published", detail, postType: stored.type });
-    if (ndjson) writeStderr(JSON.stringify({ adapter: "mktg-native", item: i, status: "published", detail }));
+    // mktg-native is a LOCAL workspace queue — the write never leaves the
+    // machine, so the item status is always queued-local regardless of the
+    // stored post's internal draft/scheduled/published state.
+    const detail = `queued-local (${stored.status}) → ${targetResolution.targets.map((target) => target.identifier).join(", ")}`;
+    results.push({ item: i, status: "queued-local", detail, postType: stored.type });
+    if (ndjson) writeStderr(JSON.stringify({ adapter: "mktg-native", item: i, status: "queued-local", detail }));
   }
 
   return {
     adapter: "mktg-native",
     items: items.length,
-    published: results.filter((result) => result.status === "published").length,
+    published: countTerminal(results),
     failed: results.filter((result) => result.status === "failed").length,
     errors: results.filter((result) => result.status === "failed").map((result) => result.detail),
     results,
@@ -836,8 +844,10 @@ const publishPostiz = async (inp: PublishPostizInput): Promise<AdapterResult> =>
     }
 
     marker.sent[key] = { postedAt: new Date().toISOString(), providers: [...providers] };
-    if (inp.ndjson) writeStderr(JSON.stringify({ adapter: "postiz", item: i, status: "published", providers }));
-    results.push({ item: i, status: "published", detail: `draft → ${providers.join(", ")}` });
+    if (inp.ndjson) writeStderr(JSON.stringify({ adapter: "postiz", item: i, status: "draft-external", providers }));
+    // The v1 postiz adapter only creates drafts (buildCreatePostDraft) —
+    // postiz itself owns any later scheduling/sending.
+    results.push({ item: i, status: "draft-external", detail: `draft on postiz → ${providers.join(", ")}` });
     published++;
   }
 

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -99,6 +99,34 @@ export const handler: CommandHandler<RunResult> = async (args, flags) => {
     ], DOCS.skills);
   }
 
+  // Validate --writes BEFORE any dependency lookup (manifest, install dir):
+  // static input errors must precede environment errors, so an agent gets
+  // INVALID_ARGS about its payload whether or not skills are installed.
+  // Every path must pass the sandbox pipeline AND exist — recording work
+  // that didn't happen is the exact lie this command exists to prevent.
+  const validatedWrites: string[] = [];
+  if (wantComplete && writesList.length > 0) {
+    const writeErrors: string[] = [];
+    for (const w of writesList) {
+      const check = validatePathInput(flags.cwd, w);
+      if (!check.ok) {
+        writeErrors.push(`'${w}': ${check.message}`);
+        continue;
+      }
+      if (!(await Bun.file(check.path).exists())) {
+        writeErrors.push(`'${w}': file does not exist`);
+        continue;
+      }
+      validatedWrites.push(w);
+    }
+    if (writeErrors.length > 0) {
+      return invalidArgs(`Invalid --writes: ${writeErrors.join("; ")}`, [
+        "Writes must be existing files inside the project (brand/, marketing/, .mktg/)",
+        "Create the files first, then record completion with the same command",
+      ], DOCS.skills);
+    }
+  }
+
   // Lane 1 / Wave A audit fix: every other resource-name command in the
   // registry validates its positional via these two checks; `mktg run`
   // was the lone gap. Reject control chars + cap length at 128 BEFORE
@@ -153,32 +181,6 @@ export const handler: CommandHandler<RunResult> = async (args, flags) => {
     }));
   }
   const now = new Date().toISOString();
-
-  // Validate --writes: every path must pass the sandbox pipeline AND exist.
-  // Recording work that didn't happen is the exact lie this command now
-  // exists to prevent — invalid writes fail loudly with fix guidance.
-  const validatedWrites: string[] = [];
-  if (wantComplete && writesList.length > 0) {
-    const writeErrors: string[] = [];
-    for (const w of writesList) {
-      const check = validatePathInput(flags.cwd, w);
-      if (!check.ok) {
-        writeErrors.push(`'${w}': ${check.message}`);
-        continue;
-      }
-      if (!(await Bun.file(check.path).exists())) {
-        writeErrors.push(`'${w}': file does not exist`);
-        continue;
-      }
-      validatedWrites.push(w);
-    }
-    if (writeErrors.length > 0) {
-      return invalidArgs(`Invalid --writes: ${writeErrors.join("; ")}`, [
-        "Writes must be existing files inside the project (brand/, marketing/, .mktg/)",
-        "Create the files first, then record completion with the same command",
-      ], DOCS.skills);
-    }
-  }
 
   // Surface prior run context — agent sees usage history with every load
   const lastRun = await getLastRun(flags.cwd, resolved.name);

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -3,16 +3,25 @@
 
 import { join } from "node:path";
 import type { CommandHandler, CommandSchema, PrerequisiteStatus } from "../types";
-import { ok } from "../types";
+import { ok, err } from "../types";
 import { invalidArgs, notFound, DOCS, parseJsonInput, rejectControlChars, validateResourceId, validatePathInput } from "../core/errors";
 import { resolveManifest, getSkill, getSkillsInstallDir } from "../core/skills";
 import { checkPrerequisites } from "../core/skill-lifecycle";
 import { logRun, getLastRun, getRunHistory, isCompletedRecord } from "../core/run-log";
+import { compileBrandContext, filesForSkillActivation, type ContextFileEntry } from "../core/context-compiler";
 import { appendLearning, type LearningEntry } from "../core/brand";
 import { writeStderr } from "../core/output";
 
 const VALID_RUN_RESULTS = ["success", "partial", "failed"] as const;
 type RunOutcome = typeof VALID_RUN_RESULTS[number];
+
+type ActivationContext = {
+  readonly layer: string;
+  readonly files: Record<string, ContextFileEntry>;
+  readonly tokenEstimate: number;
+  readonly budgetDropped: readonly string[];
+  readonly templatesSkipped: readonly string[];
+};
 
 export const schema: CommandSchema = {
   name: "run",
@@ -23,25 +32,29 @@ export const schema: CommandSchema = {
     { name: "--complete", type: "boolean", required: false, description: "Record a completed run (work actually happened) instead of a load event" },
     { name: "--result", type: "string", required: false, description: "Outcome with --complete: success | partial | failed (default success)" },
     { name: "--writes", type: "string", required: false, description: "Comma-separated files the agent produced (repeatable); each must exist inside the project" },
+    { name: "--with-context", type: "boolean", required: false, description: "One-shot activation: include non-template brand context selected from the skill's declared reads (or layer matrix)" },
+    { name: "--budget", type: "string", required: false, description: "With --with-context: approximate token budget for context files (priority truncation)" },
+    { name: "--strict", type: "boolean", required: false, description: "Exit 3 (DEPENDENCY_MISSING) when any prerequisite (skills, brand files, envs, tools, catalogs) is unsatisfied" },
     { name: "--ndjson", type: "boolean", required: false, description: "Stream prerequisite check, skill-loaded, and complete events as NDJSON lines to stderr" },
   ],
   output: {
     skill: "string — resolved skill name",
     content: "string — full SKILL.md content",
-    prerequisites: "PrerequisiteStatus — prerequisite check results",
+    prerequisites: "PrerequisiteStatus — prerequisite check results (skills, brandFiles, envs, tools, catalogs)",
     loggedAt: "string | null — ISO timestamp of logged run (null on --dry-run)",
     event: "'loaded' | 'completed' — what was logged: load events never imply work",
     result: "'success' | 'partial' | 'failed' | null — outcome with --complete; null on loads",
     writes: "string[] | null — validated files recorded with --complete; null on loads",
+    context: "object | null — with --with-context: {layer, files, tokenEstimate, budgetDropped, templatesSkipped}; null otherwise",
     priorRuns: "object — lastRun timestamp, lastEvent, runCount, and lastResult for this skill",
     learningAppended: "string | null — the table row appended to learnings.md, or null if --learning not provided",
   },
   examples: [
     { args: "mktg run seo-content --json", description: "Load SEO content skill for agent (logs event: loaded)" },
-    { args: "mktg run brand-voice --dry-run", description: "Preview without logging" },
+    { args: "mktg run seo-content --with-context --budget 4000 --json", description: "One-shot activation: skill + brand context in one call" },
+    { args: "mktg run postiz --strict --json", description: "Fail fast (exit 3) when env vars like POSTIZ_API_KEY are missing" },
     { args: "mktg run seo-content --complete --writes marketing/content/x.md --result success --json", description: "Record completed work with validated writes" },
     { args: "mktg skill history seo-content --json", description: "See load vs completion events for a skill" },
-    { args: "mktg run seo-content --ndjson", description: "Stream prerequisite, load, and complete events to stderr" },
   ],
   vocabulary: ["run", "execute", "load skill", "complete", "record outcome"],
 };
@@ -61,6 +74,7 @@ type RunResult = {
   readonly event: "loaded" | "completed";
   readonly result: "success" | "partial" | "failed" | null;
   readonly writes: readonly string[] | null;
+  readonly context: ActivationContext | null;
   readonly priorRuns: PriorRunContext;
   readonly learningAppended: string | null;
 };
@@ -70,20 +84,25 @@ export const handler: CommandHandler<RunResult> = async (args, flags) => {
   const skillName = positionalArgs[0];
   const ndjson = args.includes("--ndjson");
   const wantComplete = args.includes("--complete");
+  const withContext = args.includes("--with-context");
+  const strict = args.includes("--strict");
 
   if (!skillName) {
     return invalidArgs("Missing skill name", ["Usage: mktg run <skill-name>", "mktg list --json to see available skills"], DOCS.skills);
   }
 
-  // Parse --result / --writes (completion-only flags)
+  // Parse --result / --writes (completion-only flags) and --budget
   let resultArg: RunOutcome | undefined;
   const writesRaw: string[] = [];
+  let budget: number | undefined;
   for (let i = 0; i < args.length; i++) {
     const a = args[i]!;
     if (a === "--result" && args[i + 1]) { resultArg = args[i + 1] as RunOutcome; i++; }
     else if (a.startsWith("--result=")) { resultArg = a.slice(9) as RunOutcome; }
     else if (a === "--writes" && args[i + 1]) { writesRaw.push(...args[i + 1]!.split(",")); i++; }
     else if (a.startsWith("--writes=")) { writesRaw.push(...a.slice(9).split(",")); }
+    else if (a === "--budget" && args[i + 1]) { budget = parseInt(args[i + 1]!, 10); i++; }
+    else if (a.startsWith("--budget=")) { budget = parseInt(a.slice(9), 10); }
   }
   const writesList = writesRaw.map(w => w.trim()).filter(Boolean);
 
@@ -96,6 +115,14 @@ export const handler: CommandHandler<RunResult> = async (args, flags) => {
     return invalidArgs("--result and --writes require --complete", [
       "Usage: mktg run <skill> --complete [--result success] [--writes path1,path2]",
       "A bare 'mktg run' logs event: loaded — completions must be explicit",
+    ], DOCS.skills);
+  }
+  if (budget !== undefined && (isNaN(budget) || budget < 1)) {
+    return invalidArgs("--budget must be a positive integer", ["Example: mktg run seo-content --with-context --budget 4000"], DOCS.skills);
+  }
+  if (budget !== undefined && !withContext) {
+    return invalidArgs("--budget requires --with-context", [
+      "Usage: mktg run <skill> --with-context --budget 4000",
     ], DOCS.skills);
   }
 
@@ -122,7 +149,9 @@ export const handler: CommandHandler<RunResult> = async (args, flags) => {
     ], DOCS.skills);
   }
 
-  // Check prerequisites (warn but don't block — progressive enhancement)
+  // Check prerequisites (skills, brand files, envs, tools, catalogs).
+  // Default: warn but don't block — progressive enhancement.
+  // --strict: any unsatisfied prerequisite is a hard dependency failure.
   const prerequisites = await checkPrerequisites(resolved.name, flags.cwd, manifest);
   if (ndjson) {
     writeStderr(JSON.stringify({
@@ -133,6 +162,12 @@ export const handler: CommandHandler<RunResult> = async (args, flags) => {
         missing: prerequisites.missing,
       },
     }));
+  }
+  if (strict && !prerequisites.satisfied) {
+    return err("DEPENDENCY_MISSING", `Prerequisites not satisfied for '${resolved.name}' (--strict)`, [
+      ...prerequisites.remediation,
+      "Run without --strict to load anyway (progressive enhancement)",
+    ], 3);
   }
 
   // Read SKILL.md from install directory
@@ -177,6 +212,33 @@ export const handler: CommandHandler<RunResult> = async (args, flags) => {
         "Writes must be existing files inside the project (brand/, marketing/, .mktg/)",
         "Create the files first, then record completion with the same command",
       ], DOCS.skills);
+    }
+  }
+
+  // One-shot activation envelope: compile brand context for this skill.
+  // Declared manifest reads win; layer matrix is the fallback. Template
+  // files are excluded but named in templatesSkipped — nothing is silent.
+  let context: ActivationContext | null = null;
+  if (withContext) {
+    const manifestEntry = manifest.skills[resolved.name]!;
+    const selection = filesForSkillActivation(manifestEntry);
+    const compiled = await compileBrandContext(flags.cwd, {
+      ...(selection.files ? { files: selection.files } : {}),
+      ...(budget !== undefined ? { budget } : {}),
+      excludeTemplates: true,
+    });
+    context = {
+      layer: selection.layer,
+      files: compiled.files,
+      tokenEstimate: compiled.tokenEstimate,
+      budgetDropped: compiled.budgetDropped,
+      templatesSkipped: compiled.templatesSkipped,
+    };
+    if (ndjson) {
+      writeStderr(JSON.stringify({
+        type: "context",
+        data: { skill: resolved.name, layer: context.layer, files: Object.keys(compiled.files), tokenEstimate: compiled.tokenEstimate, budgetDropped: compiled.budgetDropped, templatesSkipped: compiled.templatesSkipped },
+      }));
     }
   }
 
@@ -246,6 +308,7 @@ export const handler: CommandHandler<RunResult> = async (args, flags) => {
     event,
     result: outcome,
     writes: wantComplete ? validatedWrites : null,
+    context,
     priorRuns,
     learningAppended,
   };

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -4,39 +4,51 @@
 import { join } from "node:path";
 import type { CommandHandler, CommandSchema, PrerequisiteStatus } from "../types";
 import { ok } from "../types";
-import { invalidArgs, notFound, DOCS, parseJsonInput, rejectControlChars, validateResourceId } from "../core/errors";
+import { invalidArgs, notFound, DOCS, parseJsonInput, rejectControlChars, validateResourceId, validatePathInput } from "../core/errors";
 import { resolveManifest, getSkill, getSkillsInstallDir } from "../core/skills";
 import { checkPrerequisites } from "../core/skill-lifecycle";
-import { logRun, getLastRun, getRunHistory } from "../core/run-log";
+import { logRun, getLastRun, getRunHistory, isCompletedRecord } from "../core/run-log";
 import { appendLearning, type LearningEntry } from "../core/brand";
 import { writeStderr } from "../core/output";
 
+const VALID_RUN_RESULTS = ["success", "partial", "failed"] as const;
+type RunOutcome = typeof VALID_RUN_RESULTS[number];
+
 export const schema: CommandSchema = {
   name: "run",
-  description: "Load a skill for agent consumption — checks prerequisites, surfaces prior run context, and logs execution",
+  description: "Load a skill for agent consumption — logs a 'loaded' event by default; record real outcomes with --complete so plan/status stay honest",
   positional: { name: "skill", description: "Skill name to run", required: true },
   flags: [
     { name: "--learning", type: "string", required: false, description: "JSON learning entry to append to brand/learnings.md after run" },
+    { name: "--complete", type: "boolean", required: false, description: "Record a completed run (work actually happened) instead of a load event" },
+    { name: "--result", type: "string", required: false, description: "Outcome with --complete: success | partial | failed (default success)" },
+    { name: "--writes", type: "string", required: false, description: "Comma-separated files the agent produced (repeatable); each must exist inside the project" },
     { name: "--ndjson", type: "boolean", required: false, description: "Stream prerequisite check, skill-loaded, and complete events as NDJSON lines to stderr" },
   ],
   output: {
     skill: "string — resolved skill name",
     content: "string — full SKILL.md content",
     prerequisites: "PrerequisiteStatus — prerequisite check results",
-    loggedAt: "string — ISO timestamp of logged run",
-    priorRuns: "object — lastRun timestamp, runCount, and lastResult for this skill",
+    loggedAt: "string | null — ISO timestamp of logged run (null on --dry-run)",
+    event: "'loaded' | 'completed' — what was logged: load events never imply work",
+    result: "'success' | 'partial' | 'failed' | null — outcome with --complete; null on loads",
+    writes: "string[] | null — validated files recorded with --complete; null on loads",
+    priorRuns: "object — lastRun timestamp, lastEvent, runCount, and lastResult for this skill",
     learningAppended: "string | null — the table row appended to learnings.md, or null if --learning not provided",
   },
   examples: [
-    { args: "mktg run seo-content --json", description: "Load SEO content skill for agent" },
+    { args: "mktg run seo-content --json", description: "Load SEO content skill for agent (logs event: loaded)" },
     { args: "mktg run brand-voice --dry-run", description: "Preview without logging" },
+    { args: "mktg run seo-content --complete --writes marketing/content/x.md --result success --json", description: "Record completed work with validated writes" },
+    { args: "mktg skill history seo-content --json", description: "See load vs completion events for a skill" },
     { args: "mktg run seo-content --ndjson", description: "Stream prerequisite, load, and complete events to stderr" },
   ],
-  vocabulary: ["run", "execute", "load skill"],
+  vocabulary: ["run", "execute", "load skill", "complete", "record outcome"],
 };
 
 type PriorRunContext = {
   readonly lastRun: string | null;
+  readonly lastEvent: "loaded" | "completed" | null;
   readonly lastResult: string | null;
   readonly runCount: number;
 };
@@ -46,6 +58,9 @@ type RunResult = {
   readonly content: string;
   readonly prerequisites: PrerequisiteStatus;
   readonly loggedAt: string | null;
+  readonly event: "loaded" | "completed";
+  readonly result: "success" | "partial" | "failed" | null;
+  readonly writes: readonly string[] | null;
   readonly priorRuns: PriorRunContext;
   readonly learningAppended: string | null;
 };
@@ -54,9 +69,34 @@ export const handler: CommandHandler<RunResult> = async (args, flags) => {
   const positionalArgs = args.filter(a => !a.startsWith("--"));
   const skillName = positionalArgs[0];
   const ndjson = args.includes("--ndjson");
+  const wantComplete = args.includes("--complete");
 
   if (!skillName) {
     return invalidArgs("Missing skill name", ["Usage: mktg run <skill-name>", "mktg list --json to see available skills"], DOCS.skills);
+  }
+
+  // Parse --result / --writes (completion-only flags)
+  let resultArg: RunOutcome | undefined;
+  const writesRaw: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i]!;
+    if (a === "--result" && args[i + 1]) { resultArg = args[i + 1] as RunOutcome; i++; }
+    else if (a.startsWith("--result=")) { resultArg = a.slice(9) as RunOutcome; }
+    else if (a === "--writes" && args[i + 1]) { writesRaw.push(...args[i + 1]!.split(",")); i++; }
+    else if (a.startsWith("--writes=")) { writesRaw.push(...a.slice(9).split(",")); }
+  }
+  const writesList = writesRaw.map(w => w.trim()).filter(Boolean);
+
+  if (resultArg !== undefined && !VALID_RUN_RESULTS.includes(resultArg)) {
+    return invalidArgs(`Invalid --result '${resultArg}'`, [
+      `Valid values: ${VALID_RUN_RESULTS.join(" | ")}`,
+    ], DOCS.skills);
+  }
+  if (!wantComplete && (resultArg !== undefined || writesList.length > 0)) {
+    return invalidArgs("--result and --writes require --complete", [
+      "Usage: mktg run <skill> --complete [--result success] [--writes path1,path2]",
+      "A bare 'mktg run' logs event: loaded — completions must be explicit",
+    ], DOCS.skills);
   }
 
   // Lane 1 / Wave A audit fix: every other resource-name command in the
@@ -114,11 +154,38 @@ export const handler: CommandHandler<RunResult> = async (args, flags) => {
   }
   const now = new Date().toISOString();
 
+  // Validate --writes: every path must pass the sandbox pipeline AND exist.
+  // Recording work that didn't happen is the exact lie this command now
+  // exists to prevent — invalid writes fail loudly with fix guidance.
+  const validatedWrites: string[] = [];
+  if (wantComplete && writesList.length > 0) {
+    const writeErrors: string[] = [];
+    for (const w of writesList) {
+      const check = validatePathInput(flags.cwd, w);
+      if (!check.ok) {
+        writeErrors.push(`'${w}': ${check.message}`);
+        continue;
+      }
+      if (!(await Bun.file(check.path).exists())) {
+        writeErrors.push(`'${w}': file does not exist`);
+        continue;
+      }
+      validatedWrites.push(w);
+    }
+    if (writeErrors.length > 0) {
+      return invalidArgs(`Invalid --writes: ${writeErrors.join("; ")}`, [
+        "Writes must be existing files inside the project (brand/, marketing/, .mktg/)",
+        "Create the files first, then record completion with the same command",
+      ], DOCS.skills);
+    }
+  }
+
   // Surface prior run context — agent sees usage history with every load
   const lastRun = await getLastRun(flags.cwd, resolved.name);
   const priorHistory = await getRunHistory(flags.cwd, resolved.name, 10000);
   const priorRuns: PriorRunContext = {
     lastRun: lastRun?.timestamp ?? null,
+    lastEvent: lastRun ? (isCompletedRecord(lastRun) ? "completed" : "loaded") : null,
     lastResult: lastRun?.result ?? null,
     runCount: priorHistory.length,
   };
@@ -157,12 +224,16 @@ export const handler: CommandHandler<RunResult> = async (args, flags) => {
     learningAppended = learningResult.row;
   }
 
-  // Log execution (unless dry-run)
+  // Log the event (unless dry-run). A bare run is a LOAD — never an outcome.
+  // Completions carry the explicit result + validated writes.
+  const event = wantComplete ? "completed" : "loaded";
+  const outcome: RunOutcome | null = wantComplete ? (resultArg ?? "success") : null;
   if (!flags.dryRun) {
     await logRun(flags.cwd, {
       skill: resolved.name,
       timestamp: now,
-      result: "success",
+      event,
+      ...(wantComplete ? { result: outcome ?? "success", writes: validatedWrites } : {}),
       brandFilesChanged: learningAppended ? ["learnings.md"] : [],
     });
   }
@@ -172,12 +243,15 @@ export const handler: CommandHandler<RunResult> = async (args, flags) => {
     content,
     prerequisites,
     loggedAt: flags.dryRun ? null : now,
+    event,
+    result: outcome,
+    writes: wantComplete ? validatedWrites : null,
     priorRuns,
     learningAppended,
   };
 
   if (ndjson) {
-    writeStderr(JSON.stringify({ type: "complete", data: { skill: resolved.name, result: "success" } }));
+    writeStderr(JSON.stringify({ type: "complete", data: { skill: resolved.name, event, ...(outcome ? { result: outcome } : {}) } }));
   }
 
   return ok(result);

--- a/src/commands/skill.ts
+++ b/src/commands/skill.ts
@@ -458,9 +458,12 @@ const handleLog = async (args: readonly string[], flags: { cwd: string; dryRun: 
     ? args[1] as typeof VALID_RESULTS[number]
     : "success";
 
+  // `skill log` records an outcome, so it is always a completed event.
+  // Loads are logged exclusively by `mktg run` (event: "loaded").
   const record = {
     skill: name,
     timestamp: new Date().toISOString(),
+    event: "completed" as const,
     result: resultArg as "success" | "partial" | "failed",
     brandFilesChanged: [] as string[],
   };

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -24,7 +24,7 @@ export const schema: CommandSchema = {
     "agents": "{installed, total} — agent counts",
     "content": "{totalFiles, byDir} — content file counts with breakdown",
     "integrations": "Record<string, IntegrationEntry> — env var readiness for third-party skills",
-    "recentActivity": "Record<string, {lastRun, result, daysSince}> — per-skill execution history",
+    "recentActivity": "Record<string, {lastRun, result|null, event: 'loaded'|'completed', daysSince}> — per-skill run history (loads never imply outcomes)",
     "nextActions": "string[] — prioritized suggestions for what the agent should do next",
     "health": "'ready' | 'incomplete' | 'needs-setup' — overall project marketing readiness",
   },
@@ -64,7 +64,8 @@ type ContentSummary = {
 
 type ActivityEntry = {
   readonly lastRun: string;
-  readonly result: string;
+  readonly result: string | null;
+  readonly event: "loaded" | "completed";
   readonly daysSince: number;
 };
 
@@ -337,8 +338,11 @@ export const handler: CommandHandler<StatusResult> = async (_args, flags) => {
   if (activityKeys.length > 0) {
     lines.push(bold("  Recent Activity") + dim(` ${activityKeys.length} skills run`));
     for (const [skill, activity] of Object.entries(recentActivity).slice(0, 5)) {
-      const icon = activity.result === "success" ? green("●") : activity.result === "partial" ? yellow("●") : red("●");
-      lines.push(`    ${icon} ${skill} ${dim(`(${activity.daysSince}d ago, ${activity.result})`)}`);
+      const icon = activity.event === "loaded"
+        ? dim("○")
+        : activity.result === "success" ? green("●") : activity.result === "partial" ? yellow("●") : red("●");
+      const label = activity.event === "loaded" ? "loaded" : activity.result;
+      lines.push(`    ${icon} ${skill} ${dim(`(${activity.daysSince}d ago, ${label})`)}`);
     }
     if (activityKeys.length > 5) {
       lines.push(dim(`    ... and ${activityKeys.length - 5} more`));

--- a/src/core/catalogs.ts
+++ b/src/core/catalogs.ts
@@ -73,7 +73,7 @@ export const detectAdapterCollisions = (
     seen.set(`publish_adapters:${name}`, ["<builtin>"]);
   }
 
-  const kinds = ["publish_adapters", "scheduling_adapters", "email_adapters"] as const;
+  const kinds = ["publish_adapters", "scheduling_adapters", "email_adapters", "research_adapters"] as const;
   for (const [catName, cat] of Object.entries(manifest.catalogs)) {
     for (const kind of kinds) {
       const adapters = cat.capabilities[kind] ?? [];
@@ -175,7 +175,7 @@ const validateShape = (
     }
     const caps = e.capabilities as Record<string, unknown>;
     let hasAnyAdapter = false;
-    for (const kind of ["publish_adapters", "scheduling_adapters", "email_adapters"] as const) {
+    for (const kind of ["publish_adapters", "scheduling_adapters", "email_adapters", "research_adapters"] as const) {
       const arr = caps[kind];
       if (arr === undefined) continue;
       if (!Array.isArray(arr)) {
@@ -227,6 +227,20 @@ const validateShape = (
     }
     if (auth.header_format !== undefined && auth.header_format !== "bearer" && auth.header_format !== "bare") {
       return { ok: false, detail: "'auth.header_format' must be 'bearer' or 'bare' when present", path: `catalogs.${name}.auth.header_format` };
+    }
+
+    // mcp (optional): { url_env, default_url } — MCP-over-HTTP endpoint contract
+    if (e.mcp !== undefined) {
+      if (e.mcp === null || typeof e.mcp !== "object" || Array.isArray(e.mcp)) {
+        return { ok: false, detail: "'mcp' must be an object", path: `catalogs.${name}.mcp` };
+      }
+      const mcp = e.mcp as Record<string, unknown>;
+      if (typeof mcp.url_env !== "string" || mcp.url_env.length === 0) {
+        return { ok: false, detail: "'mcp.url_env' must be a non-empty string", path: `catalogs.${name}.mcp.url_env` };
+      }
+      if (typeof mcp.default_url !== "string" || !mcp.default_url.startsWith("https://")) {
+        return { ok: false, detail: "'mcp.default_url' must be an https URL", path: `catalogs.${name}.mcp.default_url` };
+      }
     }
   }
 

--- a/src/core/context-compiler.ts
+++ b/src/core/context-compiler.ts
@@ -1,0 +1,179 @@
+// mktg — Brand context compiler (shared core)
+// Token estimation, priority truncation, layer/file selection, template
+// handling. Consumed by `mktg context` (full envelope) and
+// `mktg run <skill> --with-context` (one-shot activation envelope).
+
+import { join } from "node:path";
+import { BRAND_FILES, type BrandFile } from "../types";
+import { isTemplateContent, getBrandStatus, CONTEXT_MATRIX } from "./brand";
+
+// Token estimation: ~4 chars per token
+export const estimateTokens = (text: string): number => Math.ceil(text.length / 4);
+
+// Truncate content to fit a token budget, preserving leading lines
+export const truncateToTokens = (content: string, maxTokens: number): { text: string; truncated: boolean } => {
+  if (estimateTokens(content) <= maxTokens) return { text: content, truncated: false };
+  const charBudget = maxTokens * 4;
+  const truncated = content.slice(0, charBudget);
+  // Cut at last newline to avoid mid-line truncation
+  const lastNewline = truncated.lastIndexOf("\n");
+  const text = lastNewline > 0 ? truncated.slice(0, lastNewline) + "\n[...truncated]" : truncated + "\n[...truncated]";
+  return { text, truncated: true };
+};
+
+// Priority order for truncation — most important files first
+export const FILE_PRIORITY: readonly BrandFile[] = [
+  "voice-profile.md",
+  "positioning.md",
+  "audience.md",
+  "competitors.md",
+  "landscape.md",
+  "keyword-plan.md",
+  "creative-kit.md",
+  "stack.md",
+  "assets.md",
+  "learnings.md",
+];
+
+export const CONTEXT_LAYERS = Object.keys(CONTEXT_MATRIX) as (keyof typeof CONTEXT_MATRIX)[];
+
+export type ContextFileEntry = {
+  readonly content: string;
+  readonly tokens: number;
+  readonly truncated: boolean;
+  readonly freshness: string;
+};
+
+export type CompiledContext = {
+  readonly files: Record<string, ContextFileEntry>;
+  readonly tokenEstimate: number;
+  /** Files dropped entirely because the budget ran out (structured signal). */
+  readonly budgetDropped: readonly string[];
+  /** Existing template files excluded from output (only when excludeTemplates). */
+  readonly templatesSkipped: readonly string[];
+  readonly summary: {
+    readonly totalFiles: number;
+    readonly populatedFiles: number;
+    readonly templateFiles: number;
+    readonly staleFiles: number;
+  };
+};
+
+export type CompileContextOptions = {
+  /** CONTEXT_MATRIX layer name. Ignored when `files` is set. */
+  readonly layer?: string;
+  /** Explicit brand-file selection (wins over layer). */
+  readonly files?: readonly BrandFile[];
+  /** Approximate token budget — truncates files by FILE_PRIORITY. */
+  readonly budget?: number;
+  /** Exclude template-content files from output (reported in templatesSkipped). */
+  readonly excludeTemplates?: boolean;
+};
+
+export const compileBrandContext = async (
+  cwd: string,
+  options: CompileContextOptions = {},
+): Promise<CompiledContext> => {
+  const { layer, files, budget, excludeTemplates = false } = options;
+
+  const targetFiles: readonly BrandFile[] = files
+    ?? (layer ? CONTEXT_MATRIX[layer as keyof typeof CONTEXT_MATRIX] : BRAND_FILES);
+
+  const brandStatuses = await getBrandStatus(cwd);
+  const statusMap = new Map(brandStatuses.map(s => [s.file, s]));
+
+  const brandDir = join(cwd, "brand");
+  const fileEntries: [string, ContextFileEntry][] = [];
+  const templatesSkipped: string[] = [];
+  let totalPopulated = 0;
+  let totalTemplate = 0;
+  let totalStale = 0;
+
+  for (const file of targetFiles) {
+    const status = statusMap.get(file);
+    if (!status || !status.exists) continue;
+
+    const filePath = join(brandDir, file);
+    try {
+      const content = await Bun.file(filePath).text();
+      const isTemplate = isTemplateContent(file, content);
+      const freshness = isTemplate ? "template" : status.freshness;
+
+      if (isTemplate) {
+        totalTemplate++;
+        if (excludeTemplates) {
+          templatesSkipped.push(file);
+          continue;
+        }
+      } else {
+        totalPopulated++;
+      }
+      if (status.freshness === "stale") totalStale++;
+
+      const entry: ContextFileEntry = {
+        content,
+        tokens: estimateTokens(content),
+        truncated: false,
+        freshness,
+      };
+      fileEntries.push([file, entry]);
+    } catch { /* skip unreadable files */ }
+  }
+
+  const budgetDropped: string[] = [];
+  if (budget !== undefined && budget > 0) {
+    const priorityOrder = new Map(FILE_PRIORITY.map((f, i) => [f, i]));
+    fileEntries.sort((a, b) => (priorityOrder.get(a[0] as BrandFile) ?? 99) - (priorityOrder.get(b[0] as BrandFile) ?? 99));
+
+    let remainingTokens = budget;
+    for (let i = 0; i < fileEntries.length; i++) {
+      const [name, entry] = fileEntries[i]!;
+      if (remainingTokens <= 0) {
+        fileEntries[i] = [name, { content: "[...truncated — budget exceeded]", tokens: 0, truncated: true, freshness: entry.freshness }];
+        budgetDropped.push(name);
+        continue;
+      }
+      const { text, truncated } = truncateToTokens(entry.content, remainingTokens);
+      const tokens = estimateTokens(text);
+      remainingTokens -= tokens;
+      fileEntries[i] = [name, { content: text, tokens, truncated, freshness: entry.freshness }];
+    }
+  }
+
+  const filesOut = Object.fromEntries(fileEntries);
+  const tokenEstimate = fileEntries.reduce((sum, [, e]) => sum + e.tokens, 0);
+
+  return {
+    files: filesOut,
+    tokenEstimate,
+    budgetDropped,
+    templatesSkipped,
+    summary: {
+      totalFiles: fileEntries.length,
+      populatedFiles: totalPopulated,
+      templateFiles: totalTemplate,
+      staleFiles: totalStale,
+    },
+  };
+};
+
+/**
+ * Select context files for a skill's activation envelope:
+ * declared manifest reads win; orchestrators and unknown layers get the
+ * full matrix; everything else maps 1:1 to a CONTEXT_MATRIX layer.
+ */
+export const filesForSkillActivation = (entry: {
+  readonly layer: string;
+  readonly reads: readonly string[];
+}): { files: readonly BrandFile[] | undefined; layer: string } => {
+  const readFiles = entry.reads
+    .map(f => f.replace(/^brand\//, ""))
+    .filter((f): f is BrandFile => (BRAND_FILES as readonly string[]).includes(f));
+  if (readFiles.length > 0) {
+    return { files: readFiles, layer: "reads" };
+  }
+  if (entry.layer === "orchestrator" || !(entry.layer in CONTEXT_MATRIX)) {
+    return { files: undefined, layer: "all" };
+  }
+  return { files: CONTEXT_MATRIX[entry.layer as keyof typeof CONTEXT_MATRIX], layer: entry.layer };
+};

--- a/src/core/run-log.ts
+++ b/src/core/run-log.ts
@@ -9,7 +9,8 @@ const LOG_FILE = ".mktg/runs.jsonl";
 
 export type RunSummaryEntry = {
   readonly lastRun: string;
-  readonly result: string;
+  readonly result: string | null;
+  readonly event: "loaded" | "completed";
   readonly runCount: number;
   readonly daysSince: number;
 };
@@ -20,8 +21,25 @@ export type RunStats = {
   readonly successCount: number;
   readonly failedCount: number;
   readonly partialCount: number;
+  readonly loadedCount: number;
+  readonly completedCount: number;
   readonly successRate: number;
 };
+
+export type RunHistoryFilter = {
+  /** Keep only records that represent completed work (see isCompletedRecord). */
+  readonly completedOnly?: boolean;
+};
+
+/**
+ * Dual-read: an explicit event field wins. Pre-event records are legacy —
+ * only those with real brand writes count as completed work; legacy
+ * result:"success" records with empty writes were load-only and must NOT
+ * unlock downstream plan/distribute steps.
+ */
+export const isCompletedRecord = (record: SkillRunRecord): boolean =>
+  record.event === "completed" ||
+  (record.event === undefined && record.brandFilesChanged.length > 0);
 
 export const logRun = async (
   cwd: string,
@@ -50,12 +68,14 @@ export const getRunHistory = async (
   cwd: string,
   skillName?: string,
   limit: number = 50,
+  filter?: RunHistoryFilter,
 ): Promise<SkillRunRecord[]> => {
   const logPath = join(cwd, LOG_FILE);
   try {
     const content = await readFile(logPath, "utf-8");
     let records = parseJsonl(content);
     if (skillName) records = records.filter(r => r.skill === skillName);
+    if (filter?.completedOnly) records = records.filter(isCompletedRecord);
     return records.slice(-limit).reverse(); // Most recent first
   } catch {
     return []; // No log file yet
@@ -72,8 +92,9 @@ export const getLastRun = async (
 
 export const getRunSummary = async (
   cwd: string,
+  filter?: RunHistoryFilter,
 ): Promise<Record<string, RunSummaryEntry>> => {
-  const history = await getRunHistory(cwd, undefined, 1000);
+  const history = await getRunHistory(cwd, undefined, 1000, filter);
   const summary: Record<string, RunSummaryEntry> = {};
   // history is most-recent-first, so count all but only take metadata from first seen
   const counts: Record<string, number> = {};
@@ -81,7 +102,13 @@ export const getRunSummary = async (
     counts[record.skill] = (counts[record.skill] ?? 0) + 1;
     if (!summary[record.skill]) {
       const daysSince = Math.floor((Date.now() - new Date(record.timestamp).getTime()) / (1000 * 60 * 60 * 24));
-      summary[record.skill] = { lastRun: record.timestamp, result: record.result, runCount: 0, daysSince };
+      summary[record.skill] = {
+        lastRun: record.timestamp,
+        result: record.result ?? null,
+        event: isCompletedRecord(record) ? "completed" : "loaded",
+        runCount: 0,
+        daysSince,
+      };
     }
   }
   // Fill in counts
@@ -96,15 +123,21 @@ export const getRunStats = async (
 ): Promise<RunStats> => {
   const history = await getRunHistory(cwd, undefined, 10000);
   const skills = new Set(history.map(r => r.skill));
-  const successCount = history.filter(r => r.result === "success").length;
-  const failedCount = history.filter(r => r.result === "failed").length;
-  const partialCount = history.filter(r => r.result === "partial").length;
+  // Result counts cover only records that carry an outcome (completed runs
+  // and pre-event legacy records). Load events have no result by design.
+  const outcomeRecords = history.filter(r => r.result !== undefined);
+  const successCount = outcomeRecords.filter(r => r.result === "success").length;
+  const failedCount = outcomeRecords.filter(r => r.result === "failed").length;
+  const partialCount = outcomeRecords.filter(r => r.result === "partial").length;
+  const completedCount = history.filter(isCompletedRecord).length;
   return {
     totalRuns: history.length,
     uniqueSkills: skills.size,
     successCount,
     failedCount,
     partialCount,
-    successRate: history.length > 0 ? Math.round((successCount / history.length) * 100) : 0,
+    loadedCount: history.length - completedCount,
+    completedCount,
+    successRate: outcomeRecords.length > 0 ? Math.round((successCount / outcomeRecords.length) * 100) : 0,
   };
 };

--- a/src/core/skill-lifecycle.ts
+++ b/src/core/skill-lifecycle.ts
@@ -7,6 +7,8 @@ import { homedir } from "node:os";
 import { isTemplateContent } from "./brand";
 import { sandboxPath } from "./errors";
 import { getPackageRoot } from "./paths";
+import { loadCatalogManifest, computeConfiguredStatus } from "./catalogs";
+import { toolAvailable, toolInstallHint } from "./tool-registry";
 import type {
   BrandFile,
   BRAND_FILES,
@@ -346,13 +348,16 @@ export const checkPrerequisites = async (
   if (!entry) {
     return {
       satisfied: false,
-      missing: { skills: [], brandFiles: [] },
+      missing: { skills: [], brandFiles: [], envs: [], tools: [], catalogs: [] },
       remediation: [`Skill '${skillName}' not found in manifest`],
     };
   }
 
   const missingSkills: string[] = [];
   const missingBrandFiles: BrandFile[] = [];
+  const missingEnvs: string[] = [];
+  const missingTools: string[] = [];
+  const missingCatalogs: string[] = [];
   const remediation: string[] = [];
 
   // Check depends_on skills are installed
@@ -400,9 +405,51 @@ export const checkPrerequisites = async (
     }
   }
 
+  // Check manifest-declared env vars (shared with doctor's integration checks)
+  for (const envVar of entry.env_vars ?? []) {
+    if (!process.env[envVar] && !missingEnvs.includes(envVar)) {
+      missingEnvs.push(envVar);
+      remediation.push(`Set ${envVar} — mktg doctor shows integration status + signup links`);
+    }
+  }
+
+  // Check manifest-declared CLI tools against the shared tool registry —
+  // remediation strings are byte-identical to doctor's install hints.
+  for (const tool of entry.tools ?? []) {
+    if (!toolAvailable(tool) && !missingTools.includes(tool)) {
+      missingTools.push(tool);
+      const hint = toolInstallHint(tool);
+      remediation.push(hint ? `Install ${tool}: ${hint}` : `Install ${tool} (see mktg doctor)`);
+    }
+  }
+
+  // Check catalogs that claim this skill (e.g. postiz → postiz skill).
+  // Env gaps merge into missing.envs (deduped); the catalog itself is named
+  // so agents can route to `mktg catalog info <name>`.
+  const catalogResult = await loadCatalogManifest();
+  if (catalogResult.ok) {
+    for (const catalog of Object.values(catalogResult.manifest.catalogs)) {
+      if (!catalog.skills.includes(skillName)) continue;
+      const status = computeConfiguredStatus(catalog);
+      if (status.configured) continue;
+      if (!missingCatalogs.includes(catalog.name)) missingCatalogs.push(catalog.name);
+      for (const envVar of status.missingEnvs) {
+        if (!missingEnvs.includes(envVar)) {
+          missingEnvs.push(envVar);
+          remediation.push(`Set ${envVar} for catalog '${catalog.name}' — mktg catalog info ${catalog.name} --json --fields missing_envs`);
+        }
+      }
+    }
+  }
+
   return {
-    satisfied: missingSkills.length === 0 && missingBrandFiles.length === 0,
-    missing: { skills: missingSkills, brandFiles: missingBrandFiles },
+    satisfied:
+      missingSkills.length === 0 &&
+      missingBrandFiles.length === 0 &&
+      missingEnvs.length === 0 &&
+      missingTools.length === 0 &&
+      missingCatalogs.length === 0,
+    missing: { skills: missingSkills, brandFiles: missingBrandFiles, envs: missingEnvs, tools: missingTools, catalogs: missingCatalogs },
     remediation,
   };
 };

--- a/src/core/tool-registry.ts
+++ b/src/core/tool-registry.ts
@@ -1,0 +1,30 @@
+// mktg — Canonical CLI tool registry
+// Single source for doctor's ecosystem checks AND skill prerequisite
+// resolution, so remediation strings never drift between the two.
+
+export type ToolRegistryEntry = {
+  readonly name: string;
+  readonly required: boolean;
+  readonly installHint?: string;
+};
+
+export const TOOL_REGISTRY: readonly ToolRegistryEntry[] = [
+  { name: "bun", required: true, installHint: "curl -fsSL https://bun.sh/install | bash" },
+  { name: "gws", required: false, installHint: "npm i -g gws" },
+  { name: "playwright-cli", required: false, installHint: "npm i -g @playwright/cli" },
+  { name: "ffmpeg", required: false, installHint: "brew install ffmpeg" },
+  { name: "remotion", required: false, installHint: "npm i -g @remotion/cli" },
+  { name: "firecrawl", required: false, installHint: "npm i -g firecrawl" },
+  { name: "whisper-cpp", required: false, installHint: "brew install whisper-cpp" },
+  { name: "yt-dlp", required: false, installHint: "brew install yt-dlp" },
+  { name: "summarize", required: false, installHint: "npm i -g @steipete/summarize" },
+  { name: "gh", required: false, installHint: "brew install gh" },
+  { name: "gh-axi", required: false, installHint: "npm i -g gh-axi   # or: npx -y gh-axi  (see /axi)" },
+  { name: "chrome-devtools-axi", required: false, installHint: "npm i -g chrome-devtools-axi   # or: npx -y chrome-devtools-axi  (see /axi)" },
+  { name: "higgsfield", required: false, installHint: "npm i -g @higgsfield/cli && higgsfield auth login" },
+] as const;
+
+export const toolInstallHint = (name: string): string | undefined =>
+  TOOL_REGISTRY.find(t => t.name === name)?.installHint;
+
+export const toolAvailable = (name: string): boolean => Bun.which(name) !== null;

--- a/src/dashboard-contract.ts
+++ b/src/dashboard-contract.ts
@@ -226,7 +226,8 @@ export type DashboardRunEvent = {
   readonly id: string;
   readonly timestamp: string;
   readonly skill: string;
-  readonly result: string;
+  readonly event: "loaded" | "completed";
+  readonly result: string | null;
   readonly summary: string;
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -245,6 +245,20 @@ export type CatalogCapabilities = {
   readonly publish_adapters?: readonly string[];
   readonly scheduling_adapters?: readonly string[];
   readonly email_adapters?: readonly string[];
+  /** Research/data-plane adapters (SEO metrics, SERP, backlinks, …). */
+  readonly research_adapters?: readonly string[];
+};
+
+/**
+ * Optional MCP endpoint contract for catalogs whose agent surface is an
+ * MCP server (e.g. OpenSEO). `transport` stays "http" — MCP rides over
+ * HTTP; no new transport value is introduced.
+ */
+export type CatalogMcp = {
+  /** Env var agents read for the MCP URL (self-host override). */
+  readonly url_env: string;
+  /** Hosted default MCP URL (https). */
+  readonly default_url: string;
 };
 
 export type CatalogEntry = {
@@ -258,6 +272,7 @@ export type CatalogEntry = {
   readonly sdk_reference: string | null;
   readonly auth: CatalogAuth;
   readonly skills: readonly string[];
+  readonly mcp?: CatalogMcp;
 };
 
 export type CatalogsManifest = {
@@ -266,7 +281,7 @@ export type CatalogsManifest = {
 };
 
 export type CatalogCollision = {
-  readonly kind: "publish_adapters" | "scheduling_adapters" | "email_adapters";
+  readonly kind: "publish_adapters" | "scheduling_adapters" | "email_adapters" | "research_adapters";
   readonly adapter: string;
   readonly declaredBy: readonly string[];
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -168,6 +168,8 @@ export type SkillManifestEntry = {
   readonly review_interval_days: number;
   readonly version?: string; // semver string for per-skill versioning
   readonly env_vars?: readonly string[];
+  /** CLI tools (from core/tool-registry) this skill shells out to. */
+  readonly tools?: readonly string[];
   readonly routing?: SkillRoutingEntry; // Optional CMO routing metadata
 };
 
@@ -353,6 +355,12 @@ export type PrerequisiteStatus = {
   readonly missing: {
     readonly skills: readonly string[];
     readonly brandFiles: readonly BrandFile[];
+    /** Manifest-declared env vars absent from process.env. */
+    readonly envs: readonly string[];
+    /** Manifest-declared CLI tools not found on PATH. */
+    readonly tools: readonly string[];
+    /** Catalogs backing this skill that are not fully configured. */
+    readonly catalogs: readonly string[];
   };
   readonly remediation: readonly string[];
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,6 +35,21 @@ export type CommandResult<T = unknown> =
 
 export type PublishPostType = "draft" | "schedule" | "now" | "update";
 
+/**
+ * Per-item publish truth. Every adapter maps its outcome to exactly one:
+ * - "queued-local"   — written to the local mktg-native queue (.mktg/native-publish/)
+ * - "draft-external" — draft created on an external service (Typefully, postiz)
+ * - "sent"           — confirmed sent/scheduled on an external network (Resend)
+ * - "written-file"   — file adapter output under .mktg/published/
+ * - "failed"         — adapter rejected the item (detail carries why)
+ * - "skipped"        — dry-run preview or idempotency skip
+ * Local queue writes NEVER report "sent"; external drafts NEVER report "sent".
+ */
+export type PublishItemStatus = "queued-local" | "draft-external" | "sent" | "written-file" | "failed" | "skipped";
+
+/** Statuses that count as terminal adapter success (drives `published` counts). */
+export const TERMINAL_PUBLISH_STATUSES: readonly PublishItemStatus[] = ["queued-local", "draft-external", "sent", "written-file"];
+
 // Result constructors
 export const ok = <T>(data: T, display?: string): CommandResult<T> => ({
   ok: true,

--- a/src/types.ts
+++ b/src/types.ts
@@ -429,10 +429,21 @@ export type SkillEvaluation = {
 };
 
 // Skill execution history
+export type SkillRunEvent = "loaded" | "completed";
+
 export type SkillRunRecord = {
   readonly skill: string;
   readonly timestamp: string; // ISO 8601
-  readonly result: "success" | "partial" | "failed";
+  /**
+   * What actually happened. "loaded" = SKILL.md was read for the agent
+   * (no work implied). "completed" = the agent reported an outcome.
+   * Absent in pre-event records — treat via isCompletedRecord() dual-read.
+   */
+  readonly event?: SkillRunEvent;
+  /** Outcome of a completed run. Absent on load events — a load is not a success. */
+  readonly result?: "success" | "partial" | "failed";
+  /** Files the agent produced, recorded at --complete time (validated to exist). */
+  readonly writes?: readonly string[];
   readonly brandFilesChanged: readonly string[];
   readonly durationMs?: number;
   readonly note?: string;

--- a/studio/CLAUDE.md
+++ b/studio/CLAUDE.md
@@ -4,7 +4,7 @@
 
 ## Driver/Dashboard Contract
 
-- **Driver:** /cmo (Claude Code) runs in the user's terminal. It reads brand/ files, executes the 63 marketing skills, and calls the studio's HTTP API (POST `/api/activity/log`, `/api/navigate`, `/api/toast`, `/api/brand/refresh`, etc.) to keep the dashboard in sync.
+- **Driver:** /cmo (Claude Code) runs in the user's terminal. It reads brand/ files, executes the 64 marketing skills, and calls the studio's HTTP API (POST `/api/activity/log`, `/api/navigate`, `/api/toast`, `/api/brand/refresh`, etc.) to keep the dashboard in sync.
 - **Dashboard:** Next.js + Bun server. Subscribes to `/api/events` (SSE) for live updates. Renders primary surfaces (Pulse, Signals, Publish, Brand, Settings) + a right-hand Activity panel that shows the /cmo activity stream. Trend radar is a Signals mode; Audience summary and next actions live on Pulse.
 - **Activity panel:** Replaces the old chat slot. Lists skill runs, brand writes, publishes, navigates, and toasts  -  a live log of what /cmo is doing.
 - **AGPL firewall:** Never import `@postiz/*`. Raw fetch only over the network boundary.
@@ -115,7 +115,7 @@ This project follows the same agent-native contract as mktg itself:
 ┌──────────────────┐ ┌──────────────────┐ ┌──────────────────────────┐
 │ Next.js 16 │────▶│ Bun.serve │────▶│ Claude Code (local) │
 │ Dashboard │◀─SSE│ (local server) │ │ ├── /cmo skill │
-│ │ │ SQLite │ │ ├── 63 marketing skills │
+│ │ │ SQLite │ │ ├── 64 marketing skills │
 │ 5 surfaces + │ │ brand/ watcher │ │ ├── mktg CLI (--json) │
 │ Activity panel │ │ Job queue │ │ └── Postiz adapter │
 └──────────────────┘ └──────────────────┘ └──────────────────────────┘
@@ -182,7 +182,7 @@ Tests: 2599 pass / 0 fail / 96 files
 │ └── transcribe.ts  -  whisper.cpp + yt-dlp + ffmpeg orchestration
 ├── skills/  -  50 SKILL.md files (see §Skills below)
 ├── agents/ - 6 agent .md files (see §Agents below)
-├── skills-manifest.json  -  64 skills: triggers, categories, layers, reads, writes, env_vars
+├── skills-manifest.json  -  65 skills: triggers, categories, layers, reads, writes, env_vars
 ├── agents-manifest.json - 6 agents: categories, files, reads, writes, tier
 ├── catalogs-manifest.json  -  1 catalog (postiz): capabilities, auth, transport, license
 ├── brand/SCHEMA.md  -  schema for all 10 brand files
@@ -258,7 +258,7 @@ Rules: ~/projects/mktgmono/marketing-cli/skills/cmo/rules/ (14 files, ~1,900 lin
 ```
 
 **What /cmo knows:**
-- Routes to any of 64 skills based on user intent + brand state
+- Routes to any of 65 skills based on user intent + brand state
 - 10 named orchestration playbooks (Full Product Launch, Content Engine, Founder Voice Rebrand, Conversion Audit, Retention Recovery, Visual Identity, Video Content, Email Infrastructure, SEO Authority Build, Newsletter Launch)
 - L0-L4 progressive enhancement ladder (what's possible at each brand completeness level)
 - Error recovery + degraded-mode playbook (what to do when integrations fail)
@@ -611,7 +611,7 @@ components/workspace/skill-browser/  -  skill browser + execution trigger UI
 - Port signal severity + spike detection from Convex to local TypeScript
 
 ### Phase 5: Skill Browser + Onboarding (2-3 days)
-- Skill browser: `mktg list --json` → browse all 64 skills, one-click trigger
+- Skill browser: `mktg list --json` → browse all 65 skills, one-click trigger
 - Execution progress: running → result → files changed
 - Onboarding: detect fresh install (mktg status → needs-setup) → wizard → mktg init → foundation skills
 - First-run "wow moment": Pulse, Signals, Publish, Brand, and Settings populate as foundation skills complete
@@ -631,7 +631,7 @@ components/workspace/skill-browser/  -  skill browser + execution trigger UI
 >
 > **Dashboard layer (this repo)**: 5 workspace tabs (Pulse, Signals, Publish, Brand, Settings), Activity panel, signal severity scoring. Local-first  -  no cloud dependencies.
 >
-> **mktg** is the marketing brain  -  64 skills, /cmo orchestrator (2,400 lines of routing knowledge), brand memory (10 files that compound), upstream catalogs. This is the engine. Everything runs through `mktg --json` for infrastructure and /cmo for intelligence.
+> **mktg** is the marketing brain  -  65 skills, /cmo orchestrator (2,400 lines of routing knowledge), brand memory (10 files that compound), upstream catalogs. This is the engine. Everything runs through `mktg --json` for infrastructure and /cmo for intelligence.
 >
 > **postiz** is the distribution layer  -  30+ social providers via REST API. AGPL-firewalled. Call it, never fork it.
 >

--- a/studio/README.md
+++ b/studio/README.md
@@ -2,7 +2,7 @@
 
 > The visual layer that ships inside [`marketing-cli`](https://www.npmjs.com/package/marketing-cli). Your brand memory on disk, one agent running the show.
 
-Studio is the dashboard companion to the `mktg` CLI. The CLI ships the brain: 63 marketing skills + the `/cmo` orchestrator. Studio ships the eyes: a Next.js dashboard, a local Bun API, SQLite, live SSE, and a 21/21 agent-DX HTTP surface that `/cmo` drives via Bash + curl. No SDK, no MCP config. Claude Code already has `Bash`; that's the whole contract.
+Studio is the dashboard companion to the `mktg` CLI. The CLI ships the brain: 64 marketing skills + the `/cmo` orchestrator. Studio ships the eyes: a Next.js dashboard, a local Bun API, SQLite, live SSE, and a 21/21 agent-DX HTTP surface that `/cmo` drives via Bash + curl. No SDK, no MCP config. Claude Code already has `Bash`; that's the whole contract.
 
 Studio lives under `studio/` inside the `marketing-cli` repo as a bun-workspace member. It is not a separate package. Installing the CLI brings the launcher with it.
 
@@ -11,7 +11,7 @@ Studio lives under `studio/` inside the `marketing-cli` repo as a bun-workspace 
 ## Quick start
 
 ```bash
-npm i -g marketing-cli         # CLI + /cmo + 64 skills + studio launcher
+npm i -g marketing-cli         # CLI + /cmo + 65 skills + studio launcher
 mktg init                      # seed brand/*.md in the current project
 mktg studio                    # boot API (:3001) + dashboard (:3000)
 ```

--- a/studio/app/layout.tsx
+++ b/studio/app/layout.tsx
@@ -35,7 +35,7 @@ export const metadata: Metadata = {
     template: "%s | mktg studio",
   },
   description:
-    "Local-first marketing studio powered by /cmo -- 64 skills, brand intelligence, and social distribution in one dashboard.",
+    "Local-first marketing studio powered by /cmo -- 65 skills, brand intelligence, and social distribution in one dashboard.",
 }
 
 export default function RootLayout({

--- a/studio/components/workspace/publish/scheduled-queue.tsx
+++ b/studio/components/workspace/publish/scheduled-queue.tsx
@@ -247,7 +247,7 @@ function StatusChip({ status, adapter }: { status: string; adapter: string }) {
 
 // CLI publish-truth parity: the native backend is a LOCAL workspace queue
 // (.mktg/native-publish/). Its internal draft/scheduled/published states all
-// mean "written locally" — the chip must never imply a network send.
+// mean "written locally" - the chip must never imply a network send.
 // Mirrors PublishItemStatus in src/types.ts.
 function displayStatus(status: string, adapter: string): string {
   if (adapter === "mktg-native") {

--- a/studio/components/workspace/publish/scheduled-queue.tsx
+++ b/studio/components/workspace/publish/scheduled-queue.tsx
@@ -138,7 +138,7 @@ export function ScheduledQueue({
         ) : (
           <ul className="space-y-2">
             {posts.map((post) => (
-              <ScheduledPostRow key={post.id} post={post} />
+              <ScheduledPostRow key={post.id} post={post} adapter={adapter} />
             ))}
           </ul>
         )}
@@ -147,7 +147,7 @@ export function ScheduledQueue({
   )
 }
 
-function ScheduledPostRow({ post }: { post: ScheduledPost }) {
+function ScheduledPostRow({ post, adapter }: { post: ScheduledPost; adapter: string }) {
   const firstPost = post.posts?.[0]
   const firstPart = firstPost?.value?.[0]
   const content = firstPart?.content ?? ""
@@ -196,7 +196,7 @@ function ScheduledPostRow({ post }: { post: ScheduledPost }) {
             </div>
           )}
           <div className="mt-1.5 flex flex-wrap items-center gap-1.5 text-[10px] text-muted-foreground">
-            <StatusChip status={status} />
+            <StatusChip status={status} adapter={adapter} />
             <span title={post.date}>{relative}</span>
             {previewProviders.length > 0 && (
               <span className="flex items-center gap-1">
@@ -226,8 +226,9 @@ function isImageAsset(path: string): boolean {
   return /\.(png|jpe?g|webp|gif|svg|avif)$/i.test(path)
 }
 
-function StatusChip({ status }: { status: string }) {
-  const tone = statusTone(status)
+function StatusChip({ status, adapter }: { status: string; adapter: string }) {
+  const label = displayStatus(status, adapter)
+  const tone = statusTone(label)
   return (
     <span
       className={cn(
@@ -235,19 +236,35 @@ function StatusChip({ status }: { status: string }) {
         tone === "draft" && "border-muted text-muted-foreground",
         tone === "scheduled" && "border-blue-500/30 bg-blue-500/10 text-blue-700 dark:text-blue-300",
         tone === "published" && "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+        tone === "queued-local" && "border-sky-500/30 bg-sky-500/10 text-sky-700 dark:text-sky-300",
         tone === "failed" && "border-red-500/30 bg-red-500/10 text-red-700 dark:text-red-300",
       )}
     >
-      {status}
+      {label}
     </span>
   )
 }
 
-function statusTone(status: string): "draft" | "scheduled" | "published" | "failed" {
+// CLI publish-truth parity: the native backend is a LOCAL workspace queue
+// (.mktg/native-publish/). Its internal draft/scheduled/published states all
+// mean "written locally" — the chip must never imply a network send.
+// Mirrors PublishItemStatus in src/types.ts.
+function displayStatus(status: string, adapter: string): string {
+  if (adapter === "mktg-native") {
+    const s = status.toLowerCase()
+    if (s.includes("fail") || s.includes("error")) return "failed"
+    if (s.includes("draft")) return "queued-local (draft)"
+    return "queued-local"
+  }
+  return status
+}
+
+function statusTone(status: string): "draft" | "scheduled" | "published" | "queued-local" | "failed" {
   const s = status.toLowerCase()
-  if (s.includes("publish")) return "published"
+  if (s.includes("queued-local")) return "queued-local"
   if (s.includes("fail") || s.includes("error")) return "failed"
   if (s.includes("draft")) return "draft"
+  if (s.includes("publish")) return "published"
   return "scheduled"
 }
 

--- a/tests/e2e/release/tarball.test.ts
+++ b/tests/e2e/release/tarball.test.ts
@@ -175,18 +175,24 @@ describe("e2e: forbidden paths do not ship", () => {
 // ===========================================================================
 
 describe("e2e: published package.json description carries canonical skill count", () => {
-  test("package.json description references 64 (canonical total)", () => {
+  // Canonical total is derived from the manifest — never hardcode a count here.
+  const canonicalTotal = Object.keys(
+    JSON.parse(readFileSync(join(PROJECT_ROOT, "skills-manifest.json"), "utf-8")).skills,
+  ).length;
+  const canonicalMarketing = canonicalTotal - 1;
+
+  test("package.json description references the canonical total", () => {
     // npm pack --json reports the file list but not contents; read the
     // working-tree package.json which the publish would have used.
     const pkg = JSON.parse(readFileSync(join(PROJECT_ROOT, "package.json"), "utf-8")) as {
       description: string;
     };
-    expect(pkg.description).toContain("64");
+    expect(pkg.description).toContain(String(canonicalTotal));
     expect(pkg.description).not.toContain("51 skills");
     expect(pkg.description).not.toContain("50 skills");
   });
 
-  test("all 4 plugin manifest descriptions reference 64", () => {
+  test("all 4 plugin manifest descriptions reference the canonical total", () => {
     const claude = JSON.parse(readFileSync(join(PROJECT_ROOT, ".claude-plugin/plugin.json"), "utf-8")) as {
       description: string;
     };
@@ -202,10 +208,10 @@ describe("e2e: published package.json description carries canonical skill count"
     };
 
     for (const desc of [claude.description, marketplace.plugins[0]!.description, codex.description, gemini.description]) {
-      expect(desc).toContain("64");
+      expect(desc).toContain(String(canonicalTotal));
       expect(desc).not.toContain("51 skills");
       expect(desc).not.toContain("50 skills");
     }
-    expect(codex.interface.longDescription).toContain("63 marketing skills");
+    expect(codex.interface.longDescription).toContain(`${canonicalMarketing} marketing skills`);
   });
 });

--- a/tests/e2e/skills/all-skills-run.test.ts
+++ b/tests/e2e/skills/all-skills-run.test.ts
@@ -85,8 +85,8 @@ const manifest: SkillsManifest = await Bun.file(manifestPath).json();
 const skillNames = Object.keys(manifest.skills);
 
 describe("E2E: catalog totals", () => {
-  test("manifest contains 64 skills (catalog total)", () => {
-    expect(skillNames.length).toBe(64);
+  test("manifest contains the full skill catalog (count read from manifest, never hardcoded)", () => {
+    expect(skillNames.length).toBeGreaterThanOrEqual(64);
   });
 
   test("Tier 2 set is the 12 documented external-API skills", () => {

--- a/tests/integration/catalog-manifest.test.ts
+++ b/tests/integration/catalog-manifest.test.ts
@@ -128,6 +128,88 @@ describe("detectLicenseDenials — copyleft + transport gate", () => {
 });
 
 // =========================================================================
+// research_adapters capability + mcp block (OpenSEO Phase 1)
+// =========================================================================
+
+describe("research_adapters capability family", () => {
+  test("research_adapters collisions are detected across catalogs", () => {
+    const manifest: CatalogsManifest = {
+      version: 1,
+      catalogs: {
+        openseo: makeEntry("openseo", { capabilities: { research_adapters: ["openseo"] } }),
+        copycat: makeEntry("copycat", { capabilities: { research_adapters: ["openseo"] } }),
+      },
+    };
+    const collisions = detectAdapterCollisions(manifest, { publish_adapters: [] });
+    expect(collisions).toHaveLength(1);
+    expect(collisions[0]).toMatchObject({ kind: "research_adapters", adapter: "openseo" });
+  });
+
+  test("shipped manifest includes the openseo research catalog with mcp contract", async () => {
+    const result = await loadCatalogManifest();
+    if (!result.ok) throw new Error("shipped manifest failed to load");
+    const openseo = result.manifest.catalogs["openseo"];
+    expect(openseo).toBeDefined();
+    expect(openseo!.license).toBe("MIT");
+    expect(openseo!.transport).toBe("http");
+    expect(openseo!.capabilities.research_adapters).toEqual(["openseo"]);
+    expect(openseo!.mcp?.url_env).toBe("OPENSEO_MCP_URL");
+    expect(openseo!.mcp?.default_url).toBe("https://app.openseo.so/mcp");
+    expect(openseo!.auth.credential_envs).toEqual(["OPENSEO_API_KEY"]);
+  });
+
+  test("mcp block with non-https default_url is rejected", async () => {
+    const { _testing } = await import("../../src/core/catalogs");
+    const bad = {
+      version: 1,
+      catalogs: {
+        badmcp: {
+          ...makeEntry("badmcp", { capabilities: { research_adapters: ["badmcp"] } }),
+          mcp: { url_env: "BADMCP_MCP_URL", default_url: "http://insecure.example.com/mcp" },
+        },
+      },
+    };
+    const result = _testing.validateShape(bad);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.detail).toContain("https");
+  });
+
+  test("mcp block missing url_env is rejected", async () => {
+    const { _testing } = await import("../../src/core/catalogs");
+    const bad = {
+      version: 1,
+      catalogs: {
+        badmcp: {
+          ...makeEntry("badmcp", { capabilities: { research_adapters: ["badmcp"] } }),
+          mcp: { default_url: "https://app.openseo.so/mcp" },
+        },
+      },
+    };
+    const result = _testing.validateShape(bad);
+    expect(result.ok).toBe(false);
+  });
+
+  test("research-only catalog with no skills is rejected (zero-capability guard still holds)", async () => {
+    const { _testing } = await import("../../src/core/catalogs");
+    const empty = { version: 1, catalogs: { hollow: { ...makeEntry("hollow", { capabilities: {}, skills: [] }), skills: [] } } };
+    const result = _testing.validateShape(empty);
+    expect(result.ok).toBe(false);
+  });
+
+  test("research_adapters-only catalog (no skills) passes shape validation", async () => {
+    const { _testing } = await import("../../src/core/catalogs");
+    const okShape = {
+      version: 1,
+      catalogs: {
+        researchonly: { ...makeEntry("researchonly", { capabilities: { research_adapters: ["researchonly"] }, skills: [] }), skills: [] },
+      },
+    };
+    const result = _testing.validateShape(okShape);
+    expect(result.ok).toBe(true);
+  });
+});
+
+// =========================================================================
 // Adapter-name collision detection
 // =========================================================================
 

--- a/tests/plan.test.ts
+++ b/tests/plan.test.ts
@@ -114,3 +114,107 @@ describe("mktg plan", () => {
     await rm(tmp, { recursive: true, force: true });
   });
 });
+
+// ==================== Honesty: loads never unlock execute/distribute ====================
+
+const seedBrandTemplates = async (tmp: string): Promise<void> => {
+  const brandDir = join(tmp, "brand");
+  await mkdir(brandDir, { recursive: true });
+  await writeFile(join(brandDir, "voice-profile.md"), "real voice content — not the template " + "x".repeat(600));
+  await writeFile(join(brandDir, "audience.md"), BRAND_TEMPLATES["audience.md"]);
+};
+
+const seedRunLog = async (tmp: string, records: ReadonlyArray<Record<string, unknown>>): Promise<void> => {
+  await mkdir(join(tmp, ".mktg"), { recursive: true });
+  const lines = records.map(r => JSON.stringify(r)).join("\n") + "\n";
+  await writeFile(join(tmp, ".mktg", "runs.jsonl"), lines);
+};
+
+describe("plan honesty gates", () => {
+  test("load-only content run does NOT produce a distribute task", async () => {
+    const tmp = await mkdtemp(join(tmpdir(), "mktg-plan-honest-"));
+    await seedBrandTemplates(tmp);
+    await seedRunLog(tmp, [
+      { skill: "seo-content", timestamp: "2026-07-20T10:00:00.000Z", event: "loaded", brandFilesChanged: [] },
+    ]);
+    const { stdout } = await run(["plan", "--json", "--cwd", tmp]);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.tasks.some((t: { id: string }) => t.id === "distribute-content")).toBe(false);
+    await rm(tmp, { recursive: true, force: true });
+  });
+
+  test("load-only content run still counts as never-completed for execute suggestions", async () => {
+    const tmp = await mkdtemp(join(tmpdir(), "mktg-plan-honest-"));
+    await seedBrandTemplates(tmp);
+    await seedRunLog(tmp, [
+      { skill: "seo-content", timestamp: "2026-07-20T10:00:00.000Z", event: "loaded", brandFilesChanged: [] },
+    ]);
+    const { stdout } = await run(["plan", "--json", "--cwd", tmp]);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.tasks.some((t: { id: string }) => t.id === "run-seo-content")).toBe(true);
+    await rm(tmp, { recursive: true, force: true });
+  });
+
+  test("completed content run unlocks the distribute task", async () => {
+    const tmp = await mkdtemp(join(tmpdir(), "mktg-plan-honest-"));
+    await seedBrandTemplates(tmp);
+    await seedRunLog(tmp, [
+      { skill: "seo-content", timestamp: "2026-07-20T10:00:00.000Z", event: "completed", result: "success", writes: ["marketing/content/x.md"], brandFilesChanged: [] },
+    ]);
+    const { stdout } = await run(["plan", "--json", "--cwd", tmp]);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.tasks.some((t: { id: string }) => t.id === "distribute-content")).toBe(true);
+    await rm(tmp, { recursive: true, force: true });
+  });
+
+  test("marketing/ artifacts alone (no completed content run) unlock distribute", async () => {
+    const tmp = await mkdtemp(join(tmpdir(), "mktg-plan-honest-"));
+    await seedBrandTemplates(tmp);
+    await mkdir(join(tmp, "marketing", "content"), { recursive: true });
+    await writeFile(join(tmp, "marketing", "content", "article.md"), "# Real artifact");
+    const { stdout } = await run(["plan", "--json", "--cwd", tmp]);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.tasks.some((t: { id: string }) => t.id === "distribute-content")).toBe(true);
+    await rm(tmp, { recursive: true, force: true });
+  });
+
+  test("completed distribution run suppresses the distribute task", async () => {
+    const tmp = await mkdtemp(join(tmpdir(), "mktg-plan-honest-"));
+    await seedBrandTemplates(tmp);
+    await seedRunLog(tmp, [
+      { skill: "seo-content", timestamp: "2026-07-20T10:00:00.000Z", event: "completed", result: "success", writes: ["marketing/content/x.md"], brandFilesChanged: [] },
+      { skill: "content-atomizer", timestamp: "2026-07-20T11:00:00.000Z", event: "completed", result: "success", writes: ["marketing/social/a.md"], brandFilesChanged: [] },
+    ]);
+    const { stdout } = await run(["plan", "--json", "--cwd", tmp]);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.tasks.some((t: { id: string }) => t.id === "distribute-content")).toBe(false);
+    await rm(tmp, { recursive: true, force: true });
+  });
+
+  test("legacy load (result success, no writes) does NOT unlock distribute", async () => {
+    const tmp = await mkdtemp(join(tmpdir(), "mktg-plan-honest-"));
+    await seedBrandTemplates(tmp);
+    await seedRunLog(tmp, [
+      { skill: "seo-content", timestamp: "2026-07-20T10:00:00.000Z", result: "success", brandFilesChanged: [] },
+    ]);
+    const { stdout } = await run(["plan", "--json", "--cwd", tmp]);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.tasks.some((t: { id: string }) => t.id === "distribute-content")).toBe(false);
+    await rm(tmp, { recursive: true, force: true });
+  });
+
+  test("health stays 'incomplete' when brand files exist but are all templates", async () => {
+    const tmp = await mkdtemp(join(tmpdir(), "mktg-plan-honest-"));
+    const brandDir = join(tmp, "brand");
+    await mkdir(brandDir, { recursive: true });
+    await writeFile(join(brandDir, "voice-profile.md"), BRAND_TEMPLATES["voice-profile.md"]);
+    await writeFile(join(brandDir, "audience.md"), BRAND_TEMPLATES["audience.md"]);
+    await writeFile(join(brandDir, "competitors.md"), BRAND_TEMPLATES["competitors.md"]);
+    await writeFile(join(brandDir, "positioning.md"), BRAND_TEMPLATES["positioning.md"]);
+    const { stdout } = await run(["plan", "--json", "--cwd", tmp]);
+    const parsed = JSON.parse(stdout);
+    // 4 files EXIST — the old health check called this "ready". Templates are not population.
+    expect(parsed.health).toBe("incomplete");
+    await rm(tmp, { recursive: true, force: true });
+  });
+});

--- a/tests/publish.test.ts
+++ b/tests/publish.test.ts
@@ -141,3 +141,75 @@ describe("mktg publish", () => {
     await rm(tmp, { recursive: true, force: true });
   });
 });
+
+// ==================== Publish truth enum (Phase 5) ====================
+// Locks the status strings agents read: queued-local | draft-external |
+// sent | written-file | failed | skipped. A local queue write is NEVER
+// "sent"; an external draft is NEVER "published".
+
+describe("publish truth enum", () => {
+  test("file adapter --confirm reports written-file, not published", async () => {
+    const tmp = await mkdtemp(join(tmpdir(), "mktg-pub-enum-"));
+    const manifest = {
+      name: "enum-file",
+      items: [{ type: "file", adapter: "file", content: "x", metadata: { filename: "x.txt" } }],
+    };
+    await Bun.write(join(tmp, "publish.json"), JSON.stringify(manifest));
+    const { stdout, exitCode } = await run(["publish", "--confirm", "--json", "--cwd", tmp]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.adapters[0].results[0].status).toBe("written-file");
+    expect(parsed.adapters[0].results[0].detail).toContain(".mktg/published/");
+    await rm(tmp, { recursive: true, force: true });
+  });
+
+  test("mktg-native --confirm reports queued-local, never sent/published", async () => {
+    const tmp = await mkdtemp(join(tmpdir(), "mktg-pub-enum-"));
+    // Connect a native provider first
+    await run([
+      "publish", "--native-upsert-provider",
+      "--input", '{"identifier":"linkedin","name":"Test LinkedIn","profile":"test"}',
+      "--json", "--cwd", tmp,
+    ]);
+    const manifest = {
+      name: "enum-native",
+      items: [{
+        type: "social",
+        adapter: "mktg-native",
+        content: "Queue me locally",
+        metadata: { providers: ["linkedin"], postType: "now" },
+      }],
+    };
+    await Bun.write(join(tmp, "publish.json"), JSON.stringify(manifest));
+    const { stdout, exitCode } = await run(["publish", "--adapter", "mktg-native", "--confirm", "--json", "--cwd", tmp]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    const item = parsed.adapters[0].results[0];
+    expect(item.status).toBe("queued-local");
+    expect(item.detail).toContain("queued-local");
+    expect(JSON.stringify(parsed)).not.toContain('"status":"sent"');
+    expect(JSON.stringify(parsed)).not.toContain('"status":"published"');
+    await rm(tmp, { recursive: true, force: true });
+  });
+
+  test("dry-run keeps skipped status across all adapters", async () => {
+    const tmp = await mkdtemp(join(tmpdir(), "mktg-pub-enum-"));
+    const manifest = {
+      name: "enum-dry",
+      items: [
+        { type: "file", adapter: "file", content: "a", metadata: { filename: "a.txt" } },
+        { type: "social", adapter: "typefully", content: "b" },
+      ],
+    };
+    await Bun.write(join(tmp, "publish.json"), JSON.stringify(manifest));
+    const { stdout, exitCode } = await run(["publish", "--json", "--cwd", tmp]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    for (const adapter of parsed.adapters) {
+      for (const item of adapter.results) {
+        expect(["skipped", "failed"]).toContain(item.status);
+      }
+    }
+    await rm(tmp, { recursive: true, force: true });
+  });
+});

--- a/tests/run-activation.test.ts
+++ b/tests/run-activation.test.ts
@@ -1,0 +1,223 @@
+// Tests for mktg run --with-context (one-shot activation) and --strict prereqs
+// Real file I/O in isolated temp dirs, no mocks.
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { join } from "node:path";
+import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { compileBrandContext, filesForSkillActivation } from "../src/core/context-compiler";
+import { BRAND_TEMPLATES } from "../src/core/brand";
+
+const CLI_DIR = import.meta.dir.replace("/tests", "");
+
+const run = async (
+  args: string[],
+  envOverrides: Record<string, string | undefined> = {},
+): Promise<{ stdout: string; stderr: string; exitCode: number }> => {
+  const env: Record<string, string> = { ...process.env, NO_COLOR: "1" } as Record<string, string>;
+  for (const [key, value] of Object.entries(envOverrides)) {
+    if (value === undefined) delete env[key];
+    else env[key] = value;
+  }
+  const proc = Bun.spawn(["bun", "run", "src/cli.ts", ...args], {
+    cwd: CLI_DIR,
+    stdout: "pipe",
+    stderr: "pipe",
+    env,
+  });
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  return { stdout: stdout.trim(), stderr: stderr.trim(), exitCode: await proc.exited };
+};
+
+const REAL_CONTENT = (label: string): string => `# ${label}\n\nReal populated content — not a template. ${"x".repeat(400)}`;
+
+describe("run --with-context", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "mktg-activation-"));
+    await mkdir(join(tmpDir, "brand"), { recursive: true });
+    await writeFile(join(tmpDir, "brand", "voice-profile.md"), REAL_CONTENT("Voice"));
+    await writeFile(join(tmpDir, "brand", "keyword-plan.md"), REAL_CONTENT("Keywords"));
+    await writeFile(join(tmpDir, "brand", "audience.md"), BRAND_TEMPLATES["audience.md"]);
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  test("returns context files from the skill's declared reads", async () => {
+    const { stdout, exitCode } = await run(["run", "brand-voice", "--with-context", "--json", "--cwd", tmpDir]);
+    if (exitCode !== 0) return; // skill not installed — acceptable environment skip
+    const parsed = JSON.parse(stdout);
+    expect(parsed.context).not.toBeNull();
+    expect(parsed.context.layer).toBe("reads");
+    expect(Object.keys(parsed.context.files)).toEqual(["voice-profile.md"]);
+    expect(parsed.context.files["voice-profile.md"].freshness).not.toBe("template");
+    expect(parsed.context.tokenEstimate).toBeGreaterThan(0);
+  });
+
+  test("template files are excluded and named in templatesSkipped (nothing silent)", async () => {
+    const { stdout, exitCode } = await run(["run", "seo-content", "--with-context", "--json", "--cwd", tmpDir]);
+    if (exitCode !== 0) return;
+    const parsed = JSON.parse(stdout);
+    expect(Object.keys(parsed.context.files)).not.toContain("audience.md");
+    expect(parsed.context.templatesSkipped).toContain("audience.md");
+    expect(Object.keys(parsed.context.files).sort()).toEqual(["keyword-plan.md", "voice-profile.md"]);
+  });
+
+  test("--budget truncates and reports budgetDropped as a structured signal", async () => {
+    // budget=1: the top-priority file consumes the entire budget immediately
+    // (newline-preserving truncation), so the second file MUST overflow.
+    const { stdout, exitCode } = await run(["run", "seo-content", "--with-context", "--budget", "1", "--json", "--cwd", tmpDir]);
+    if (exitCode !== 0) return;
+    const parsed = JSON.parse(stdout);
+    expect(parsed.context.budgetDropped).toContain("keyword-plan.md");
+    expect(parsed.context.files["keyword-plan.md"].truncated).toBe(true);
+    expect(parsed.context.files["voice-profile.md"].truncated).toBe(true);
+  });
+
+  test("context is null without --with-context", async () => {
+    const { stdout, exitCode } = await run(["run", "brand-voice", "--json", "--cwd", tmpDir]);
+    if (exitCode !== 0) return;
+    const parsed = JSON.parse(stdout);
+    expect(parsed.context).toBeNull();
+  });
+
+  test("--budget without --with-context exits 2", async () => {
+    const { stdout, exitCode } = await run(["run", "brand-voice", "--budget", "100", "--json", "--cwd", tmpDir]);
+    expect(exitCode).toBe(2);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.error.message).toContain("--with-context");
+  });
+
+  test("--fields can trim the context payload", async () => {
+    const { stdout, exitCode } = await run(["run", "brand-voice", "--with-context", "--fields", "skill,context.tokenEstimate,context.templatesSkipped", "--json", "--cwd", tmpDir]);
+    if (exitCode !== 0) return;
+    const parsed = JSON.parse(stdout);
+    expect(parsed.skill).toBe("brand-voice");
+    expect(parsed.context.tokenEstimate).toBeGreaterThan(0);
+    expect(parsed.content).toBeUndefined();
+  });
+});
+
+describe("run --strict + rich prerequisites", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "mktg-strict-"));
+    await mkdir(join(tmpDir, "brand"), { recursive: true });
+    await writeFile(join(tmpDir, "brand", "voice-profile.md"), REAL_CONTENT("Voice"));
+    await writeFile(join(tmpDir, "brand", "audience.md"), REAL_CONTENT("Audience"));
+    await writeFile(join(tmpDir, "brand", "positioning.md"), REAL_CONTENT("Positioning"));
+    await writeFile(join(tmpDir, "brand", "learnings.md"), REAL_CONTENT("Learnings"));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  test("postiz surfaces missing envs + catalog even without --strict", async () => {
+    const { stdout, exitCode } = await run(
+      ["run", "postiz", "--json", "--cwd", tmpDir],
+      { POSTIZ_API_KEY: undefined, POSTIZ_API_BASE: undefined },
+    );
+    if (exitCode !== 0) return;
+    const parsed = JSON.parse(stdout);
+    expect(parsed.prerequisites.satisfied).toBe(false);
+    expect(parsed.prerequisites.missing.envs).toContain("POSTIZ_API_KEY");
+    expect(parsed.prerequisites.missing.envs).toContain("POSTIZ_API_BASE");
+    expect(parsed.prerequisites.missing.catalogs).toContain("postiz");
+    expect(parsed.prerequisites.remediation.join(" ")).toContain("POSTIZ_API_KEY");
+  });
+
+  test("postiz --strict exits 3 DEPENDENCY_MISSING when env vars are absent", async () => {
+    const { stdout, exitCode } = await run(
+      ["run", "postiz", "--strict", "--json", "--cwd", tmpDir],
+      { POSTIZ_API_KEY: undefined, POSTIZ_API_BASE: undefined },
+    );
+    expect(exitCode).toBe(3);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.error.code).toBe("DEPENDENCY_MISSING");
+    expect(parsed.error.suggestions.join(" ")).toContain("POSTIZ_API_KEY");
+    // No log written — the run never happened
+    expect(await Bun.file(join(tmpDir, ".mktg", "runs.jsonl")).exists()).toBe(false);
+  });
+
+  test("postiz --strict passes when env vars are set and brand reads populated", async () => {
+    const { exitCode } = await run(
+      ["run", "postiz", "--strict", "--json", "--cwd", tmpDir],
+      { POSTIZ_API_KEY: "test-key", POSTIZ_API_BASE: "https://api.postiz.com" },
+    );
+    // depends_on content-atomizer is installed in this environment
+    expect(exitCode).toBe(0);
+  });
+
+  test("offline skill (brainstorm) stays exit 0 with empty envs under --strict", async () => {
+    const { exitCode } = await run(
+      ["run", "brainstorm", "--strict", "--json", "--cwd", tmpDir],
+      { POSTIZ_API_KEY: undefined, POSTIZ_API_BASE: undefined, EXA_API_KEY: undefined, FIRECRAWL_API_KEY: undefined },
+    );
+    if (exitCode === 1) return; // skill not installed — environment skip
+    expect(exitCode).toBe(0);
+  });
+
+  test("skill with missing CLI tool reports it in missing.tools with doctor-identical hint", async () => {
+    // firecrawl CLI is not installed in this environment
+    const { stdout, exitCode } = await run(["run", "firecrawl", "--json", "--cwd", tmpDir], { FIRECRAWL_API_KEY: "k" });
+    if (exitCode !== 0) return;
+    const parsed = JSON.parse(stdout);
+    if (parsed.prerequisites.missing.tools.includes("firecrawl")) {
+      expect(parsed.prerequisites.remediation.join(" ")).toContain("npm i -g firecrawl");
+    }
+  });
+});
+
+describe("context-compiler core", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "mktg-compiler-"));
+    await mkdir(join(tmpDir, "brand"), { recursive: true });
+    await writeFile(join(tmpDir, "brand", "voice-profile.md"), REAL_CONTENT("Voice"));
+    await writeFile(join(tmpDir, "brand", "audience.md"), BRAND_TEMPLATES["audience.md"]);
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  test("filesForSkillActivation: declared reads win over layer matrix", () => {
+    const sel = filesForSkillActivation({ layer: "execution", reads: ["brand/voice-profile.md"] });
+    expect(sel.layer).toBe("reads");
+    expect(sel.files).toEqual(["voice-profile.md"]);
+  });
+
+  test("filesForSkillActivation: orchestrator falls back to all files", () => {
+    const sel = filesForSkillActivation({ layer: "orchestrator", reads: [] });
+    expect(sel.layer).toBe("all");
+    expect(sel.files).toBeUndefined();
+  });
+
+  test("filesForSkillActivation: layer maps 1:1 when no reads declared", () => {
+    const sel = filesForSkillActivation({ layer: "distribution", reads: [] });
+    expect(sel.layer).toBe("distribution");
+    expect(sel.files).toContain("stack.md");
+  });
+
+  test("compileBrandContext excludeTemplates omits + names templates", async () => {
+    const compiled = await compileBrandContext(tmpDir, { excludeTemplates: true });
+    expect(Object.keys(compiled.files)).toEqual(["voice-profile.md"]);
+    expect(compiled.templatesSkipped).toContain("audience.md");
+    expect(compiled.summary.templateFiles).toBe(1);
+  });
+
+  test("compileBrandContext without exclusion keeps templates (context cmd contract)", async () => {
+    const compiled = await compileBrandContext(tmpDir);
+    expect(Object.keys(compiled.files).sort()).toEqual(["audience.md", "voice-profile.md"]);
+    expect(compiled.files["audience.md"]!.freshness).toBe("template");
+  });
+});

--- a/tests/run-log.test.ts
+++ b/tests/run-log.test.ts
@@ -5,7 +5,7 @@ import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { join } from "node:path";
 import { mkdtemp, rm, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { logRun, getRunHistory, getLastRun, getRunSummary, getRunStats } from "../src/core/run-log";
+import { logRun, getRunHistory, getLastRun, getRunSummary, getRunStats, isCompletedRecord } from "../src/core/run-log";
 import type { SkillRunRecord } from "../src/types";
 
 const run = async (args: string[]): Promise<{ stdout: string; stderr: string; exitCode: number }> => {
@@ -328,5 +328,72 @@ describe("mktg skill log", () => {
 
     const exists = await Bun.file(join(tmpDir, ".mktg", "runs.jsonl")).exists();
     expect(exists).toBe(false);
+  });
+});
+
+// ==================== Event semantics: loaded vs completed ====================
+
+describe("isCompletedRecord dual-read", () => {
+  test("explicit completed event counts", () => {
+    expect(isCompletedRecord({ skill: "a", timestamp: "t", event: "completed", result: "success", brandFilesChanged: [] })).toBe(true);
+  });
+
+  test("explicit loaded event does NOT count, even if it carried a result", () => {
+    expect(isCompletedRecord({ skill: "a", timestamp: "t", event: "loaded", brandFilesChanged: [] })).toBe(false);
+  });
+
+  test("legacy record with brand writes counts as completed (transitional dual-read)", () => {
+    expect(isCompletedRecord({ skill: "a", timestamp: "t", result: "success", brandFilesChanged: ["voice-profile.md"] })).toBe(true);
+  });
+
+  test("legacy result:'success' with empty writes was a LOAD — must not count", () => {
+    expect(isCompletedRecord({ skill: "a", timestamp: "t", result: "success", brandFilesChanged: [] })).toBe(false);
+  });
+});
+
+describe("completedOnly filtering", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "mktg-runlog-filter-"));
+    await logRun(tmpDir, { skill: "seo-content", timestamp: "2026-03-13T10:00:00.000Z", event: "loaded", brandFilesChanged: [] });
+    await logRun(tmpDir, { skill: "seo-content", timestamp: "2026-03-13T11:00:00.000Z", event: "completed", result: "success", writes: ["marketing/x.md"], brandFilesChanged: [] });
+    await logRun(tmpDir, { skill: "legacy-skill", timestamp: "2026-03-13T12:00:00.000Z", result: "success", brandFilesChanged: ["audience.md"] });
+    await logRun(tmpDir, { skill: "legacy-load", timestamp: "2026-03-13T13:00:00.000Z", result: "success", brandFilesChanged: [] });
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  test("getRunHistory completedOnly keeps completions + legacy-with-writes only", async () => {
+    const completed = await getRunHistory(tmpDir, undefined, 50, { completedOnly: true });
+    const skills = completed.map(r => r.skill).sort();
+    expect(skills).toEqual(["legacy-skill", "seo-content"]);
+    expect(completed.find(r => r.skill === "legacy-load")).toBeUndefined();
+  });
+
+  test("getRunSummary completedOnly drops load-only skills entirely", async () => {
+    const summary = await getRunSummary(tmpDir, { completedOnly: true });
+    expect(Object.keys(summary).sort()).toEqual(["legacy-skill", "seo-content"]);
+    expect(summary["legacy-load"]).toBeUndefined();
+  });
+
+  test("summary entries expose event + nullable result", async () => {
+    const summary = await getRunSummary(tmpDir);
+    expect(summary["seo-content"]!.event).toBe("completed");
+    expect(summary["seo-content"]!.result).toBe("success");
+    expect(summary["legacy-load"]!.event).toBe("loaded");
+  });
+
+  test("stats count loaded vs completed separately; rate uses outcome records only", async () => {
+    const stats = await getRunStats(tmpDir);
+    expect(stats.totalRuns).toBe(4);
+    expect(stats.completedCount).toBe(2);
+    expect(stats.loadedCount).toBe(2);
+    // 3 records carry an outcome field (completed + both legacy records);
+    // only the explicit load event has none.
+    expect(stats.successCount).toBe(3);
+    expect(stats.successRate).toBe(100);
   });
 });

--- a/tests/run.test.ts
+++ b/tests/run.test.ts
@@ -3,7 +3,7 @@
 
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { join } from "node:path";
-import { mkdtemp, rm, readFile } from "node:fs/promises";
+import { mkdtemp, rm, readFile, writeFile, mkdir } from "node:fs/promises";
 import { tmpdir } from "node:os";
 
 const run = async (args: string[]): Promise<{ stdout: string; stderr: string; exitCode: number }> => {
@@ -86,7 +86,7 @@ describe("mktg run", () => {
     }
   });
 
-  test("successful run creates JSONL log entry", async () => {
+  test("bare run logs event 'loaded' with NO result (a load is not a success)", async () => {
     const { exitCode } = await run(["run", "brand-voice", "--json", "--cwd", tmpDir]);
     if (exitCode === 0) {
       const logContent = await readFile(join(tmpDir, ".mktg", "runs.jsonl"), "utf-8");
@@ -94,8 +94,77 @@ describe("mktg run", () => {
       expect(lines.length).toBe(1);
       const record = JSON.parse(lines[0]!);
       expect(record.skill).toBe("brand-voice");
-      expect(record.result).toBe("success");
+      expect(record.event).toBe("loaded");
+      expect(record.result).toBeUndefined();
+      expect(record.writes).toBeUndefined();
       expect(record.timestamp).toBeTruthy();
+    }
+  });
+
+  test("--complete with valid writes logs event 'completed' with result + writes", async () => {
+    await mkdir(join(tmpDir, "marketing", "content"), { recursive: true });
+    await writeFile(join(tmpDir, "marketing", "content", "x.md"), "# Article");
+    const { stdout, exitCode } = await run([
+      "run", "brand-voice", "--complete", "--writes", "marketing/content/x.md", "--result", "success", "--json", "--cwd", tmpDir,
+    ]);
+    if (exitCode === 0) {
+      const parsed = JSON.parse(stdout);
+      expect(parsed.event).toBe("completed");
+      expect(parsed.result).toBe("success");
+      expect(parsed.writes).toEqual(["marketing/content/x.md"]);
+
+      const logContent = await readFile(join(tmpDir, ".mktg", "runs.jsonl"), "utf-8");
+      const record = JSON.parse(logContent.trim().split("\n")[0]!);
+      expect(record.event).toBe("completed");
+      expect(record.result).toBe("success");
+      expect(record.writes).toEqual(["marketing/content/x.md"]);
+    }
+  });
+
+  test("--complete with a missing write path exits 2 with fix guidance (no silent success)", async () => {
+    const { stdout, exitCode } = await run([
+      "run", "brand-voice", "--complete", "--writes", "marketing/content/ghost.md", "--json", "--cwd", tmpDir,
+    ]);
+    expect(exitCode).toBe(2);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.error.code).toBe("INVALID_ARGS");
+    expect(parsed.error.message).toContain("ghost.md");
+    expect(parsed.error.suggestions.join(" ")).toContain("Create the files first");
+    const logExists = await Bun.file(join(tmpDir, ".mktg", "runs.jsonl")).exists();
+    expect(logExists).toBe(false);
+  });
+
+  test("--complete rejects traversal in writes", async () => {
+    const { stdout, exitCode } = await run([
+      "run", "brand-voice", "--complete", "--writes", "../outside.md", "--json", "--cwd", tmpDir,
+    ]);
+    expect(exitCode).toBe(2);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.error.code).toBe("INVALID_ARGS");
+  });
+
+  test("--result without --complete exits 2", async () => {
+    const { stdout, exitCode } = await run(["run", "brand-voice", "--result", "success", "--json", "--cwd", tmpDir]);
+    expect(exitCode).toBe(2);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.error.code).toBe("INVALID_ARGS");
+    expect(parsed.error.message).toContain("--complete");
+  });
+
+  test("--result rejects invalid values", async () => {
+    const { stdout, exitCode } = await run(["run", "brand-voice", "--complete", "--result", "amazing", "--json", "--cwd", tmpDir]);
+    expect(exitCode).toBe(2);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.error.message).toContain("Invalid --result");
+  });
+
+  test("--complete --result failed logs the failure honestly", async () => {
+    const { exitCode } = await run(["run", "brand-voice", "--complete", "--result", "failed", "--json", "--cwd", tmpDir]);
+    if (exitCode === 0) {
+      const logContent = await readFile(join(tmpDir, ".mktg", "runs.jsonl"), "utf-8");
+      const record = JSON.parse(logContent.trim().split("\n")[0]!);
+      expect(record.event).toBe("completed");
+      expect(record.result).toBe("failed");
     }
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Two plan tracks land together because they touch the same catalog loader (the coordination point flagged in sequencing): **OpenSEO S1 (Phases 1/3/4)** and **CLI P9-B** (catalog sync/status honesty, un-advertise path). This PR also carries the OpenSEO plan doc (cherry-picked from #41, which can be closed as superseded) with tracker rows updated on-branch.

### Catalog model (OpenSEO Phase 1)

- `CatalogCapabilities` gains **`research_adapters`** — collision detection and shape validation extended; zero-capability guard preserved
- New optional **`CatalogEntry.mcp` = `{ url_env, default_url(https) }`** — MCP rides over `transport: "http"`; **no new transport value**, so license-gate and `sdk_reference` invariants are untouched (audit refinement of the plan's `transport:"mcp"` idea)
- `catalogs-manifest.json` gains **openseo**: MIT, pinned `v0.1.2` (verified against upstream releases), bearer auth, `research_adapters: ["openseo"]`, `mcp.default_url: https://app.openseo.so/mcp`

### P9-B honesty (un-advertise)

- `catalog sync` schema + error strings now say "upstream version check not yet implemented" — and the **phantom `plan v2 §Phase A-prime` doc reference is removed**
- `catalog status` schema says `healthy` is always null (probes unimplemented, never guessed)
- CONTEXT.md catalog section matches reality

### OpenSEO S1 wiring (Phases 3 + 4)

- **`skills/openseo/SKILL.md`** — catalog companion: readiness ladder (L0 Exa fallback with metrics `unknown` → L3 synced `.seo/` state), cost discipline for DataForSEO spend, anti-patterns (inventing KD/volume, calling DataForSEO directly, unconfirmed bulk calls)
- **`.mcp.json`** gains the openseo server; **CONTEXT.md** gains the research-backend matrix (OpenSEO vs Exa vs Firecrawl); **AGENTS.md** Drop-in Catalog Contract documents `research_adapters` + `mcp`
- **Counts 64 → 65**: derive-counts surfaces + CLAUDE.md/README/`/cmo` copy; hardcoded-count tests fixed to derive from the manifest (enforcing the repo's own "never hardcode skill counts" rule)

### Verification

- Root `bun test` → **3267 pass / 0 fail** (new: research collision, mcp shape rejection, zero-capability guard, shipped-openseo contract, drift-locked skill envs)
- `bun x tsc --noEmit` → clean

### Dogfood evidence

```
mktg catalog info openseo --fields configured,missing_envs,mcp
  → configured:false, missing_envs:[OPENSEO_API_BASE, OPENSEO_API_KEY], mcp.default_url present
mktg catalog sync --json
  → every catalog: to_version:null, error:"upstream version check not yet implemented"
mktg run openseo --fields skill,event,prerequisites
  → loads; prereqs name missing envs AND the openseo catalog (M1+M2 composition works)
```

### Sequence context

Remaining from the two plans: M4 (`mktg route` + dashboard consolidation + studio resolve), then OpenSEO S2 (adapted `openseo-*` workflow skills + CMO Path A/B) and M5. OpenSEO Phase 2 is `in_progress` (env surfacing done; named readiness states deferred). Tracker rows updated on this branch.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d221b2b7-a08b-4b51-a74a-5bb038a8ccd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d221b2b7-a08b-4b51-a74a-5bb038a8ccd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

