### PR TITLE
feat(skills): adapt 7 OpenSEO workflow skills + Backend Selection rewiring (OpenSEO S2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "marketing-cli",
-      "description": "Agent-native marketing playbook CLI: 65 skills, 5 research/review agents, brand memory, and /cmo orchestration.",
+      "description": "Agent-native marketing playbook CLI: 72 skills, 5 research/review agents, brand memory, and /cmo orchestration.",
       "version": "0.6.0",
       "source": "./",
       "homepage": "https://github.com/MoizIbnYousaf/marketing-cli",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "marketing-cli",
   "version": "0.6.0",
-  "description": "Agent-native marketing playbook CLI: 65 skills, 5 research/review agents, brand memory, and /cmo orchestration.",
+  "description": "Agent-native marketing playbook CLI: 72 skills, 5 research/review agents, brand memory, and /cmo orchestration.",
   "author": {
     "name": "Moiz Ibn Yousaf",
     "url": "https://github.com/MoizIbnYousaf/marketing-cli"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "marketing-cli",
   "version": "0.6.0",
-  "description": "Agent-native marketing playbook CLI: 65 skills, 5 research/review agents, brand memory, and /cmo orchestration.",
+  "description": "Agent-native marketing playbook CLI: 72 skills, 5 research/review agents, brand memory, and /cmo orchestration.",
   "author": {
     "name": "Moiz Ibn Yousaf",
     "url": "https://github.com/MoizIbnYousaf/marketing-cli"
@@ -21,7 +21,7 @@
   "interface": {
     "displayName": "Marketing CLI",
     "shortDescription": "A CMO for your agent.",
-    "longDescription": "Install one CLI and give your agent 64 marketing skills, 5 research/review agents, persistent brand memory, native publishing workflows, and a local marketing studio.",
+    "longDescription": "Install one CLI and give your agent 71 marketing skills, 5 research/review agents, persistent brand memory, native publishing workflows, and a local marketing studio.",
     "developerName": "Moiz Ibn Yousaf",
     "category": "Productivity",
     "capabilities": [

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@
 
 ## What This Is
 
-A TypeScript/Bun agent-native marketing playbook CLI. 65 marketing skills (63 playbook + `/cmo` + `/axi`), 6 agents, 21 commands, 2 upstream catalogs. The Studio dashboard (Next.js + Bun API) ships inside the same tarball and is launched via `mktg studio`.
+A TypeScript/Bun agent-native marketing playbook CLI. 72 marketing skills (70 playbook + `/cmo` + `/axi`), 6 agents, 21 commands, 2 upstream catalogs. The Studio dashboard (Next.js + Bun API) ships inside the same tarball and is launched via `mktg studio`.
 
 | Component | Count | Purpose |
 |---|---|---|
@@ -48,7 +48,7 @@ src/
 │   ├── skill-add.ts    # External skill chaining (mktg skill add)
 │   ├── agents.ts       # Agent registry, install to ~/.claude/agents/
 │   └── transcribe.ts   # whisper.cpp + yt-dlp + ffmpeg pipeline
-skills/                  # 65 SKILL.md files installed to ~/.claude/skills/
+skills/                  # 72 SKILL.md files installed to ~/.claude/skills/
 skills-manifest.json     # Definitive skill list with metadata
 agents/                  # 6 agent .md files installed to ~/.claude/agents/
 agents-manifest.json     # Definitive agent list with metadata

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p align="center">
   <a href="https://github.com/MoizIbnYousaf/marketing-cli/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-10b981" alt="MIT License"></a>
-  <img src="https://img.shields.io/badge/skills-65-10b981" alt="65 Skills">
+  <img src="https://img.shields.io/badge/skills-72-10b981" alt="72 Skills">
   <img src="https://img.shields.io/badge/agents-5-10b981" alt="5 Agents">
   <a href="https://www.npmjs.com/package/marketing-cli"><img src="https://img.shields.io/npm/v/marketing-cli?color=10b981" alt="npm"></a>
   <img src="https://img.shields.io/badge/tests-2,624-10b981" alt="2,624 tests">
@@ -12,7 +12,7 @@
 </p>
 
 <p align="center">
-  <b>One package. One install. CLI for the agent, Studio for the human. 65 skills, 6 research agents, brand memory that compounds.</b>
+  <b>One package. One install. CLI for the agent, Studio for the human. 72 skills, 6 research agents, brand memory that compounds.</b>
 </p>
 
 ---
@@ -25,7 +25,7 @@ One npm package, two surfaces. The CLI is the agent surface, the Studio dashboar
 
 | Surface | What it is | Path |
 |---|---|---|
-| `mktg` CLI | 65 skills, 6 agents, brand memory, `/cmo` orchestration | (root) |
+| `mktg` CLI | 72 skills, 6 agents, brand memory, `/cmo` orchestration | (root) |
 | Studio dashboard | Local Next.js + Bun API: pulse, signals, brand visualizer, publish queue | [`studio/`](studio/) |
 
 `npm i -g marketing-cli` installs both. The repo uses a bun workspace because Studio is a Next.js app with its own build, but at install time it is one package, one tarball.
@@ -34,7 +34,7 @@ One npm package, two surfaces. The CLI is the agent surface, the Studio dashboar
 
 You ask your agent for marketing help. It writes generic copy and forgets your audience by tomorrow. The skills it would use aren't installed; the brand files don't exist; the agent learns this halfway through, when something fails mid-execution. Every session is the first session.
 
-`marketing-cli` fixes that. Install once and your agent inherits 65 skills, 6 research agents, and a brand memory that compounds. Session 10 starts where session 9 ended. Every conversation builds on the last.
+`marketing-cli` fixes that. Install once and your agent inherits 72 skills, 6 research agents, and a brand memory that compounds. Session 10 starts where session 9 ended. Every conversation builds on the last.
 
 ---
 
@@ -57,7 +57,7 @@ You ask your agent for marketing help. It writes generic copy and forgets your a
 | | |
 |---|---|
 | **`mktg` CLI** | 21 commands, 21/21 Agent DX score, JSON-by-default |
-| **65 marketing skills** | The playbook, copied to `~/.claude/skills/` |
+| **72 marketing skills** | The playbook, copied to `~/.claude/skills/` |
 | **5 research + review agents** | Parallel sub-agents in `~/.claude/agents/` |
 | **10 brand memory files** | Persistent marketing memory in your project's `brand/` (10 templates plus `SCHEMA.md`), created by `mktg init` |
 | **`/cmo` orchestrator** | The brain that routes every request to the right skill |
@@ -97,7 +97,7 @@ mktg orchestrates; it doesn't reimplement. When a good tool already exists, we c
 npm i -g marketing-cli
 ```
 
-That's it. The global npm install copies the 65 skills into `~/.claude/skills/` and the 6 agents into `~/.claude/agents/`. No second install command, no `mktg init` to remember.
+That's it. The global npm install copies the 72 skills into `~/.claude/skills/` and the 6 agents into `~/.claude/agents/`. No second install command, no `mktg init` to remember.
 
 Then open Claude Code in your project and run:
 
@@ -232,7 +232,7 @@ Organized by marketing layer. Foundation builds up to distribution.
 
 | Skill | What it does |
 |-------|-------------|
-| **cmo** | Orchestrates all 65 skills. Routing table, disambiguation, guardrails. |
+| **cmo** | Orchestrates all 72 skills. Routing table, disambiguation, guardrails. |
 | **axi** | AXI catalog router — gh-axi, chrome-devtools-axi, principles, AXI vs MCP. |
 | **brand-voice** | Define or extract brand voice from existing content |
 | **audience-research** | Build buyer personas with parallel web research |
@@ -348,7 +348,7 @@ The 3 research agents run **in parallel**. Results write back to `brand/` so eve
 | `mktg init` | Scaffold `brand/` plus install skills plus install agents |
 | `mktg status` | Project marketing state snapshot |
 | `mktg doctor` | Health checks: brand files, skills, agents, CLI tools, integrations |
-| `mktg list` | Show all 65 skills with install status and metadata |
+| `mktg list` | Show all 72 skills with install status and metadata |
 | `mktg update` | Re-install skills from latest package version |
 | `mktg schema` | Introspect all commands, flags, and output shapes |
 | `mktg skill` | Inspect, validate, register, analyze, and chain external skills |
@@ -472,7 +472,7 @@ Contributions welcome. The fastest ways to help:
 
 ## Acknowledgments
 
-- [Corey Haines' Marketing Skills](https://github.com/coreyhaines31/marketingskills): the breadth skill collection that inspired many of mktg's 65 skills
+- [Corey Haines' Marketing Skills](https://github.com/coreyhaines31/marketingskills): the breadth skill collection that inspired many of mktg's 72 skills
 - [Postiz](https://github.com/gitroomhq/postiz-app) by [@gitroomhq](https://github.com/gitroomhq): the upstream catalog for 30+ social provider integrations (LinkedIn, Reddit, Bluesky, Mastodon, Threads, Instagram, TikTok, YouTube, Pinterest, Discord, Slack, etc.). mktg connects via REST API; license stays firewalled.
 - [last30days-skill](https://github.com/mvanhorn/last30days-skill) by [@mvanhorn](https://github.com/mvanhorn): live research across Reddit, X, YouTube, Hacker News, GitHub, and the web. `/cmo` chains it before any market claim, so the playbook stays grounded in what's actually happening this month, not training-data folklore.
 - [`@steipete/summarize`](https://github.com/steipete/summarize) by [@steipete](https://github.com/steipete): the text-compression CLI that mktg's `summarize` skill wraps with rules and budgets.

--- a/docs/openseo-integration-plan.md
+++ b/docs/openseo-integration-plan.md
@@ -90,8 +90,8 @@ Playbooks stay in mktg. **Metrics, SERP truth, rank tracking, backlinks, GSC** c
 | 2 | Doctor + env/MCP readiness | `in_progress` | #46 | envs surface via doctor catalog checks + prereqs; named readiness states (mcp_client_only etc.) deferred |
 | 3 | Root MCP wiring + agent install docs | `completed` | #46 | 2026-07-27 — `.mcp.json` openseo server + CONTEXT backend matrix |
 | 4 | First-class `openseo` skill (adapter / coach) | `completed` | #46 | 2026-07-27 — `skills/openseo/SKILL.md` (65 skills); drift-locked envs |
-| 5 | Steal & adapt OpenSEO workflow skills (`openseo-*`) | `pending` | | Upstream provenance |
-| 6 | Rewire existing SEO skills + `/cmo` Path A/B | `pending` | | Prefer OpenSEO when configured |
+| 5 | Steal & adapt OpenSEO workflow skills (`openseo-*`) | `completed` | cursor/openseo-workflow-skills-ccd8 | 2026-07-28 — all 7 adapted (light `upstream` provenance, snapshot f569726); 65 → 72 skills |
+| 6 | Rewire existing SEO skills + `/cmo` Path A/B | `completed` | cursor/openseo-workflow-skills-ccd8 | 2026-07-28 — Backend Selection on 6 skills; playbooks data-plane gate; ecosystem research matrix |
 | 7 | Brand / `.seo` / OpenSEO project sync contract | `pending` | | |
 | 8 | CLI surface: `mktg catalog` / optional `mktg seo` | `pending` | | |
 | 9 | Studio: SEO panel / deep links / status | `pending` | | |

--- a/docs/openseo-integration-plan.md
+++ b/docs/openseo-integration-plan.md
@@ -90,8 +90,8 @@ Playbooks stay in mktg. **Metrics, SERP truth, rank tracking, backlinks, GSC** c
 | 2 | Doctor + env/MCP readiness | `in_progress` | #46 | envs surface via doctor catalog checks + prereqs; named readiness states (mcp_client_only etc.) deferred |
 | 3 | Root MCP wiring + agent install docs | `completed` | #46 | 2026-07-27 — `.mcp.json` openseo server + CONTEXT backend matrix |
 | 4 | First-class `openseo` skill (adapter / coach) | `completed` | #46 | 2026-07-27 — `skills/openseo/SKILL.md` (65 skills); drift-locked envs |
-| 5 | Steal & adapt OpenSEO workflow skills (`openseo-*`) | `completed` | cursor/openseo-workflow-skills-ccd8 | 2026-07-28 — all 7 adapted (light `upstream` provenance, snapshot f569726); 65 → 72 skills |
-| 6 | Rewire existing SEO skills + `/cmo` Path A/B | `completed` | cursor/openseo-workflow-skills-ccd8 | 2026-07-28 — Backend Selection on 6 skills; playbooks data-plane gate; ecosystem research matrix |
+| 5 | Steal & adapt OpenSEO workflow skills (`openseo-*`) | `completed` | #49 | 2026-07-28 — all 7 adapted (light `upstream` provenance, snapshot f569726); 65 → 72 skills |
+| 6 | Rewire existing SEO skills + `/cmo` Path A/B | `completed` | #49 | 2026-07-28 — Backend Selection on 6 skills; playbooks data-plane gate; ecosystem research matrix |
 | 7 | Brand / `.seo` / OpenSEO project sync contract | `pending` | | |
 | 8 | CLI surface: `mktg catalog` / optional `mktg seo` | `pending` | | |
 | 9 | Studio: SEO panel / deep links / status | `pending` | | |

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "marketing-cli",
   "version": "0.6.0",
-  "description": "Agent-native marketing playbook CLI: 65 skills, 5 research/review agents, brand memory, and /cmo orchestration."
+  "description": "Agent-native marketing playbook CLI: 72 skills, 5 research/review agents, brand memory, and /cmo orchestration."
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "marketing-cli",
   "version": "0.6.0",
-  "description": "Agent-native marketing playbook: 65 skills, 5 research agents, brand memory that compounds, plus a local Studio dashboard (beta). One install, then /cmo in Claude Code walks you through a 4-question setup wizard. CLI for the agent, Studio for the human.",
+  "description": "Agent-native marketing playbook: 72 skills, 5 research agents, brand memory that compounds, plus a local Studio dashboard (beta). One install, then /cmo in Claude Code walks you through a 4-question setup wizard. CLI for the agent, Studio for the human.",
   "type": "module",
   "workspaces": [
     "studio"

--- a/skills-manifest.json
+++ b/skills-manifest.json
@@ -2126,6 +2126,244 @@
         "OPENSEO_API_KEY",
         "OPENSEO_API_BASE"
       ]
+    },
+    "openseo-project-setup": {
+      "source": "new",
+      "category": "seo",
+      "layer": "foundation",
+      "tier": "nice-to-have",
+      "reads": [
+        "keyword-plan.md"
+      ],
+      "writes": [
+        "keyword-plan.md"
+      ],
+      "depends_on": [],
+      "triggers": [
+        "set up openseo",
+        "link seo project",
+        "connect gsc",
+        "start seo for this site",
+        "openseo project id"
+      ],
+      "review_interval_days": 60,
+      "version": "1.0.0",
+      "env_vars": [
+        "OPENSEO_API_KEY",
+        "OPENSEO_API_BASE"
+      ],
+      "upstream": {
+        "primary": {
+          "repo": "every-app/open-seo",
+          "path": ".agents/skills/seo-project-setup",
+          "snapshot_sha": "f56972639f14e7e766498a8a2f6441913eb83c0c",
+          "snapshot_at": "2026-07-28T00:30:08.274Z"
+        }
+      }
+    },
+    "openseo-coach": {
+      "source": "new",
+      "category": "seo",
+      "layer": "strategy",
+      "tier": "nice-to-have",
+      "reads": [
+        "keyword-plan.md",
+        "positioning.md"
+      ],
+      "writes": [],
+      "depends_on": [],
+      "triggers": [
+        "seo coach",
+        "new to seo",
+        "explain openseo",
+        "what seo should i do",
+        "seo strategy help"
+      ],
+      "review_interval_days": 60,
+      "version": "1.0.0",
+      "env_vars": [
+        "OPENSEO_API_KEY",
+        "OPENSEO_API_BASE"
+      ],
+      "upstream": {
+        "primary": {
+          "repo": "every-app/open-seo",
+          "path": ".agents/skills/seo-coach",
+          "snapshot_sha": "f56972639f14e7e766498a8a2f6441913eb83c0c",
+          "snapshot_at": "2026-07-28T00:30:08.274Z"
+        }
+      }
+    },
+    "openseo-keyword-research": {
+      "source": "new",
+      "category": "seo",
+      "layer": "strategy",
+      "tier": "nice-to-have",
+      "reads": [
+        "keyword-plan.md",
+        "positioning.md"
+      ],
+      "writes": [
+        "keyword-plan.md"
+      ],
+      "depends_on": [],
+      "triggers": [
+        "keyword difficulty",
+        "search volume",
+        "keyword opportunities",
+        "striking distance keywords",
+        "measured keyword research"
+      ],
+      "review_interval_days": 60,
+      "version": "1.0.0",
+      "env_vars": [
+        "OPENSEO_API_KEY",
+        "OPENSEO_API_BASE"
+      ],
+      "upstream": {
+        "primary": {
+          "repo": "every-app/open-seo",
+          "path": ".agents/skills/keyword-research",
+          "snapshot_sha": "f56972639f14e7e766498a8a2f6441913eb83c0c",
+          "snapshot_at": "2026-07-28T00:30:08.274Z"
+        }
+      }
+    },
+    "openseo-keyword-clustering": {
+      "source": "new",
+      "category": "seo",
+      "layer": "strategy",
+      "tier": "nice-to-have",
+      "reads": [
+        "keyword-plan.md"
+      ],
+      "writes": [
+        "keyword-plan.md"
+      ],
+      "depends_on": [],
+      "triggers": [
+        "cluster keywords",
+        "keyword mapping",
+        "map keywords to pages",
+        "keyword cannibalization",
+        "which page should target"
+      ],
+      "review_interval_days": 60,
+      "version": "1.0.0",
+      "env_vars": [
+        "OPENSEO_API_KEY",
+        "OPENSEO_API_BASE"
+      ],
+      "upstream": {
+        "primary": {
+          "repo": "every-app/open-seo",
+          "path": ".agents/skills/keyword-clustering",
+          "snapshot_sha": "f56972639f14e7e766498a8a2f6441913eb83c0c",
+          "snapshot_at": "2026-07-28T00:30:08.274Z"
+        }
+      }
+    },
+    "openseo-competitive-landscape": {
+      "source": "new",
+      "category": "seo",
+      "layer": "strategy",
+      "tier": "nice-to-have",
+      "reads": [
+        "landscape.md",
+        "competitors.md"
+      ],
+      "writes": [
+        "landscape.md"
+      ],
+      "depends_on": [],
+      "triggers": [
+        "competitive landscape seo",
+        "who ranks for",
+        "seo market map",
+        "how competitive is",
+        "serp competitors"
+      ],
+      "review_interval_days": 60,
+      "version": "1.0.0",
+      "env_vars": [
+        "OPENSEO_API_KEY",
+        "OPENSEO_API_BASE"
+      ],
+      "upstream": {
+        "primary": {
+          "repo": "every-app/open-seo",
+          "path": ".agents/skills/competitive-landscape",
+          "snapshot_sha": "f56972639f14e7e766498a8a2f6441913eb83c0c",
+          "snapshot_at": "2026-07-28T00:30:08.274Z"
+        }
+      }
+    },
+    "openseo-competitor-analysis": {
+      "source": "new",
+      "category": "seo",
+      "layer": "strategy",
+      "tier": "nice-to-have",
+      "reads": [
+        "competitors.md",
+        "positioning.md"
+      ],
+      "writes": [
+        "competitors.md"
+      ],
+      "depends_on": [],
+      "triggers": [
+        "analyze competitor",
+        "competitor keywords",
+        "competitor backlinks",
+        "beat competitor",
+        "competitor seo teardown"
+      ],
+      "review_interval_days": 60,
+      "version": "1.0.0",
+      "env_vars": [
+        "OPENSEO_API_KEY",
+        "OPENSEO_API_BASE"
+      ],
+      "upstream": {
+        "primary": {
+          "repo": "every-app/open-seo",
+          "path": ".agents/skills/competitor-analysis",
+          "snapshot_sha": "f56972639f14e7e766498a8a2f6441913eb83c0c",
+          "snapshot_at": "2026-07-28T00:30:08.274Z"
+        }
+      }
+    },
+    "openseo-link-prospecting": {
+      "source": "new",
+      "category": "seo",
+      "layer": "distribution",
+      "tier": "nice-to-have",
+      "reads": [
+        "positioning.md"
+      ],
+      "writes": [],
+      "depends_on": [],
+      "triggers": [
+        "link prospecting",
+        "find backlink opportunities",
+        "resource page outreach",
+        "get backlinks for",
+        "link building outreach"
+      ],
+      "review_interval_days": 60,
+      "version": "1.0.0",
+      "env_vars": [
+        "OPENSEO_API_KEY",
+        "OPENSEO_API_BASE"
+      ],
+      "upstream": {
+        "primary": {
+          "repo": "every-app/open-seo",
+          "path": ".agents/skills/link-prospecting",
+          "snapshot_sha": "f56972639f14e7e766498a8a2f6441913eb83c0c",
+          "snapshot_at": "2026-07-28T00:30:08.274Z"
+        }
+      }
     }
   },
   "redirects": {

--- a/skills/ai-seo/SKILL.md
+++ b/skills/ai-seo/SKILL.md
@@ -36,6 +36,11 @@ This is a different game. AI engines don't rank pages — they synthesize answer
 
 1. Read `brand/` directory: load `voice-profile.md`, `keyword-plan.md`, `positioning.md`, `competitors.md` if present.
 2. Show what loaded:
+
+## Backend Selection
+
+1. **OpenSEO configured**: use measured rank/SERP data (`get_ranked_keywords`, `get_serp_results`) to prioritize which pages get AI-search optimization first; use OpenSEO AI-search features when exposed via MCP.
+2. **OpenSEO absent**: optimize from crawl/Exa evidence; label ranking data `unknown`.
    ```
    Brand context loaded:
    ├── Voice Profile   ✓/✗

--- a/skills/cmo/SKILL.md
+++ b/skills/cmo/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cmo
 description: |
-  A senior marketing operator for any project. Orchestrates 65 marketing skills to build brands, generate content, and distribute across channels. Use this skill whenever the user wants to do marketing  -  brand voice, copy, SEO, email, social, launches, or anything marketing-related. Also triggers on 'help me market', 'write copy', 'launch strategy', 'brand voice', 'SEO', 'content', 'email sequence', 'social posts', 'landing page', 'grow', 'audience', 'competitors', 'what should I do next for marketing', 'I need more users', 'how do I get people to care', or any marketing request. When in doubt about which marketing skill to use, start here  -  even if the user's request is vague or doesn't explicitly mention marketing.
+  A senior marketing operator for any project. Orchestrates 72 marketing skills to build brands, generate content, and distribute across channels. Use this skill whenever the user wants to do marketing  -  brand voice, copy, SEO, email, social, launches, or anything marketing-related. Also triggers on 'help me market', 'write copy', 'launch strategy', 'brand voice', 'SEO', 'content', 'email sequence', 'social posts', 'landing page', 'grow', 'audience', 'competitors', 'what should I do next for marketing', 'I need more users', 'how do I get people to care', or any marketing request. When in doubt about which marketing skill to use, start here  -  even if the user's request is vague or doesn't explicitly mention marketing.
 allowed-tools:
   - Bash(mktg *)
   - Bash(curl *)
@@ -54,7 +54,7 @@ Follow this escalation pattern. Always start at the highest applicable level:
 
 1. Run `mktg status --json` (or `mktg status --json --cwd <path>` for other projects)
 2. If health is `"needs-setup"`:
-   - Use AskUserQuestion: "No marketing setup found in this project. Want me to initialize marketing here? This will create a `brand/` directory and install 65 marketing skills."
+   - Use AskUserQuestion: "No marketing setup found in this project. Want me to initialize marketing here? This will create a `brand/` directory and install 72 marketing skills."
    - Options: "Yes, initialize marketing" / "No, not this project"
    - If yes → run `mktg init --yes`
    - If no → stop gracefully: "Got it. Run `/cmo` again when you're ready."

--- a/skills/cmo/rules/ecosystem.md
+++ b/skills/cmo/rules/ecosystem.md
@@ -51,6 +51,29 @@ When a platform has no usable API, /cmo routes to the browser. Multiple browser 
 
 ## MCP servers
 
+### OpenSEO - SEO data plane (catalog + MCP)
+
+**What it is:** Open-source Semrush/Ahrefs alternative ([every-app/open-seo](https://github.com/every-app/open-seo), MIT). Registered as the `openseo` catalog with a `research_adapters` capability — mktg's measured-metrics backend for SEO: KD, volume, CPC, intent, SERP, ranked keywords, backlinks, rank tracking, GSC.
+
+**Research backend matrix (route by job):**
+
+| Job | Preferred | Fallback |
+|---|---|---|
+| KD / volume / CPC / intent | OpenSEO MCP (`get_keyword_metrics`, `research_keywords`) | none — mark `unknown` |
+| Live SERP for a keyword | OpenSEO MCP (`get_serp_results`) | firecrawl/Exa scrape (weaker) |
+| Domain ranked keywords / backlinks | OpenSEO MCP (`get_ranked_keywords`, `get_backlinks_overview`) | `competitive-intel` qualitative |
+| GSC striking-distance / cannibalization | OpenSEO (`get_search_console_performance`) | manual GSC CSV export into `.seo/gsc/` |
+| Open-web discovery / Reddit / GitHub | Exa | — |
+| Fetch known-URL content | firecrawl | — |
+
+**Skills:** `openseo` (adapter/readiness), `openseo-project-setup`, `openseo-coach`, `openseo-keyword-research`, `openseo-keyword-clustering`, `openseo-competitive-landscape`, `openseo-competitor-analysis`, `openseo-link-prospecting`.
+
+**CMO routes to OpenSEO when:** any metrics-bearing SEO request arrives and `mktg catalog info openseo --json --fields configured` returns true. SEO playbook skills (`keyword-research`, `seo-audit`, `off-page-seo`, `ai-seo`, `seo-machine`, `competitor-alternatives`) have Backend Selection sections that prefer OpenSEO when ready.
+
+**Wired via:** `.mcp.json` at the repo root (`openseo` server, hosted MCP `https://app.openseo.so/mcp`, `OPENSEO_MCP_URL` override for self-host) and `OPENSEO_API_KEY` for non-interactive automation (`mktg doctor` surfaces catalog readiness). Cost discipline: bulk research + `save_keywords` require confirmation (DataForSEO credit).
+
+---
+
 ### Exa - first-class skills + MCP
 
 **What it is:** Semantic web research platform. Distinct from firecrawl:

--- a/skills/cmo/rules/playbooks.md
+++ b/skills/cmo/rules/playbooks.md
@@ -168,6 +168,8 @@ Named end-to-end recipes. When the builder asks for something big, pick the righ
 
 Two paths. Pick by the user's horizon. If unclear, ask once with `AskUserQuestion`.
 
+**Data plane first (both paths):** check `mktg catalog info openseo --json --fields configured`. When OpenSEO is ready, measured metrics (KD, volume, SERP, backlinks, GSC) come from the `openseo-*` skills and the playbook skills below consume them via their Backend Selection sections. When OpenSEO is absent, the same playbook steps run on Exa/Firecrawl with every metric marked as unknown — never invented.
+
 **Path A triggers:** *"rank higher on Google"*, *"improve SEO"*, *"I want to show up in AI search"*, *"compete for [topic]"*, *"write me an SEO article"*  -  short-horizon, one-shot, no roadmap.
 
 **Path B triggers:** *"SEO machine"*, *"build organic traffic"*, *"programmatic SEO"*, *"alternatives pages"*, *"comparison pages"*, *"/for/ pages"*, *"we need traffic"*, *"build an SEO engine"*  -  multi-phase, ship dozens of pages, persistent roadmap.
@@ -178,11 +180,11 @@ Two paths. Pick by the user's horizon. If unclear, ask once with `AskUserQuestio
 
 | # | Skill | Artifact |
 |---|---|---|
-| 1 | `keyword-research` | `brand/keyword-plan.md` with primary, secondary, long-tail terms + search intent notes. |
+| 1 | `keyword-research` (OpenSEO path: `openseo-keyword-research`) | `brand/keyword-plan.md` with primary, secondary, long-tail terms + search intent notes. Measured KD/volume when OpenSEO is configured. |
 | 2 | `seo-content` (ongoing) | `marketing/content/*.md`  -  rankable, anti-AI-slop articles with schema. |
 | 3 | `ai-seo` | Entity optimization, structured data, citation-worthy formatting for ChatGPT/Perplexity/Claude/Gemini/AI Overviews. |
-| 4 | `competitor-alternatives` | `marketing/alternatives/<competitor>-vs-us.md`  -  high-intent comparison pages. |
-| 5 | `seo-audit` (periodically) | Site architecture + schema markup audit. |
+| 4 | `competitor-alternatives` (OpenSEO path: target picks from `openseo-competitor-analysis`) | `marketing/alternatives/<competitor>-vs-us.md`  -  high-intent comparison pages. |
+| 5 | `seo-audit` (periodically) | Site architecture + schema markup audit. Rank snapshots in `.seo/rank-snapshots/` when OpenSEO is configured. |
 
 **Stop:** one cornerstone + one AI-SEO piece + one alternatives page shipped. Schedule re-runs quarterly.
 
@@ -194,8 +196,8 @@ When the user wants an *operating system* for organic growth  -  not one article
 
 | # | Skill / Agent | Artifact |
 |---|---|---|
-| 1 | Foundation prerequisites (if missing) | Spawn `mktg-competitive-scanner` + `mktg-audience-researcher` in parallel (Exa via `company-research` / `exa-search`) → `brand/competitors.md`, `brand/audience.md`. Run `keyword-research` → `brand/keyword-plan.md`. |
-| 2 | `seo-machine` (Initialize) | `docs/seo-machine.md` roadmap + `.seo/brand.md` + `.seo/link-inventory.md` + `.seo/config.json`. Stack auto-detected. |
+| 1 | Foundation prerequisites (if missing) | Spawn `mktg-competitive-scanner` + `mktg-audience-researcher` in parallel (Exa via `company-research` / `exa-search`) → `brand/competitors.md`, `brand/audience.md`. Run `keyword-research` → `brand/keyword-plan.md` (OpenSEO path: `openseo-keyword-research` for measured inputs; `openseo-project-setup` first if `.seo/openseo.json` is missing). |
+| 2 | `seo-machine` (Initialize) | `docs/seo-machine.md` roadmap + `.seo/brand.md` + `.seo/link-inventory.md` + `.seo/config.json`. Stack auto-detected. OpenSEO path: targets pre-validated with `get_keyword_metrics`; clusters from `openseo-keyword-clustering` in `marketing/seo/clusters/`. |
 | 3 | `seo-machine` (Resume  -  per phase) | Generates the phase's pages (e.g. 12 `/alternatives/<competitor>` pages, or 8 `/for/<persona>` use-case pages) directly into the user's framework (Next.js / Astro / Rails+Inertia / markdown fallback). |
 | 4 | Per-phase quality gate  -  `mktg-content-reviewer` (voice) + `mktg-seo-analyst` (keyword adherence) | Scored, not rewritten. Spawn both in one message after each phase. |
 | 5 | Off-page checklist + technical audit | Chain into `off-page-seo` skill → spawns `mktg-backlink-prospector` agent to research competitor referring-domains → writes `.seo/backlink-targets.json`. Plus `scripts/link_audit.py` + `scripts/tech_audit.py` run locally; findings appended to `docs/seo-machine.md`. |

--- a/skills/competitor-alternatives/SKILL.md
+++ b/skills/competitor-alternatives/SKILL.md
@@ -34,6 +34,11 @@ People searching "[Competitor] alternatives" or "[Product] vs [Competitor]" have
 
 1. Read `brand/` directory: load `competitors.md`, `positioning.md`, `voice-profile.md`, `audience.md` if present.
 2. Show what loaded:
+
+## Backend Selection
+
+1. **OpenSEO configured**: pick comparison targets from measured SERP overlap (`find_serp_competitors`, `get_serp_results`) and use `openseo-competitor-analysis` findings in `brand/competitors.md` when present.
+2. **OpenSEO absent**: choose targets from Exa SERP scraping; label overlap strength `unknown`.
    ```
    Brand context loaded:
    ├── Competitors    ✓/✗  ({N} competitors profiled)

--- a/skills/keyword-research/SKILL.md
+++ b/skills/keyword-research/SKILL.md
@@ -22,6 +22,13 @@ description: >
 
 > **Note:** Examples below use fictional brands (Acme, Lumi, Helm). Replace with your own brand context.
 
+## Backend Selection
+
+1. **OpenSEO configured** (`mktg catalog info openseo --json --fields configured` → true): get measured metrics (KD, volume, CPC, intent, SERP, GSC striking-distance) from OpenSEO via `openseo-keyword-research` instead of estimating. This skill remains the methodology — strategy, prioritization, and the `brand/keyword-plan.md` structure.
+2. **OpenSEO absent**: proceed with the Exa-stack validation below (Phase 3) and mark every metric `unknown`. Never invent KD/volume.
+
+Rule of thumb: OpenSEO is the data plane, this skill is the playbook. When both exist, the playbook consumes measured inputs.
+
 # /keyword-research -- Data-Backed Keyword Strategy
 
 Most keyword research is backwards. People start with tools, get overwhelmed by
@@ -49,34 +56,14 @@ Do not start from scratch. Instead:
 1. Read the existing plan.
 2. Present a summary of the current keyword strategy:
    ```
-   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   EXISTING KEYWORD PLAN (last updated {date})
+   Pillars: {Pillar 1} {N} clusters {priority} · {Pillar 2} {N} {priority} · {Pillar 3} {N} {priority}
+   Top keywords: {kw1} {priority} · {kw2} {priority} · {kw3} {priority}
+   Content briefs: {N} created, {N} published
 
-     EXISTING KEYWORD PLAN
-     Last updated {date} by /keyword-research
-
-   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-     Pillars:
-     ├── {Pillar 1}    {N} clusters    Priority: {level}
-     ├── {Pillar 2}    {N} clusters    Priority: {level}
-     └── {Pillar 3}    {N} clusters    Priority: {level}
-
-     Top keywords:
-     ├── {keyword 1}   {priority}
-     ├── {keyword 2}   {priority}
-     └── {keyword 3}   {priority}
-
-     Content briefs: {N} created, {N} published
-
-     ──────────────────────────────────────────────
-
-     What would you like to do?
-
-     ① Refresh with new SERP data
-     ② Add a new topic area
-     ③ Re-prioritize existing clusters
-     ④ Full rebuild from scratch
-     ⑤ Generate briefs for top keywords
+   What would you like to do?
+   ① Refresh with new SERP data  ② Add a new topic area  ③ Re-prioritize clusters
+   ④ Full rebuild from scratch   ⑤ Generate briefs for top keywords
    ```
 
 3. Process the user's choice:
@@ -86,23 +73,7 @@ Do not start from scratch. Instead:
    - Option ④ --> Full process from scratch
    - Option ⑤ --> Skip to content brief generation for highest-priority unfilled clusters
 
-4. Before overwriting, show a diff of what changed:
-   ```
-   Changes to keyword plan:
-
-   New clusters added:
-   ├── "AI email marketing" (Pillar: AI Marketing)
-   └── "automated content creation" (Pillar: AI Marketing)
-
-   Priority changes:
-   ├── "marketing automation" High → Critical
-   └── "fractional CMO" Medium → Low
-
-   Removed:
-   └── "our methodology" (failed validation)
-
-   Save these changes? (y/n)
-   ```
+4. Before overwriting, show a compact diff of what changed (new clusters, priority changes, removals) and ask: "Save these changes? (y/n)"
 
 5. Only overwrite after explicit confirmation.
 

--- a/skills/off-page-seo/SKILL.md
+++ b/skills/off-page-seo/SKILL.md
@@ -31,6 +31,11 @@ The off-page half of the SEO operation. Pairs with `seo-machine` (on-page progra
 
 1. Load brand context: `positioning.md`, `competitors.md`, `audience.md`, `voice-profile.md`. Missing files are fine.
 2. Surface what loaded:
+
+## Backend Selection
+
+1. **OpenSEO configured**: ground backlink gaps in measured data (`get_backlinks_overview`, `get_domain_overview`) and consume `.seo/backlink-targets.json` from `openseo-link-prospecting` when present. Write refreshed overviews to `.seo/backlink-overview.json`.
+2. **OpenSEO absent**: prospect and prioritize with Exa/web evidence only; label authority metrics `unknown`.
    ```
    Brand context loaded:
    ├── Positioning    ✓/✗  (drives outreach angle + value-add framing)

--- a/skills/openseo-coach/SKILL.md
+++ b/skills/openseo-coach/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: openseo-coach
+description: >-
+  Friendly SEO coach mode for the mktg + OpenSEO stack. Use this skill when
+  the user is new to SEO, unsure which SEO workflow to run, asks "what does
+  OpenSEO do", wants strategy explained in plain language, or needs help
+  choosing between keyword research, clustering, competitive analysis, and
+  link prospecting. Triggers: "seo coach", "new to seo", "explain openseo",
+  "what seo should i do", "seo strategy help".
+category: seo
+tier: nice-to-have
+layer: strategy
+reads:
+  - brand/keyword-plan.md
+  - brand/positioning.md
+env_vars:
+  - OPENSEO_API_KEY
+  - OPENSEO_API_BASE
+triggers:
+  - seo coach
+  - new to seo
+  - explain openseo
+  - what seo should i do
+  - seo strategy help
+---
+
+# OpenSEO Coach
+
+A friendly coach for the mktg + OpenSEO stack. You explain what the workflows do, pick the ONE next step that fits the user's situation, and keep SEO feeling doable. You write no files; you route, explain, and build confidence.
+
+## On Activation
+
+1. Read `brand/keyword-plan.md` and `brand/positioning.md` if present (tolerate missing/templates — a template means "no plan yet," which is a coaching signal, not an error).
+2. Check `mktg catalog info openseo --json --fields configured` to know whether measured data is available today. This determines whether you recommend OpenSEO-backed flows or the Exa fallback with metrics `unknown`.
+3. Check `.seo/openseo.json` — no binding means `openseo-project-setup` is the likely first step.
+
+## First Response
+
+Ask in one small batch:
+
+- Are you new to SEO, experienced, or in between?
+- What site or project is this?
+- Strategy, execution help, or tool explanation?
+
+Then offer 2–4 concrete options, never a menu of ten. Example openers:
+
+- "Let's set up your SEO project context." (`openseo-project-setup`)
+- "Let's find keyword opportunities." (`openseo-keyword-research`)
+- "Let's map keywords to pages." (`openseo-keyword-clustering`)
+- "Let's study one competitor." (`openseo-competitor-analysis`)
+
+## What Each Workflow Does (plain language)
+
+| Skill | One-liner |
+|---|---|
+| `openseo-project-setup` | Binds this repo to an OpenSEO project; connects GSC |
+| `openseo-keyword-research` | Finds search opportunities with real volume/KD/intent |
+| `openseo-keyword-clustering` | Groups keywords by intent and maps them to pages |
+| `openseo-competitive-landscape` | Who wins this market and why |
+| `openseo-competitor-analysis` | Deep dive on one competitor's keywords and gaps |
+| `openseo-link-prospecting` | Finds sites likely to link to you + outreach drafts |
+| `keyword-research` (mktg) | The playbook version; Exa-backed when OpenSEO is absent |
+
+## Data-Source Coaching (the distinction users trip on)
+
+- **OpenSEO MCP** = third-party measured data (KD, volume, SERP, backlinks, rank tracking). Costs DataForSEO credit per call — that's why bulk work asks first.
+- **GSC** = the user's OWN first-party data (clicks/impressions/position). Free. Always the best starting point when connected.
+- **Exa/web search** = open-web discovery and narrative context. No metrics — anything that smells like KD/volume from this path is `unknown`.
+- **mktg playbooks** = the methodology (what to DO with the data): `seo-content`, `seo-machine`, `off-page-seo`, `ai-seo`.
+
+## Coaching Patterns
+
+- **Unsure user**: clarify goal → inventory what they have → pick ONE workflow → explain what happens → ask only for the next input.
+- **Education ask**: plain-language concept → map it to a workflow → concrete example → offer to run it.
+- **Strategy ask**: business goals before keywords; SEO competitors ≠ business competitors; SERP intent beats guessing.
+- **Execution ask**: move fast into the workflow; OpenSEO data when configured; confirm before any `save_keywords` or bulk call.
+
+## Anti-Patterns
+
+- **Offering a ten-item menu** — because choice paralysis is the #1 reason SEO efforts stall at week one. One next step beats ten options every time.
+- **Explaining SEO jargon with more jargon** — because the user asked a coach, not a course. If a concept needs three acronyms, the explanation isn't ready.
+- **Recommending OpenSEO bulk research when GSC is connected and free** — because first-party striking-distance terms are higher signal AND zero credit cost; spending money before reading free data is backwards.
+- **Pretending OpenSEO browses pages or finds contacts** — because it doesn't; web/search/browser tools do that part (see `openseo-link-prospecting`'s split). Misattribution teaches the user a wrong mental model that breaks later.
+- **Coaching toward a workflow the data can't support** — because recommending measured-KD research with no OpenSEO connection sets the user up for a wall. Check readiness first; name the fallback explicitly.
+
+---
+
+*Adapted from [every-app/open-seo](https://github.com/every-app/open-seo) `.agents/skills/seo-coach` (MIT). Coaching content upstream; mktg routing, readiness checks, and cost framing added here.*

--- a/skills/openseo-competitive-landscape/SKILL.md
+++ b/skills/openseo-competitive-landscape/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: openseo-competitive-landscape
+description: >-
+  Map who is winning an SEO market with measured data — recurring SERP
+  domains, organic footprints, winning content themes, backlink authority,
+  and the gaps worth attacking. Use this skill for market-level questions
+  ("who ranks for X", "how competitive is this space", "where are the SEO
+  openings") before committing to keyword targets or content themes. For one
+  named competitor, use openseo-competitor-analysis instead. Triggers:
+  "competitive landscape seo", "who ranks for", "seo market map", "how
+  competitive is", "serp competitors".
+category: seo
+tier: nice-to-have
+layer: strategy
+reads:
+  - brand/landscape.md
+  - brand/competitors.md
+writes:
+  - brand/landscape.md
+env_vars:
+  - OPENSEO_API_KEY
+  - OPENSEO_API_BASE
+triggers:
+  - competitive landscape seo
+  - who ranks for
+  - seo market map
+  - how competitive is
+  - serp competitors
+allowed-tools:
+  - Bash(mktg catalog *)
+  - Bash(mktg run *)
+---
+
+# OpenSEO Competitive Landscape
+
+Answer with measured data: who is winning this SEO market, what content works for them, and where the openings are. Findings update `brand/landscape.md` (mktg's market memory) with an evidence tier mktg's `landscape-scan` cannot reach alone.
+
+## On Activation
+
+1. **Catalog + binding**: `mktg catalog info openseo --json --fields configured` + `.seo/openseo.json`. No OpenSEO → fall back to `landscape-scan` (Exa qualitative) and label authority/metrics `unknown`.
+2. **Brand grounding**: read `brand/landscape.md` + `brand/competitors.md` (tolerate templates) — known competitors seed the query set; positioning filters "SEO competitor" from "business competitor."
+
+## OpenSEO MCP Tools
+
+- `research_keywords` + `get_keyword_metrics`: build + validate a 5–10 query market set (mixed intent: informational, commercial, comparison, tool terms).
+- `find_serp_competitors`: recurring domains across the keyword set at scale — use before manual SERP counting.
+- `get_serp_results`: inspect live SERP composition/features (≤10 queries per call).
+- `get_domain_overview`: organic footprint for top 3–5 recurring domains.
+- `get_ranked_keywords`: exact ranking keywords/URLs/intents for leaders.
+- `get_backlinks_overview`: authority comparison where rankings look authority-driven (may be unavailable on some accounts — continue without it).
+- `get_search_console_performance`: when the user's own domain is compared and GSC is connected, anchor THEIR side with first-party data instead of third-party estimates.
+
+## Workflow
+
+1. Define the market query set (positioning-filtered, mixed intent).
+2. `find_serp_competitors` for recurring domains; `get_keyword_metrics` to validate demand/difficulty.
+3. Group recurring domains by type: direct product competitors, publishers/media, marketplaces/directories, communities/forums, docs/resources.
+4. `get_domain_overview` top 3–5; `get_ranked_keywords` for direct competitors + relevant publishers; `get_backlinks_overview` where authority explains wins.
+5. Synthesize: winning content types, SERP formats, authority advantages, underserved angles.
+6. Update `brand/landscape.md`: leaders, winnable area, biggest barrier, query set used, content formats that work, keyword/theme gaps — dated, with the measured-vs-estimate caveat.
+7. Recommend next: `openseo-competitor-analysis` (one domain), `openseo-keyword-clustering` (page mapping), or `seo-content`.
+
+## Output Format
+
+| Domain | Type | Why they matter | Organic footprint | Winning themes | Weakness/gap |
+| ------ | ---- | --------------- | ----------------- | -------------- | ------------ |
+
+## Anti-Patterns
+
+- **Treating business competitors as SEO competitors** — because the company that competes for customers often isn't who competes for SERPs (publishers and directories win informational queries). Label domain types; never merge the lists.
+- **Quoting estimate numbers as exact traffic** — because third-party organic estimates can be off by multiples, and a plan built on fake precision breaks on contact with reality. Say "estimate" or "directional."
+- **Small query sets presented as market truth** — because 4 queries is a peek, not a map. Call small-set results directional and say what would confirm them.
+- **Stopping at "X is winning" without the why** — because a leader list with no content-theme or authority explanation gives the user nothing to act on. Every leader gets a "why they win" and a "where they're weak."
+- **Abandoning the analysis when backlinks are unavailable** — because SERP + domain evidence still answers "who and what." Degrade gracefully and name the missing tier.
+
+---
+
+*Adapted from [every-app/open-seo](https://github.com/every-app/open-seo) `.agents/skills/competitive-landscape` (MIT). Workflow upstream; mktg brand-memory writes and fallback wiring added here.*

--- a/skills/openseo-competitor-analysis/SKILL.md
+++ b/skills/openseo-competitor-analysis/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: openseo-competitor-analysis
+description: >-
+  Deep-dive ONE competitor's organic footprint — exact ranking keywords and
+  URLs, content themes, backlink profile, and exploitable gaps — with
+  findings written into brand/competitors.md. Use this skill when the user
+  names a competitor and wants to know what to learn from them, counter, or
+  outrank, including head-to-head comparisons against the user's own domain.
+  For market-level mapping first, use openseo-competitive-landscape.
+  Triggers: "analyze competitor", "competitor keywords", "competitor
+  backlinks", "beat <competitor>", "competitor seo teardown".
+category: seo
+tier: nice-to-have
+layer: strategy
+reads:
+  - brand/competitors.md
+  - brand/positioning.md
+writes:
+  - brand/competitors.md
+env_vars:
+  - OPENSEO_API_KEY
+  - OPENSEO_API_BASE
+triggers:
+  - analyze competitor
+  - competitor keywords
+  - competitor backlinks
+  - beat competitor
+  - competitor seo teardown
+allowed-tools:
+  - Bash(mktg catalog *)
+  - Bash(mktg run *)
+---
+
+# OpenSEO Competitor Analysis
+
+Analyze one competitor deeply enough to decide what to learn from, avoid, counter-position against, or outrank. Findings merge into `brand/competitors.md` — mktg's competitor memory that `competitive-intel` maintains qualitatively and this skill now grounds in measured rows.
+
+## On Activation
+
+1. **Catalog + binding**: `mktg catalog info openseo --json --fields configured` + `.seo/openseo.json`. No OpenSEO → hand off to `competitive-intel` (Exa qualitative), labeling metrics `unknown`.
+2. **Brand grounding**: read `brand/competitors.md` + `brand/positioning.md` (tolerate templates). If the competitor isn't named, ask — never guess the domain.
+
+## OpenSEO MCP Tools
+
+- `get_domain_overview`: baseline organic traffic + keyword count (both domains when comparing).
+- `get_ranked_keywords`: exact keyword/URL/rank/intent/traffic rows. Use `maxRank`, `minSearchVolume`, `excludeBrandTerms`, `resultTypes` filters to keep rows relevant.
+- `get_backlinks_overview`: backlink/referring-domain profile (may be unavailable — continue without it).
+- `find_serp_competitors`: validate the named competitor actually overlaps in search.
+- `get_serp_results`: head-to-head SERP checks for the important shared terms.
+- `get_search_console_performance`: when comparing to the user's domain and GSC is connected, the USER's baseline is first-party — never estimate your own side from third-party data.
+- `research_keywords`: expand gap terms.
+
+## Workflow
+
+1. `get_domain_overview` for the competitor (and the user's domain when comparing).
+2. `get_ranked_keywords` for the competitor with sensible filters; same for the user, or `get_serp_results` for shared terms when a lighter check suffices.
+3. `find_serp_competitors` when the supplied competitor's search overlap is unclear.
+4. Group keywords into themes: product/category, alternatives/comparisons, templates/tools, educational guides, branded demand.
+5. `get_backlinks_overview` when authority appears to explain rankings.
+6. `get_serp_results` for the important head-to-head terms.
+7. Synthesize the plan: what they do well, where they're vulnerable, which pages/keywords to pursue, what NOT to copy.
+8. Merge into `brand/competitors.md` (preserve existing sections; date the entry; confirm before overwriting populated competitor entries).
+9. Hand off: `competitor-alternatives` for "X vs Y" pages, `seo-content` for gap-driven briefs, `openseo-keyword-clustering` for page mapping.
+
+## Output Format
+
+Start with: snapshot, biggest lesson, best opportunity to beat them. Then:
+
+| Area | Competitor pattern | Evidence | OpenSEO opportunity |
+| ---- | ------------------ | -------- | ------------------- |
+
+## Anti-Patterns
+
+- **Treating every competitor keyword as desirable** — because ranking for a term and PROFITING from a term are different things; filter through positioning before anything lands in a plan.
+- **Inferring page-level content strategy from keyword rows alone** — because a keyword list can't tell you WHY a page works (structure, depth, format). Use SERP/web evidence for page-level claims.
+- **Estimating the user's own performance from third-party data when GSC exists** — because first-party clicks/impressions/position are free and exact; third-party estimates of your own site are the worst data in the room.
+- **Recommending "copy what they do"** — because imitation pages lose to the original on authority and freshness. Recommend a stronger angle on the same intent, never a replica.
+- **Separating evidence from inference nowhere** — because "they rank for X" (evidence) and "their content strategy is Y" (inference) carry different confidence and must read differently in `brand/competitors.md`.
+
+---
+
+*Adapted from [every-app/open-seo](https://github.com/every-app/open-seo) `.agents/skills/competitor-analysis` (MIT). Workflow upstream; mktg brand-memory writes and handoff wiring added here.*

--- a/skills/openseo-keyword-clustering/SKILL.md
+++ b/skills/openseo-keyword-clustering/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: openseo-keyword-clustering
+description: >-
+  Cluster keywords by search intent and map each cluster to an existing or
+  proposed page, with cannibalization detection from Search Console. Use this
+  skill when the user has a keyword list (saved set, brand/keyword-plan.md,
+  GSC export, or seed topic) and needs page targets, content briefs, or a
+  site map for SEO pages — especially before seo-content or seo-machine page
+  generation. Triggers: "cluster keywords", "keyword mapping", "map keywords
+  to pages", "keyword cannibalization", "which page should target".
+category: seo
+tier: nice-to-have
+layer: strategy
+reads:
+  - brand/keyword-plan.md
+writes:
+  - brand/keyword-plan.md
+env_vars:
+  - OPENSEO_API_KEY
+  - OPENSEO_API_BASE
+triggers:
+  - cluster keywords
+  - keyword mapping
+  - map keywords to pages
+  - keyword cannibalization
+  - which page should target
+allowed-tools:
+  - Bash(mktg catalog *)
+  - Bash(mktg run *)
+---
+
+# OpenSEO Keyword Clustering
+
+Group keywords into page-level clusters and assign each to an existing URL, a new page proposal, or a do-not-target bucket. Output lands in `marketing/seo/clusters/*.md` (per-cluster briefs) and feeds `seo-content` / `seo-machine` with measured page targets.
+
+## On Activation
+
+1. **Catalog + binding**: `mktg catalog info openseo --json --fields configured` and `.seo/openseo.json` for `projectId`. No binding → `openseo-project-setup` first. No OpenSEO at all → do lexical clustering with Exa context but label every cluster "SERP-unvalidated."
+2. **Keyword source**: prefer (a) `brand/keyword-plan.md` populated sections, (b) `list_saved_keywords` with a tag, (c) GSC live data, (d) seed discovery via `research_keywords`. Under 10 usable terms → simple map, no clustering ceremony.
+
+## OpenSEO MCP Tools
+
+- `get_search_console_performance` with `dimensions: ["query","page"]`: the cannibalization truth source — one query splitting impressions across multiple URLs means existing cannibalization, not theoretical risk.
+- `get_ranked_keywords`: domain/page-driven clustering from exact ranking rows + URLs.
+- `get_serp_results`: SERP-overlap validation for borderline terms (small batches, ≤10).
+- `list_saved_keywords` / `research_keywords`: source sets.
+- `save_keywords`: apply cluster tags ONLY after confirmation.
+
+## Workflow
+
+1. Assemble the candidate set from the source hierarchy above; dedupe and drop off-strategy terms.
+2. Cluster by intent and page type: same SERP intent + similar ranking pages belong together; different intent/buyer stage/SERP format splits. Lexical similarity is NOT evidence of same-page fit.
+3. Borderline terms: small `get_serp_results` overlap check.
+4. Assign each cluster: existing URL (if supplied and fitting), new-page proposal, or do-not-target/later.
+5. Cannibalization check: GSC query+page data first; otherwise flag where two proposed pages share one intent.
+6. Write per-cluster briefs to `marketing/seo/clusters/<cluster-slug>.md`: page type, searcher problem, required sections, internal-link targets, priority.
+7. Optionally tag clusters with `save_keywords` after confirmation.
+8. Hand off: `seo-content` for single pages, `seo-machine` for programmatic batches — both now have measured targets instead of vibes.
+
+## Output Format
+
+Summary first: cluster count, pages to create, pages to update, cannibalization issues. Then:
+
+| Cluster | Primary keyword | Secondary keywords | Intent | Target page | Priority | Notes |
+| ------- | --------------- | ------------------ | ------ | ----------- | -------- | ----- |
+
+## Anti-Patterns
+
+- **Clustering by word similarity alone** — because "best crm for dentists" and "crm pricing dentists" share words but not intent, and forcing them onto one page guarantees neither ranks. SERP intent wins; check overlap when unsure.
+- **Clustering tiny sets** — because 6 keywords don't need a clustering framework, they need a paragraph. Under 10 terms, write a simple map.
+- **Theoretical cannibalization warnings without data** — because crying cannibalization on every overlapping term freezes page production; GSC query+page splits are the only proof. No GSC → label it "potential," not "confirmed."
+- **Retagging saved keywords without confirmation** — because tags are shared account state; a bulk retag can destroy someone else's organization. Confirm first.
+- **Producing clusters with no page assignment** — because a cluster without a target page is trivia. Every cluster ends in an existing URL, a new proposal, or an explicit do-not-target decision.
+
+---
+
+*Adapted from [every-app/open-seo](https://github.com/every-app/open-seo) `.agents/skills/keyword-clustering` (MIT). Workflow upstream; mktg artifact paths, brand-memory reads, and handoff wiring added here.*

--- a/skills/openseo-keyword-research/SKILL.md
+++ b/skills/openseo-keyword-research/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: openseo-keyword-research
+description: >-
+  Discover keyword opportunities with MEASURED volume, keyword difficulty,
+  CPC, and intent from OpenSEO, then write them into brand/keyword-plan.md.
+  Use this skill whenever someone asks for keyword difficulty, KD, search
+  volume, keyword ideas with metrics, striking-distance opportunities from
+  Search Console, or SERP-validated keyword priorities. For qualitative
+  research without an OpenSEO connection, use mktg's keyword-research
+  instead (metrics will be unknown). Triggers: "keyword difficulty",
+  "search volume", "keyword opportunities", "striking distance keywords",
+  "measured keyword research".
+category: seo
+tier: nice-to-have
+layer: strategy
+reads:
+  - brand/keyword-plan.md
+  - brand/positioning.md
+writes:
+  - brand/keyword-plan.md
+env_vars:
+  - OPENSEO_API_KEY
+  - OPENSEO_API_BASE
+triggers:
+  - keyword difficulty
+  - search volume
+  - keyword opportunities
+  - striking distance keywords
+  - measured keyword research
+allowed-tools:
+  - Bash(mktg catalog *)
+  - Bash(mktg run *)
+---
+
+# OpenSEO Keyword Research
+
+Turn seed topics into a prioritized, MEASURED keyword opportunity set and land it in `brand/keyword-plan.md`. mktg's `keyword-research` is the playbook (methodology); this skill is the measured-data engine behind it when OpenSEO is configured.
+
+## On Activation
+
+1. **Catalog check**: `mktg catalog info openseo --json --fields configured` — if not configured, stop spending: state the gap and hand off to Exa-backed `keyword-research` with metrics marked `unknown`.
+2. **Project binding**: read `.seo/openseo.json` for `projectId`. Missing → run `openseo-project-setup` first (or ask the user for the project id).
+3. **Brand grounding**: read `brand/positioning.md` + existing `brand/keyword-plan.md` (tolerate templates). Business-fit beats volume-fit — the positioning file is the filter.
+
+## OpenSEO MCP Tools
+
+- `get_search_console_performance`: when GSC is connected, START here. High `rowLimit`, filter average position ~5–20 client-side (the API sorts by clicks, not position). These striking-distance terms are the fastest wins — and zero extra credit cost.
+- `get_keyword_metrics`: hydrate up to 700 keywords per call with volume, KD, intent, CPC, trends. Use on striking-distance terms and every candidate set.
+- `research_keywords`: discovery from 1–5 seeds per call; prefer ~150 results unless exhaustive research was requested.
+- `get_ranked_keywords`: when the brief includes a domain/page — exact ranking rows (near-misses, competitor-owned terms).
+- `get_serp_results`: inspect SERPs for top candidates when intent is ambiguous. Keep batches small (≤10 queries).
+- `list_saved_keywords`: avoid re-researching what's already saved.
+- `save_keywords`: ONLY after explicit user confirmation, with concise tags (`topic:<t>`, `intent:<i>`, `page:<slug>`).
+
+## Workflow
+
+1. Normalize seeds into 2–5 distinct research angles filtered by positioning.
+2. GSC connected? Pull striking-distance terms first and hydrate with `get_keyword_metrics`. Work that list before broad discovery.
+3. `research_keywords` per angle; `get_keyword_metrics` to hydrate; `get_ranked_keywords` if a domain is in the brief.
+4. Remove irrelevant, duplicate, branded-only, and off-intent terms.
+5. Prioritize by practical opportunity: business fit → clear intent → reasonable KD → volume/CPC signal → winnable SERP.
+6. `get_serp_results` for high-potential or ambiguous terms when SERP intent would change the call.
+7. Write the shortlist into `brand/keyword-plan.md` (preserve its required sections per `brand/SCHEMA.md`; confirm before overwriting populated sections).
+8. Present: best opportunity theme, top keywords now, keywords to save, SERP caveats. Then next actions: `openseo-keyword-clustering`, `seo-content`, or save.
+
+## Cost Discipline
+
+- State estimated call counts before bulk pulls (>200 keywords) and get confirmation.
+- Small exploratory batches are fine without asking.
+- GSC-first ordering exists precisely to avoid spending credits on data the user already owns.
+
+## Anti-Patterns
+
+- **Inventing metrics when OpenSEO returns nothing** — because a hallucinated KD of "about 35" silently becomes the foundation of a content plan. If OpenSEO doesn't return a value, write `unknown`.
+- **Volume-first prioritization** — because a 10k-volume term that doesn't match the product converts nobody and burns months. Positioning filters the list before metrics rank it.
+- **`save_keywords` without explicit confirmation** — because saves mutate the user's OpenSEO account and bulk saves burn credit. Ask, state the count, then save.
+- **Skipping the GSC-first pass when GSC is connected** — because striking-distance terms (positions 5–20) are provably the cheapest wins in SEO and they're free to read. Discovery research before first-party data is wasted spend.
+- **Overwriting a populated `keyword-plan.md` without confirmation** — because that file is brand memory other skills build on (`seo-content`, `seo-machine`). Merge; confirm destructive rewrites.
+
+## Progressive Enhancement
+
+| Level | Behavior |
+|---|---|
+| L0 (no OpenSEO) | Hand off to Exa-backed `keyword-research`; metrics `unknown` |
+| L1 (`OPENSEO_API_KEY`) | Metrics via available calls; MCP steps deferred |
+| L2 (MCP connected) | Full workflow incl. SERP validation |
+| L3 (GSC connected) | Striking-distance-first ordering; highest-signal path |
+
+---
+
+*Adapted from [every-app/open-seo](https://github.com/every-app/open-seo) `.agents/skills/keyword-research` (MIT). Workflow and tool guidance upstream; mktg brand-memory writes, positioning filter, and cost discipline added here.*

--- a/skills/openseo-link-prospecting/SKILL.md
+++ b/skills/openseo-link-prospecting/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: openseo-link-prospecting
+description: >-
+  Find realistic link prospects with SERP and backlink evidence, discover
+  contact paths via web tools, and draft personalized outreach — with targets
+  saved to .seo/backlink-targets.json for off-page-seo campaigns. Use this
+  skill when the user has a linkable asset (study, tool, guide, template,
+  product page) and wants backlinks, resource-page inclusions, or comparison
+  mentions. Triggers: "link prospecting", "find backlink opportunities",
+  "resource page outreach", "get backlinks for", "link building outreach".
+category: seo
+tier: nice-to-have
+layer: distribution
+reads:
+  - brand/positioning.md
+env_vars:
+  - OPENSEO_API_KEY
+  - OPENSEO_API_BASE
+triggers:
+  - link prospecting
+  - find backlink opportunities
+  - resource page outreach
+  - get backlinks for
+  - link building outreach
+allowed-tools:
+  - Bash(mktg catalog *)
+  - Bash(mktg run *)
+---
+
+# OpenSEO Link Prospecting
+
+Find pages, sites, and authors that might realistically reference the user's linkable asset — then hand `off-page-seo` a qualified target list at `.seo/backlink-targets.json` instead of a cold start.
+
+## On Activation
+
+1. **Catalog + binding**: `mktg catalog info openseo --json --fields configured` + `.seo/openseo.json`. No OpenSEO → prospect with Exa search only (queries below still apply) and label authority data `unknown`.
+2. **Clarify the asset**: what page/study/tool/template is being promoted and WHY someone would reference it. No clear asset + reason → fix that first; outreach without a reason is spam.
+3. Read `brand/positioning.md` for angle/audience fit (tolerate missing).
+
+## OpenSEO MCP Tools
+
+- `get_serp_results`: find ranking articles, listicles, resource pages, comparisons, statistics pages (≤10 queries per call).
+- `get_backlinks_overview`: competitor backlink/referring-domain patterns — where do THEY get links (may be unavailable; continue without).
+- `get_domain_overview`: qualify strong prospect domains.
+- `get_ranked_keywords`: topical-fit checks on prospects/competitors.
+- `research_keywords`: expand prospecting queries.
+
+## Contact Discovery (NOT OpenSEO)
+
+Contact paths come from web/search/browser tools (Firecrawl fetch, Exa search, browser automation) — never attribute these to OpenSEO:
+
+- Author byline pages, contact pages, editorial guidelines, about/team pages
+- LinkedIn/X/Bluesky profiles, newsletter mastheads
+- Public emails in HTML or visible text; `Person`/`Organization`/`sameAs`/`email` structured data
+
+Record only contact details actually found, each with its source URL.
+
+## Prospecting Query Patterns
+
+`<topic> resources` · `best <category> tools` · `<competitor> alternatives` · `<topic> statistics` · `<topic> guide` · `<topic> examples` · `<topic> templates` · `<topic> software` · `<topic> for <audience>`
+
+## Workflow
+
+1. Build 5–10 prospecting queries from the asset; `get_serp_results` in batches.
+2. Competitors supplied? `get_backlinks_overview` their strongest domains first.
+3. Filter: keep editorial pages, resource lists, comparisons, statistics, templates, curated directories. Drop homepages, login walls, thin affiliate, spam, and direct competitors (unless a comparison angle is valid).
+4. Per prospect, define the angle: broken/missing resource, better current data, useful tool/template, comparison inclusion, expert quote.
+5. Contact discovery on the strongest prospects via web tools (source URLs recorded).
+6. Write targets to `.seo/backlink-targets.json`:
+
+```json
+{ "version": 1, "updatedAt": "<iso>", "asset": "<url>", "targets": [{ "url": "", "domain": "", "source": "", "relevance": "", "angle": "", "contactPath": "", "contactSource": "", "priority": "high|med|low", "status": "new" }] }
+```
+
+7. Draft 2–3 reusable outreach messages (resource inclusion, article update, comparison angle). Hand the list to `off-page-seo` for the campaign cadence.
+
+## Output Format
+
+| Prospect URL | Domain | Source | Relevance | Suggested angle | Contact path | Priority |
+| ------------ | ------ | ------ | --------- | --------------- | ------------ | -------- |
+
+## Anti-Patterns
+
+- **Inventing emails, handles, or contact names** — because a single fabricated contact burns the user's credibility with a real human. Only record what was found, with the source URL; otherwise name the next discovery step.
+- **Attributing contact discovery to OpenSEO** — because OpenSEO finds PROSPECTS; web/browser tools find CONTACTS. The misattribution teaches a wrong tool model and hides the real source when details need re-verification.
+- **Mass-template outreach** — because editors can smell a blast, and one spam report damages the domain's future deliverability. Personalize by page and reason, or don't send.
+- **Prospecting without a linkable asset and reason** — because "please link to my homepage" converts at ~0%. No asset + reason, no outreach.
+- **Skipping competitor/paid-placement flags** — because pitching a direct competitor or a pay-to-play listicle wastes the user's outreach capital and can backfire publicly. Flag both in the target list.
+
+---
+
+*Adapted from [every-app/open-seo](https://github.com/every-app/open-seo) `.agents/skills/link-prospecting` (MIT). Workflow upstream; mktg artifact paths, off-page-seo handoff, and contact-attribution discipline added here.*

--- a/skills/openseo-project-setup/SKILL.md
+++ b/skills/openseo-project-setup/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: openseo-project-setup
+description: >-
+  Bind this repo to an OpenSEO project and prepare the local SEO state
+  directories. Use this skill when starting SEO work on a fresh project, when
+  `.seo/openseo.json` does not exist yet, when the OpenSEO project id is
+  unknown, or when Google Search Console needs connecting before keyword or
+  rank work can start. Triggers: "set up openseo", "link seo project",
+  "connect gsc", "start seo for this site", "openseo project id".
+category: seo
+tier: nice-to-have
+layer: foundation
+reads:
+  - brand/keyword-plan.md
+writes:
+  - brand/keyword-plan.md
+env_vars:
+  - OPENSEO_API_KEY
+  - OPENSEO_API_BASE
+triggers:
+  - set up openseo
+  - link seo project
+  - connect gsc
+  - start seo for this site
+  - openseo project id
+allowed-tools:
+  - Bash(mktg catalog *)
+  - Bash(mktg doctor *)
+  - Bash(mktg run *)
+---
+
+# OpenSEO Project Setup
+
+Bind the current repo to an OpenSEO project so every other `openseo-*` skill has a stable project id, and prepare mktg's local SEO state contract. This is a one-time-per-repo handshake, not an audit and not research.
+
+## On Activation
+
+Run these steps in order. Each has a fallback; never block on missing context.
+
+### Step 1 — Check catalog readiness
+
+```bash
+mktg catalog info openseo --json --fields configured,missing_envs,mcp
+```
+
+- Exit 1 → the openseo catalog is missing; upgrade marketing-cli. Stop.
+- `configured: false` → name the missing envs from `missing_envs`. Hosted path: sign up at openseo.so, connect the MCP in the user's agent client (root `.mcp.json` ships the `openseo` server), and/or set `OPENSEO_API_KEY` for non-interactive automation. Without any connection, stop after writing the gap note — research skills will fall back to Exa with metrics `unknown`.
+
+### Step 2 — Read brand grounding
+
+Read `brand/keyword-plan.md` and `brand/positioning.md` if they exist (tolerate missing). The domain, audience, and positioning facts go into the project record. If `brand/` is all templates, note it and recommend `/cmo` foundation first — SEO inputs without positioning are guesses.
+
+### Step 3 — Resolve the OpenSEO project
+
+Via the OpenSEO MCP tools: `whoami` (if available) then `list_projects`. Match the project to the user's domain. If the list is ambiguous, ask which project. If MCP is unavailable but `OPENSEO_API_KEY` is set, note that interactive MCP steps are deferred and record what is known.
+
+Do NOT call research tools to test connectivity — `whoami`/`list_projects` are the only probes allowed here (they are free; research calls spend DataForSEO credit).
+
+### Step 4 — Write the binding + state directories
+
+Create or update `.seo/openseo.json`:
+
+```json
+{ "version": 1, "projectId": "<id>", "domain": "<domain>", "mcpUrl": "https://app.openseo.so/mcp", "linkedAt": "<iso>", "updatedAt": "<iso>" }
+```
+
+Create `.seo/` with `rank-snapshots/` if rank tracking is in scope. If `brand/keyword-plan.md` is a template, leave it alone — the first research run populates it; do not pre-fill with placeholders.
+
+### Step 5 — Google Search Console
+
+GSC is the richest first-party signal (striking-distance terms, cannibalization).
+
+- **Hosted preferred**: point the user at the OpenSEO project's Integrations page to connect GSC natively; later skills read it live via `get_search_console_performance`.
+- **Fallback (self-host / file preference)**: ask for CSV exports into `.seo/gsc/` (`queries-last-3-months.csv`, `pages-last-3-months.csv`, 16-month variants when available).
+
+Never claim GSC is connected unless `get_search_console_performance` confirms it — it returns a "not connected" message otherwise.
+
+### Step 6 — Recommend the next skill
+
+| Situation | Next |
+|---|---|
+| No keyword plan yet | `openseo-keyword-research` |
+| Has keyword list / GSC data | `openseo-keyword-clustering` |
+| Market unclear | `openseo-competitive-landscape` |
+| Known competitor | `openseo-competitor-analysis` |
+
+## Anti-Patterns
+
+- **Running research calls as a connectivity test** — because every OpenSEO research call can spend DataForSEO credit, and a setup handshake has no business spending money. `whoami` and `list_projects` are free; use only those.
+- **Claiming GSC is connected without proof** — because downstream skills (keyword research's striking-distance strategy) silently change behavior based on that claim; a false positive turns first-party data into invented data. Verify with `get_search_console_performance` or say "not connected."
+- **Pre-filling `brand/keyword-plan.md` with placeholder keywords** — because template-detection (SHA-256) and `mktg plan` health read placeholder content as "populated," and every downstream skill then trusts fake keywords. Leave the template until real research lands.
+- **Forking state into a second project file** — because two project ids drift and every skill has to guess which is canonical. `.seo/openseo.json` is the single binding; update it, never duplicate it.
+- **Asking the user 15 questions before writing anything** — because setup should orient, not assign homework. Capture what is known, mark the rest `unknown`, and let research skills fill gaps on demand.
+
+## Progressive Enhancement
+
+| Level | Behavior |
+|---|---|
+| L0 (no envs, no MCP) | Gap note only; point at Exa-backed `keyword-research` with metrics `unknown` |
+| L1 (`OPENSEO_API_KEY`) | Binding written; MCP-dependent steps documented as deferred |
+| L2 (MCP connected) | Full project resolution + GSC live check |
+| L3 (GSC connected) | `.seo/gsc/` or live GSC feeds keyword research + clustering directly |
+
+---
+
+*Adapted from [every-app/open-seo](https://github.com/every-app/open-seo) `.agents/skills/seo-project-setup` (MIT). Upstream workflow by the OpenSEO maintainers; mktg state contract, brand grounding, and cost discipline added here.*

--- a/skills/seo-audit/SKILL.md
+++ b/skills/seo-audit/SKILL.md
@@ -46,6 +46,11 @@ This skill operates in three modes. Select based on what the user needs:
 
 1. Read `brand/` directory: load `voice-profile.md`, `stack.md`, `audience.md`, `keyword-plan.md` if present.
 2. Show what loaded:
+
+## Backend Selection
+
+1. **OpenSEO configured**: pull rank snapshots, GSC performance, and technical SERP context from OpenSEO (`get_search_console_performance`, `get_ranked_keywords`, `get_serp_results`) so the audit prioritizes pages by measured impact. Store snapshots in `.seo/rank-snapshots/`.
+2. **OpenSEO absent**: audit with crawl/Exa evidence only; label ranking impact estimates `unknown`.
    ```
    Brand context loaded:
    ├── Voice Profile   ✓/✗

--- a/skills/seo-machine/SKILL.md
+++ b/skills/seo-machine/SKILL.md
@@ -61,6 +61,11 @@ Striking-distance boosts (pages already ranking pos 5–20 in GSC) jump the queu
 
 1. Load brand context where present: `brand/keyword-plan.md`, `positioning.md`, `competitors.md`, `audience.md`, `stack.md`. Missing files are fine.
 2. Surface what loaded:
+
+## Backend Selection
+
+1. **OpenSEO configured**: validate KD/competition BEFORE generating pages (`get_keyword_metrics`, `get_serp_results`) — programmatic SEO on unvalidated targets manufactures pages nobody can rank for. Consume `marketing/seo/clusters/*.md` from `openseo-keyword-clustering` when present.
+2. **OpenSEO absent**: proceed with playbook validation (Exa + manual checks); mark competition estimates `unknown` in phase docs.
    ```
    Brand context loaded:
    ├── Keyword Plan    ✓/✗  (seeds the roadmap; ✗ → generate during Initialize)

--- a/studio/CLAUDE.md
+++ b/studio/CLAUDE.md
@@ -4,7 +4,7 @@
 
 ## Driver/Dashboard Contract
 
-- **Driver:** /cmo (Claude Code) runs in the user's terminal. It reads brand/ files, executes the 64 marketing skills, and calls the studio's HTTP API (POST `/api/activity/log`, `/api/navigate`, `/api/toast`, `/api/brand/refresh`, etc.) to keep the dashboard in sync.
+- **Driver:** /cmo (Claude Code) runs in the user's terminal. It reads brand/ files, executes the 71 marketing skills, and calls the studio's HTTP API (POST `/api/activity/log`, `/api/navigate`, `/api/toast`, `/api/brand/refresh`, etc.) to keep the dashboard in sync.
 - **Dashboard:** Next.js + Bun server. Subscribes to `/api/events` (SSE) for live updates. Renders primary surfaces (Pulse, Signals, Publish, Brand, Settings) + a right-hand Activity panel that shows the /cmo activity stream. Trend radar is a Signals mode; Audience summary and next actions live on Pulse.
 - **Activity panel:** Replaces the old chat slot. Lists skill runs, brand writes, publishes, navigates, and toasts  -  a live log of what /cmo is doing.
 - **AGPL firewall:** Never import `@postiz/*`. Raw fetch only over the network boundary.
@@ -115,7 +115,7 @@ This project follows the same agent-native contract as mktg itself:
 ┌──────────────────┐ ┌──────────────────┐ ┌──────────────────────────┐
 │ Next.js 16 │────▶│ Bun.serve │────▶│ Claude Code (local) │
 │ Dashboard │◀─SSE│ (local server) │ │ ├── /cmo skill │
-│ │ │ SQLite │ │ ├── 64 marketing skills │
+│ │ │ SQLite │ │ ├── 71 marketing skills │
 │ 5 surfaces + │ │ brand/ watcher │ │ ├── mktg CLI (--json) │
 │ Activity panel │ │ Job queue │ │ └── Postiz adapter │
 └──────────────────┘ └──────────────────┘ └──────────────────────────┘
@@ -182,7 +182,7 @@ Tests: 2599 pass / 0 fail / 96 files
 │ └── transcribe.ts  -  whisper.cpp + yt-dlp + ffmpeg orchestration
 ├── skills/  -  50 SKILL.md files (see §Skills below)
 ├── agents/ - 6 agent .md files (see §Agents below)
-├── skills-manifest.json  -  65 skills: triggers, categories, layers, reads, writes, env_vars
+├── skills-manifest.json  -  72 skills: triggers, categories, layers, reads, writes, env_vars
 ├── agents-manifest.json - 6 agents: categories, files, reads, writes, tier
 ├── catalogs-manifest.json  -  1 catalog (postiz): capabilities, auth, transport, license
 ├── brand/SCHEMA.md  -  schema for all 10 brand files
@@ -258,7 +258,7 @@ Rules: ~/projects/mktgmono/marketing-cli/skills/cmo/rules/ (14 files, ~1,900 lin
 ```
 
 **What /cmo knows:**
-- Routes to any of 65 skills based on user intent + brand state
+- Routes to any of 72 skills based on user intent + brand state
 - 10 named orchestration playbooks (Full Product Launch, Content Engine, Founder Voice Rebrand, Conversion Audit, Retention Recovery, Visual Identity, Video Content, Email Infrastructure, SEO Authority Build, Newsletter Launch)
 - L0-L4 progressive enhancement ladder (what's possible at each brand completeness level)
 - Error recovery + degraded-mode playbook (what to do when integrations fail)
@@ -611,7 +611,7 @@ components/workspace/skill-browser/  -  skill browser + execution trigger UI
 - Port signal severity + spike detection from Convex to local TypeScript
 
 ### Phase 5: Skill Browser + Onboarding (2-3 days)
-- Skill browser: `mktg list --json` → browse all 65 skills, one-click trigger
+- Skill browser: `mktg list --json` → browse all 72 skills, one-click trigger
 - Execution progress: running → result → files changed
 - Onboarding: detect fresh install (mktg status → needs-setup) → wizard → mktg init → foundation skills
 - First-run "wow moment": Pulse, Signals, Publish, Brand, and Settings populate as foundation skills complete
@@ -631,7 +631,7 @@ components/workspace/skill-browser/  -  skill browser + execution trigger UI
 >
 > **Dashboard layer (this repo)**: 5 workspace tabs (Pulse, Signals, Publish, Brand, Settings), Activity panel, signal severity scoring. Local-first  -  no cloud dependencies.
 >
-> **mktg** is the marketing brain  -  65 skills, /cmo orchestrator (2,400 lines of routing knowledge), brand memory (10 files that compound), upstream catalogs. This is the engine. Everything runs through `mktg --json` for infrastructure and /cmo for intelligence.
+> **mktg** is the marketing brain  -  72 skills, /cmo orchestrator (2,400 lines of routing knowledge), brand memory (10 files that compound), upstream catalogs. This is the engine. Everything runs through `mktg --json` for infrastructure and /cmo for intelligence.
 >
 > **postiz** is the distribution layer  -  30+ social providers via REST API. AGPL-firewalled. Call it, never fork it.
 >

--- a/studio/README.md
+++ b/studio/README.md
@@ -2,7 +2,7 @@
 
 > The visual layer that ships inside [`marketing-cli`](https://www.npmjs.com/package/marketing-cli). Your brand memory on disk, one agent running the show.
 
-Studio is the dashboard companion to the `mktg` CLI. The CLI ships the brain: 64 marketing skills + the `/cmo` orchestrator. Studio ships the eyes: a Next.js dashboard, a local Bun API, SQLite, live SSE, and a 21/21 agent-DX HTTP surface that `/cmo` drives via Bash + curl. No SDK, no MCP config. Claude Code already has `Bash`; that's the whole contract.
+Studio is the dashboard companion to the `mktg` CLI. The CLI ships the brain: 71 marketing skills + the `/cmo` orchestrator. Studio ships the eyes: a Next.js dashboard, a local Bun API, SQLite, live SSE, and a 21/21 agent-DX HTTP surface that `/cmo` drives via Bash + curl. No SDK, no MCP config. Claude Code already has `Bash`; that's the whole contract.
 
 Studio lives under `studio/` inside the `marketing-cli` repo as a bun-workspace member. It is not a separate package. Installing the CLI brings the launcher with it.
 
@@ -11,7 +11,7 @@ Studio lives under `studio/` inside the `marketing-cli` repo as a bun-workspace 
 ## Quick start
 
 ```bash
-npm i -g marketing-cli         # CLI + /cmo + 65 skills + studio launcher
+npm i -g marketing-cli         # CLI + /cmo + 72 skills + studio launcher
 mktg init                      # seed brand/*.md in the current project
 mktg studio                    # boot API (:3001) + dashboard (:3000)
 ```

--- a/studio/app/layout.tsx
+++ b/studio/app/layout.tsx
@@ -35,7 +35,7 @@ export const metadata: Metadata = {
     template: "%s | mktg studio",
   },
   description:
-    "Local-first marketing studio powered by /cmo -- 65 skills, brand intelligence, and social distribution in one dashboard.",
+    "Local-first marketing studio powered by /cmo -- 72 skills, brand intelligence, and social distribution in one dashboard.",
 }
 
 export default function RootLayout({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **OpenSEO plan Phases 5 + 6** (milestone S2 — workflow parity), on current main (which now has S1 via #46). Tracker rows updated on this branch.

### Phase 5 — seven adapted workflow skills (65 → 72)

Each fetched from upstream (`every-app/open-seo` `.agents/skills/*`, snapshot `f569726`, MIT) and adapted to the mktg drop-in contract: pushy frontmatter, On Activation with brand fallback, Anti-Patterns with WHY, progressive enhancement, cost discipline for DataForSEO spend, mktg artifact paths, attribution footer. Provenance via the light `upstream` manifest object (Exa-pack pattern).

| Skill | Writes into | Core discipline |
|---|---|---|
| `openseo-project-setup` | `.seo/openseo.json` binding | Connectivity probes are FREE calls only (`whoami`/`list_projects`) — never research calls |
| `openseo-coach` | none (coach) | GSC-free-first; one next step, never a ten-item menu |
| `openseo-keyword-research` | `brand/keyword-plan.md` | GSC striking-distance-first (free) before paid discovery; `unknown` > invented metrics |
| `openseo-keyword-clustering` | `marketing/seo/clusters/*.md` | SERP intent > lexical similarity; cannibalization only from GSC query+page proof |
| `openseo-competitive-landscape` | `brand/landscape.md` | SEO competitors ≠ business competitors; estimates labeled directional |
| `openseo-competitor-analysis` | `brand/competitors.md` | User's side from first-party GSC, never third-party estimates |
| `openseo-link-prospecting` | `.seo/backlink-targets.json` | Contact discovery correctly attributed to web tools, never OpenSEO; no invented contacts |

### Phase 6 — rewiring

- **Backend Selection** section on all 6 SEO playbook skills (`keyword-research`, `seo-audit`, `off-page-seo`, `ai-seo`, `seo-machine`, `competitor-alternatives`): OpenSEO measured data when configured; Exa/L0 with metrics `unknown` otherwise — single SEO path, no parallel stacks
- **`playbooks.md`**: SEO Authority Build gains a data-plane gate; Path A/B tables route through `openseo-*` when ready
- **`ecosystem.md`**: OpenSEO section + research backend matrix (OpenSEO vs Exa vs Firecrawl by job)
- **Counts 65 → 72** synced everywhere (derive-counts + CLAUDE.md/README/`/cmo` copy)
- **`keyword-research` trimmed 508 → 472 lines** — under the 500 cap for real, clearing the pre-existing audit violation

### Verification

- Root `bun test` → **3422 pass / 0 fail** (137 new contract tests auto-generated for the 7 skills; playbooks citation test green after de-backticking "unknown")
- Studio suite → 225 pass; `bun x tsc --noEmit` → clean

### Dogfood evidence

```
mktg update → 72 skills installed
mktg run openseo-{all seven} → event:"loaded" each
mktg route "keyword difficulty for crm keywords" → keyword-research (high)
  (playbook wins the generic route by design; its Backend Selection prefers OpenSEO when configured)
```

### Sequence context

Remaining OpenSEO milestones: S3 (state sync contract: `mktg seo` command group, project link + keyword sync), S4 (Studio SEO card + tests + self-host docs), S5 (native feel: plan/route/onboarding default to OpenSEO). `keyword-research` is now 28 lines under cap — headroom for S3's edits.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d221b2b7-a08b-4b51-a74a-5bb038a8ccd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d221b2b7-a08b-4b51-a74a-5bb038a8ccd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

