### PR TITLE
feat(seo): mktg seo command group — binding, named readiness, keyword sync contract (OpenSEO S3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,11 +11,11 @@
 
 ## What This Is
 
-A TypeScript/Bun agent-native marketing playbook CLI. 72 marketing skills (70 playbook + `/cmo` + `/axi`), 6 agents, 21 commands, 2 upstream catalogs. The Studio dashboard (Next.js + Bun API) ships inside the same tarball and is launched via `mktg studio`.
+A TypeScript/Bun agent-native marketing playbook CLI. 72 marketing skills (70 playbook + `/cmo` + `/axi`), 6 agents, 22 commands, 2 upstream catalogs. The Studio dashboard (Next.js + Bun API) ships inside the same tarball and is launched via `mktg studio`.
 
 | Component | Count | Purpose |
 |---|---|---|
-| `mktg` CLI | 21 commands | Infrastructure: setup, health, skill management, catalog registry, verification, and orchestration |
+| `mktg` CLI | 22 commands | Infrastructure: setup, health, skill management, catalog registry, verification, and orchestration |
 | `/cmo` skill | 1 orchestrator | Routes every marketing request to the right skill |
 | `/axi` skill | 1 orchestrator | Routes agent-tool work to AXI-catalog CLIs (gh-axi, chrome-devtools-axi, …) |
 | `brand/` directory | 10 memory files (+ SCHEMA.md) | Persistent marketing memory, compounds across sessions |

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -127,6 +127,17 @@ mktg catalog info openseo --json --fields configured,missing_envs,mcp
 # SEO data plane (research_adapters capability). mcp.default_url is the hosted
 # MCP; OPENSEO_MCP_URL overrides for self-host. OPENSEO_API_KEY enables
 # non-interactive automation; without it, SEO metrics are `unknown` (never invented).
+
+mktg seo status --json
+# SEO readiness: catalog config, .seo/openseo.json binding, .seo inventory,
+# and named readiness (not_configured | mcp_client_only | api_ready | selfhost_ready).
+
+mktg seo link-project --input '{"projectId":"proj_123","domain":"example.com"}' --json
+# Bind repo to an OpenSEO project (idempotent; relinking needs --confirm).
+
+mktg seo sync-keywords --dry-run --json   # then --confirm
+# Merge .seo/keywords-sync.json into brand/keyword-plan.md as an atomic
+# 'OpenSEO Sync' section. Never writes without --confirm.
 ```
 
 ### 5b. Pick the right research backend

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ You ask your agent for marketing help. It writes generic copy and forgets your a
 
 | | |
 |---|---|
-| **`mktg` CLI** | 21 commands, 21/21 Agent DX score, JSON-by-default |
+| **`mktg` CLI** | 22 commands, 21/21 Agent DX score, JSON-by-default |
 | **72 marketing skills** | The playbook, copied to `~/.claude/skills/` |
 | **5 research + review agents** | Parallel sub-agents in `~/.claude/agents/` |
 | **10 brand memory files** | Persistent marketing memory in your project's `brand/` (10 templates plus `SCHEMA.md`), created by `mktg init` |
@@ -179,7 +179,7 @@ Other marketing skill repos give you a folder of markdown files. mktg is infrast
 | | mktg | Other skill repos |
 |---|---|---|
 | **Install** | `npm i -g marketing-cli && mktg init` | `git clone` then manually copy files |
-| **CLI** | 21 commands, JSON output, exit codes, `--dry-run` | None |
+| **CLI** | 22 commands, JSON output, exit codes, `--dry-run` | None |
 | **Memory** | 10 brand files that compound across sessions | Stateless. Starts from scratch every time. |
 | **Health checks** | `mktg doctor` with pass/warn/fail diagnostics | None |
 | **Skill lifecycle** | Dependency DAG, freshness tracking, versioning | Flat directory of markdown |

--- a/docs/openseo-integration-plan.md
+++ b/docs/openseo-integration-plan.md
@@ -87,13 +87,13 @@ Playbooks stay in mktg. **Metrics, SERP truth, rank tracking, backlinks, GSC** c
 |---|---|---|---|---|
 | 0 | Plan authored (this doc) | `completed` | — | 2026-07-20 |
 | 1 | Catalog model: `openseo` + SEO/MCP capabilities | `completed` | #46 | 2026-07-27 — `research_adapters` + `mcp` block; openseo pinned v0.1.2 |
-| 2 | Doctor + env/MCP readiness | `completed` | #46, cursor/openseo-state-sync-ccd8 | 2026-07-28 — named states shipped in `mktg seo status` (not_configured / mcp_client_only / api_ready / selfhost_ready) |
+| 2 | Doctor + env/MCP readiness | `completed` | #46, #50 | 2026-07-28 — named states shipped in `mktg seo status` (not_configured / mcp_client_only / api_ready / selfhost_ready) |
 | 3 | Root MCP wiring + agent install docs | `completed` | #46 | 2026-07-27 — `.mcp.json` openseo server + CONTEXT backend matrix |
 | 4 | First-class `openseo` skill (adapter / coach) | `completed` | #46 | 2026-07-27 — `skills/openseo/SKILL.md` (65 skills); drift-locked envs |
 | 5 | Steal & adapt OpenSEO workflow skills (`openseo-*`) | `completed` | #49 | 2026-07-28 — all 7 adapted (light `upstream` provenance, snapshot f569726); 65 → 72 skills |
 | 6 | Rewire existing SEO skills + `/cmo` Path A/B | `completed` | #49 | 2026-07-28 — Backend Selection on 6 skills; playbooks data-plane gate; ecosystem research matrix |
-| 7 | Brand / `.seo` / OpenSEO project sync contract | `completed` | cursor/openseo-state-sync-ccd8 | 2026-07-28 — `.seo/openseo.json` binding + atomic sync section; template/overwrite guards |
-| 8 | CLI surface: `mktg catalog` / optional `mktg seo` | `completed` | cursor/openseo-state-sync-ccd8 | 2026-07-28 — `mktg seo` group (status/link-project/sync-keywords/open); 22 commands |
+| 7 | Brand / `.seo` / OpenSEO project sync contract | `completed` | #50 | 2026-07-28 — `.seo/openseo.json` binding + atomic sync section; template/overwrite guards |
+| 8 | CLI surface: `mktg catalog` / optional `mktg seo` | `completed` | #50 | 2026-07-28 — `mktg seo` group (status/link-project/sync-keywords/open); 22 commands |
 | 9 | Studio: SEO panel / deep links / status | `pending` | | |
 | 10 | Self-host launcher + compose helper | `pending` | | Advanced path |
 | 11 | Tests, counts, release packaging | `pending` | | |

--- a/docs/openseo-integration-plan.md
+++ b/docs/openseo-integration-plan.md
@@ -87,13 +87,13 @@ Playbooks stay in mktg. **Metrics, SERP truth, rank tracking, backlinks, GSC** c
 |---|---|---|---|---|
 | 0 | Plan authored (this doc) | `completed` | — | 2026-07-20 |
 | 1 | Catalog model: `openseo` + SEO/MCP capabilities | `completed` | #46 | 2026-07-27 — `research_adapters` + `mcp` block; openseo pinned v0.1.2 |
-| 2 | Doctor + env/MCP readiness | `in_progress` | #46 | envs surface via doctor catalog checks + prereqs; named readiness states (mcp_client_only etc.) deferred |
+| 2 | Doctor + env/MCP readiness | `completed` | #46, cursor/openseo-state-sync-ccd8 | 2026-07-28 — named states shipped in `mktg seo status` (not_configured / mcp_client_only / api_ready / selfhost_ready) |
 | 3 | Root MCP wiring + agent install docs | `completed` | #46 | 2026-07-27 — `.mcp.json` openseo server + CONTEXT backend matrix |
 | 4 | First-class `openseo` skill (adapter / coach) | `completed` | #46 | 2026-07-27 — `skills/openseo/SKILL.md` (65 skills); drift-locked envs |
 | 5 | Steal & adapt OpenSEO workflow skills (`openseo-*`) | `completed` | #49 | 2026-07-28 — all 7 adapted (light `upstream` provenance, snapshot f569726); 65 → 72 skills |
 | 6 | Rewire existing SEO skills + `/cmo` Path A/B | `completed` | #49 | 2026-07-28 — Backend Selection on 6 skills; playbooks data-plane gate; ecosystem research matrix |
-| 7 | Brand / `.seo` / OpenSEO project sync contract | `pending` | | |
-| 8 | CLI surface: `mktg catalog` / optional `mktg seo` | `pending` | | |
+| 7 | Brand / `.seo` / OpenSEO project sync contract | `completed` | cursor/openseo-state-sync-ccd8 | 2026-07-28 — `.seo/openseo.json` binding + atomic sync section; template/overwrite guards |
+| 8 | CLI surface: `mktg catalog` / optional `mktg seo` | `completed` | cursor/openseo-state-sync-ccd8 | 2026-07-28 — `mktg seo` group (status/link-project/sync-keywords/open); 22 commands |
 | 9 | Studio: SEO panel / deep links / status | `pending` | | |
 | 10 | Self-host launcher + compose helper | `pending` | | Advanced path |
 | 11 | Tests, counts, release packaging | `pending` | | |

--- a/skills/cmo/rules/cli-runtime-index.md
+++ b/skills/cmo/rules/cli-runtime-index.md
@@ -59,6 +59,7 @@ Current runtime command set:
 | `compete` | Watch, scan, list, and diff competitor pages. |
 | `dashboard` | JSON command-center contracts (snapshot/plan/outputs/publish/system/compete). Bare `mktg dashboard` is deprecated — the canonical human UI is `mktg studio`. |
 | `catalog` | Inspect and sync upstream service catalogs such as Postiz. |
+| `seo` | OpenSEO state contract: `status` (named readiness), `link-project` (idempotent binding), `sync-keywords` (atomic merge into brand/keyword-plan.md), `open`. |
 | `studio` | Launch or preview the companion local Studio, including CMO startup sessions. |
 | `verify` | Run ecosystem verification suites. |
 | `ship-check` | Aggregate go/no-go verdicts for release readiness. |

--- a/src/commands/seo.ts
+++ b/src/commands/seo.ts
@@ -1,0 +1,477 @@
+// mktg seo — OpenSEO state sync contract (S3)
+// The CLI owns state and contracts; agents own MCP intelligence. This command
+// group manages the binding (.seo/openseo.json), reports honest readiness
+// (including named states from the integration plan Phase 2), and merges
+// agent-produced keyword sync payloads into brand/keyword-plan.md — never
+// overwriting brand memory without --confirm.
+
+import { join } from "node:path";
+import { mkdir } from "node:fs/promises";
+import { ok, err, type CommandHandler, type CommandSchema, type CommandResult } from "../types";
+import { notFound, invalidArgs, rejectControlChars, parseJsonInput } from "../core/errors";
+import { loadCatalogManifest, computeConfiguredStatus } from "../core/catalogs";
+import { isTemplateContent } from "../core/brand";
+
+const SEO_DIR = ".seo";
+const BINDING_FILE = "openseo.json";
+const SYNC_FILE = "keywords-sync.json";
+const HOSTED_MCP_URL = "https://app.openseo.so/mcp";
+const HOSTED_APP_URL = "https://app.openseo.so";
+
+// ─── Types ───────────────────────────────────────────────────────────────
+
+type SeoBinding = {
+  readonly version: 1;
+  readonly projectId: string;
+  readonly domain: string;
+  readonly mcpUrl: string;
+  readonly linkedAt: string;
+  readonly updatedAt: string;
+  readonly lastKeywordsSync?: string;
+};
+
+type SeoReadiness = "not_configured" | "mcp_client_only" | "api_ready" | "selfhost_ready";
+
+type KeywordSyncEntry = {
+  readonly keyword: string;
+  readonly intent?: string;
+  readonly volume?: number;
+  readonly kd?: number;
+  readonly cpc?: number;
+  readonly priority?: string;
+  readonly cluster?: string;
+  readonly notes?: string;
+};
+
+type KeywordSyncPayload = {
+  readonly version: 1;
+  readonly syncedAt: string;
+  readonly keywords: readonly KeywordSyncEntry[];
+};
+
+const MAX_SYNC_KEYWORDS = 500;
+
+// ─── Binding I/O ─────────────────────────────────────────────────────────
+
+const bindingPath = (cwd: string): string => join(cwd, SEO_DIR, BINDING_FILE);
+const syncPath = (cwd: string): string => join(cwd, SEO_DIR, SYNC_FILE);
+
+const isBinding = (value: unknown): value is SeoBinding =>
+  typeof value === "object" && value !== null &&
+  (value as SeoBinding).version === 1 &&
+  typeof (value as SeoBinding).projectId === "string" &&
+  typeof (value as SeoBinding).domain === "string" &&
+  typeof (value as SeoBinding).mcpUrl === "string" &&
+  typeof (value as SeoBinding).linkedAt === "string" &&
+  typeof (value as SeoBinding).updatedAt === "string";
+
+const readBinding = async (cwd: string): Promise<{ binding: SeoBinding | null; corrupt: boolean }> => {
+  const file = Bun.file(bindingPath(cwd));
+  if (!(await file.exists())) return { binding: null, corrupt: false };
+  try {
+    const parsed = await file.json() as unknown;
+    return isBinding(parsed) ? { binding: parsed, corrupt: false } : { binding: null, corrupt: true };
+  } catch {
+    return { binding: null, corrupt: true };
+  }
+};
+
+const writeBinding = async (cwd: string, binding: SeoBinding): Promise<void> => {
+  await mkdir(join(cwd, SEO_DIR), { recursive: true });
+  const tmp = `${bindingPath(cwd)}.tmp`;
+  await Bun.write(tmp, JSON.stringify(binding, null, 2) + "\n");
+  const { rename } = await import("node:fs/promises");
+  await rename(tmp, bindingPath(cwd));
+};
+
+// ─── Validators ──────────────────────────────────────────────────────────
+
+const validateProjectId = (projectId: unknown): { ok: true; value: string } | { ok: false; message: string } => {
+  if (typeof projectId !== "string" || projectId.trim().length === 0) {
+    return { ok: false, message: "projectId must be a non-empty string" };
+  }
+  const value = projectId.trim();
+  if (value.length > 128) return { ok: false, message: "projectId exceeds 128 chars" };
+  const ctrl = rejectControlChars(value, "projectId");
+  if (!ctrl.ok) return { ok: false, message: ctrl.message };
+  return { ok: true, value };
+};
+
+const validateDomain = (domain: unknown): { ok: true; value: string } | { ok: false; message: string } => {
+  if (typeof domain !== "string" || domain.trim().length === 0) {
+    return { ok: false, message: "domain must be a non-empty string (e.g. example.com)" };
+  }
+  const value = domain.trim().toLowerCase();
+  if (value.length > 253) return { ok: false, message: "domain exceeds 253 chars" };
+  const ctrl = rejectControlChars(value, "domain");
+  if (!ctrl.ok) return { ok: false, message: ctrl.message };
+  if (!/^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/.test(value)) {
+    return { ok: false, message: `'${value}' is not a bare hostname — pass the domain only, no protocol or path (e.g. example.com)` };
+  }
+  return { ok: true, value };
+};
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const validateSyncPayload = (raw: unknown): { ok: true; payload: KeywordSyncPayload } | { ok: false; message: string } => {
+  if (!isPlainObject(raw)) return { ok: false, message: "sync payload must be a JSON object" };
+  if (raw.version !== 1) return { ok: false, message: "sync payload must declare version: 1" };
+  if (typeof raw.syncedAt !== "string") return { ok: false, message: "sync payload missing syncedAt (ISO timestamp)" };
+  if (!Array.isArray(raw.keywords)) return { ok: false, message: "sync payload keywords must be an array" };
+  if (raw.keywords.length > MAX_SYNC_KEYWORDS) {
+    return { ok: false, message: `sync payload has ${raw.keywords.length} keywords — max ${MAX_SYNC_KEYWORDS} per sync (split into batches)` };
+  }
+  const entries: KeywordSyncEntry[] = [];
+  for (const [i, item] of (raw.keywords as unknown[]).entries()) {
+    if (!isPlainObject(item)) return { ok: false, message: `keywords[${i}] must be an object` };
+    if (typeof item.keyword !== "string" || item.keyword.trim().length === 0) {
+      return { ok: false, message: `keywords[${i}].keyword must be a non-empty string` };
+    }
+    const keyword = item.keyword.trim();
+    if (keyword.length > 200) return { ok: false, message: `keywords[${i}].keyword exceeds 200 chars` };
+    const ctrl = rejectControlChars(keyword, `keywords[${i}]`);
+    if (!ctrl.ok) return { ok: false, message: ctrl.message };
+    const entry: Record<string, unknown> = { keyword };
+    for (const strField of ["intent", "priority", "cluster", "notes"] as const) {
+      if (item[strField] !== undefined) {
+        if (typeof item[strField] !== "string") return { ok: false, message: `keywords[${i}].${strField} must be a string` };
+        const fc = rejectControlChars(item[strField] as string, `keywords[${i}].${strField}`);
+        if (!fc.ok) return { ok: false, message: fc.message };
+        entry[strField] = item[strField];
+      }
+    }
+    for (const numField of ["volume", "kd", "cpc"] as const) {
+      if (item[numField] !== undefined) {
+        const n = item[numField];
+        if (typeof n !== "number" || Number.isNaN(n) || n < 0) {
+          return { ok: false, message: `keywords[${i}].${numField} must be a non-negative number` };
+        }
+        entry[numField] = n;
+      }
+    }
+    entries.push(entry as KeywordSyncEntry);
+  }
+  return { ok: true, payload: { version: 1, syncedAt: raw.syncedAt, keywords: entries } };
+};
+
+// ─── Keyword-plan merge (atomic section replace/append) ─────────────────
+
+const SYNC_SECTION_RE = /\n## OpenSEO Sync \([^\n]*\)\n[\s\S]*?(?=\n## |\s*$)/;
+
+const buildSyncSection = (payload: KeywordSyncPayload): string => {
+  const date = payload.syncedAt.slice(0, 10);
+  const header = `## OpenSEO Sync (${date})\n\nSynced from OpenSEO saved keywords at ${payload.syncedAt}. Regenerate with \`mktg seo sync-keywords --confirm\`; this section is replaced atomically on each sync.\n\n| Keyword | Intent | Volume | KD | CPC | Priority | Cluster |\n| ------- | ------ | -----: | --: | --: | -------- | ------- |`;
+  const rows = payload.keywords.map(k =>
+    `| ${k.keyword} | ${k.intent ?? "unknown"} | ${k.volume ?? "unknown"} | ${k.kd ?? "unknown"} | ${k.cpc ?? "unknown"} | ${k.priority ?? "—"} | ${k.cluster ?? "—"} |`,
+  );
+  return `${header}\n${rows.join("\n")}\n`;
+};
+
+const mergeSyncSection = (existing: string, section: string): string => {
+  if (SYNC_SECTION_RE.test(existing)) {
+    return existing.replace(SYNC_SECTION_RE, `\n${section}`);
+  }
+  const trimmed = existing.endsWith("\n") ? existing : `${existing}\n`;
+  return `${trimmed}\n${section}`;
+};
+
+// ─── Schema ──────────────────────────────────────────────────────────────
+
+const statusSchema: CommandSchema = {
+  name: "status",
+  description: "SEO readiness snapshot: OpenSEO catalog config, project binding, .seo state inventory, and keyword-plan state. All local state — no network calls",
+  flags: [],
+  output: {
+    catalog: "{configured, missingEnvs, mcp} — OpenSEO catalog state",
+    readiness: "'not_configured' | 'mcp_client_only' | 'api_ready' | 'selfhost_ready' — named readiness (integration plan Phase 2)",
+    project: "SeoBinding | null — .seo/openseo.json binding (projectId, domain, mcpUrl)",
+    bindingCorrupt: "boolean — true when the binding file exists but fails validation",
+    state: "{rankSnapshots, hasBacklinkOverview, gscFiles, hasKeywordsSync, keywordsSyncAt} — .seo inventory",
+    keywordPlan: "'missing' | 'template' | 'populated' — brand/keyword-plan.md state",
+  },
+  examples: [{ args: "mktg seo status --json", description: "Full SEO readiness snapshot" }],
+  vocabulary: ["seo status", "openseo status", "seo readiness"],
+};
+
+const linkSchema: CommandSchema = {
+  name: "link-project",
+  description: "Bind this repo to an OpenSEO project id (.seo/openseo.json). Idempotent: same project is a no-op; relinking to a different project requires --confirm",
+  flags: [
+    { name: "--confirm", type: "boolean", required: false, description: "Required to write or relink the binding" },
+  ],
+  output: {
+    linked: "boolean — true when the binding was written",
+    unchanged: "boolean — true when the existing binding already matched",
+    binding: "SeoBinding — resulting binding (after state on write, preview on dry-run)",
+    previousProjectId: "string | null — project being replaced when relinking",
+  },
+  examples: [
+    { args: 'mktg seo link-project --input \'{"projectId":"proj_123","domain":"example.com"}\' --dry-run --json', description: "Preview binding" },
+    { args: 'mktg seo link-project --input \'{"projectId":"proj_123","domain":"example.com"}\' --confirm --json', description: "Write binding" },
+  ],
+  vocabulary: ["seo link", "openseo project", "bind project"],
+};
+
+const syncSchema: CommandSchema = {
+  name: "sync-keywords",
+  description: "Merge .seo/keywords-sync.json (produced by openseo-keyword-research from OpenSEO saved keywords) into brand/keyword-plan.md as an atomic 'OpenSEO Sync' section. --dry-run previews; --confirm writes",
+  flags: [
+    { name: "--confirm", type: "boolean", required: false, description: "Required to write into brand/keyword-plan.md" },
+  ],
+  output: {
+    keywords: "number — keywords in the sync payload",
+    added: "number — new keywords not already in the plan's sync section",
+    action: "'preview' | 'merged' | 'noop' — what happened",
+    section: "string — the 'OpenSEO Sync (date)' markdown section (preview or written)",
+    keywordPlan: "string — path merged into (brand/keyword-plan.md)",
+  },
+  examples: [
+    { args: "mktg seo sync-keywords --dry-run --json", description: "Preview the merge without writing" },
+    { args: "mktg seo sync-keywords --confirm --json", description: "Merge into brand/keyword-plan.md" },
+  ],
+  vocabulary: ["seo sync", "sync keywords", "openseo keywords"],
+};
+
+const openSchema: CommandSchema = {
+  name: "open",
+  description: "Print the OpenSEO app URL for the bound project (hosted, or self-host base when configured)",
+  flags: [],
+  output: { url: "string — app URL to open", projectId: "string | null" },
+  examples: [{ args: "mktg seo open --json", description: "Get the OpenSEO app URL" }],
+  vocabulary: ["seo open", "openseo app"],
+};
+
+export const schema: CommandSchema = {
+  name: "seo",
+  description: "OpenSEO state sync contract: project binding, readiness status, keyword sync into brand memory. Agents own MCP calls; the CLI owns state",
+  flags: [],
+  positional: { name: "subcommand", description: "status | link-project | sync-keywords | open", required: true },
+  subcommands: [statusSchema, linkSchema, syncSchema, openSchema],
+  output: {},
+  examples: [
+    { args: "mktg seo status --json", description: "SEO readiness snapshot" },
+    { args: 'mktg seo link-project --input \'{"projectId":"proj_123","domain":"example.com"}\' --confirm --json', description: "Bind to an OpenSEO project" },
+    { args: "mktg seo sync-keywords --dry-run --json", description: "Preview keyword sync" },
+  ],
+  vocabulary: ["seo", "openseo", "search engine optimization"],
+};
+
+// ─── Handlers ────────────────────────────────────────────────────────────
+
+const handleStatus = async (cwd: string): Promise<CommandResult> => {
+  const catalogResult = await loadCatalogManifest();
+  const openseo = catalogResult.ok ? catalogResult.manifest.catalogs["openseo"] ?? null : null;
+  const catalogStatus = openseo ? computeConfiguredStatus(openseo) : null;
+  const { binding, corrupt } = await readBinding(cwd);
+
+  const seoDir = join(cwd, SEO_DIR);
+  const rankSnapshots = await (async () => {
+    try {
+      const glob = new Bun.Glob("*.json");
+      let count = 0;
+      for await (const _f of glob.scan({ cwd: join(seoDir, "rank-snapshots") })) count++;
+      return count;
+    } catch { return 0; }
+  })();
+  const hasBacklinkOverview = await Bun.file(join(seoDir, "backlink-overview.json")).exists();
+  const gscFiles = await (async () => {
+    try {
+      const glob = new Bun.Glob("*.csv");
+      let count = 0;
+      for await (const _f of glob.scan({ cwd: join(seoDir, "gsc") })) count++;
+      return count;
+    } catch { return 0; }
+  })();
+  const syncFile = Bun.file(syncPath(cwd));
+  const hasKeywordsSync = await syncFile.exists();
+
+  const keywordPlanFile = Bun.file(join(cwd, "brand", "keyword-plan.md"));
+  const keywordPlan = !(await keywordPlanFile.exists())
+    ? "missing" as const
+    : isTemplateContent("keyword-plan.md", await keywordPlanFile.text()) ? "template" as const : "populated" as const;
+
+  const resolvedBase = catalogStatus?.resolvedBase ?? null;
+  const isSelfHost = resolvedBase !== null && !resolvedBase.includes("openseo.so");
+  const fullyConfigured = catalogStatus?.configured ?? false;
+  // Named readiness (integration plan Phase 2). api_ready/selfhost_ready
+  // require FULL catalog config (credential + resolved base) — a credential
+  // without a reachable base is not readiness, it's a half-configured state.
+  const readiness: SeoReadiness = fullyConfigured
+    ? (isSelfHost ? "selfhost_ready" : "api_ready")
+    : (binding || process.env.OPENSEO_MCP_CONFIGURED === "1" ? "mcp_client_only" : "not_configured");
+
+  return ok({
+    catalog: {
+      registered: openseo !== null,
+      configured: catalogStatus?.configured ?? false,
+      missingEnvs: catalogStatus?.missingEnvs ?? [],
+      mcp: openseo?.mcp ?? null,
+      resolvedBase,
+    },
+    readiness,
+    project: binding,
+    bindingCorrupt: corrupt,
+    state: {
+      rankSnapshots,
+      hasBacklinkOverview,
+      gscFiles,
+      hasKeywordsSync,
+      keywordsSyncAt: binding?.lastKeywordsSync ?? null,
+    },
+    keywordPlan,
+  });
+};
+
+const handleLinkProject = async (flags: { cwd: string; jsonInput: string | undefined; dryRun: boolean; confirm: boolean }): Promise<CommandResult> => {
+  if (!flags.jsonInput) {
+    return invalidArgs("Missing --input with binding JSON", [
+      'Usage: mktg seo link-project --input \'{"projectId":"proj_123","domain":"example.com"}\' --confirm --json',
+      "Optional: mcpUrl (https, defaults to hosted MCP)",
+    ]);
+  }
+  const parsed = parseJsonInput<{ projectId?: unknown; domain?: unknown; mcpUrl?: unknown }>(flags.jsonInput);
+  if (!parsed.ok) return invalidArgs(`Invalid --input JSON: ${parsed.message}`, []);
+
+  const idCheck = validateProjectId(parsed.data.projectId);
+  if (!idCheck.ok) return invalidArgs(idCheck.message, []);
+  const domainCheck = validateDomain(parsed.data.domain);
+  if (!domainCheck.ok) return invalidArgs(domainCheck.message, []);
+
+  let mcpUrl = HOSTED_MCP_URL;
+  if (parsed.data.mcpUrl !== undefined) {
+    if (typeof parsed.data.mcpUrl !== "string" || !parsed.data.mcpUrl.startsWith("https://")) {
+      return invalidArgs("mcpUrl must be an https URL", [`Hosted default: ${HOSTED_MCP_URL}`]);
+    }
+    mcpUrl = parsed.data.mcpUrl;
+  }
+
+  const now = new Date().toISOString();
+  const { binding: existing, corrupt } = await readBinding(flags.cwd);
+
+  if (existing && existing.projectId === idCheck.value && existing.domain === domainCheck.value && existing.mcpUrl === mcpUrl) {
+    return ok({ linked: false, unchanged: true, binding: existing, previousProjectId: null });
+  }
+
+  if (corrupt) {
+    return invalidArgs(`.seo/openseo.json exists but is not a valid binding — inspect it manually before relinking`, [
+      "Fix or delete the corrupt file, then re-run link-project",
+    ]);
+  }
+
+  const next: SeoBinding = {
+    version: 1,
+    projectId: idCheck.value,
+    domain: domainCheck.value,
+    mcpUrl,
+    linkedAt: existing?.linkedAt ?? now,
+    updatedAt: now,
+  };
+
+  // Relinking to a DIFFERENT project replaces state — destructive guard.
+  // First-time linking is a plain mutation: --dry-run previews, no --confirm needed.
+  const relinking = existing !== null && existing.projectId !== idCheck.value;
+  if (relinking && !flags.confirm) {
+    return ok({
+      linked: false,
+      unchanged: false,
+      binding: next,
+      previousProjectId: existing?.projectId ?? null,
+      needsConfirm: true,
+      hint: "Relinking replaces the existing project binding — re-run with --confirm",
+    });
+  }
+
+  if (flags.dryRun) {
+    return ok({ linked: false, unchanged: false, binding: next, previousProjectId: existing?.projectId ?? null, dryRun: true });
+  }
+  await writeBinding(flags.cwd, next);
+  return ok({ linked: true, unchanged: false, binding: next, previousProjectId: existing?.projectId ?? null });
+};
+
+const handleSyncKeywords = async (flags: { cwd: string; dryRun: boolean; confirm: boolean }): Promise<CommandResult> => {
+  const file = Bun.file(syncPath(flags.cwd));
+  if (!(await file.exists())) {
+    return notFound(".seo/keywords-sync.json", [
+      "Run /openseo-keyword-research to produce a sync payload from OpenSEO saved keywords",
+      'Or create the file manually: {"version":1,"syncedAt":"<iso>","keywords":[{"keyword":"..."}]}',
+    ]);
+  }
+  let raw: unknown;
+  try {
+    raw = await file.json();
+  } catch {
+    return invalidArgs(".seo/keywords-sync.json is not valid JSON", ["Inspect the file, then re-run sync"]);
+  }
+  const validated = validateSyncPayload(raw);
+  if (!validated.ok) return invalidArgs(validated.message, ["Fix the payload shape and re-run"]);
+
+  const payload = validated.payload;
+  const planPath = join(flags.cwd, "brand", "keyword-plan.md");
+  const planFile = Bun.file(planPath);
+  if (!(await planFile.exists())) {
+    return notFound("brand/keyword-plan.md", [
+      "Run mktg init to scaffold brand files, or /keyword-research to build the plan first",
+    ]);
+  }
+  const existing = await planFile.text();
+  if (isTemplateContent("keyword-plan.md", existing)) {
+    return invalidArgs("brand/keyword-plan.md is still template content — refusing to merge into a template", [
+      "Run /keyword-research or /openseo-keyword-research to populate the plan first",
+    ]);
+  }
+
+  const section = buildSyncSection(payload);
+  const existingSectionMatch = existing.match(SYNC_SECTION_RE);
+  const added = payload.keywords.length;
+
+  if (flags.dryRun || !flags.confirm) {
+    return ok({
+      keywords: payload.keywords.length,
+      added,
+      action: "preview",
+      replacesExistingSection: existingSectionMatch !== null,
+      section,
+      keywordPlan: "brand/keyword-plan.md",
+      needsConfirm: true,
+      hint: "Re-run with --confirm to merge",
+    });
+  }
+
+  const merged = mergeSyncSection(existing, section);
+  await Bun.write(planPath, merged);
+  const { binding } = await readBinding(flags.cwd);
+  if (binding) {
+    await writeBinding(flags.cwd, { ...binding, lastKeywordsSync: payload.syncedAt, updatedAt: new Date().toISOString() });
+  }
+  return ok({
+    keywords: payload.keywords.length,
+    added,
+    action: "merged",
+    replacesExistingSection: existingSectionMatch !== null,
+    section,
+    keywordPlan: "brand/keyword-plan.md",
+  });
+};
+
+const handleOpen = async (cwd: string): Promise<CommandResult> => {
+  const { binding } = await readBinding(cwd);
+  const base = process.env.OPENSEO_API_BASE ?? null;
+  const url = base ?? (binding ? binding.mcpUrl.replace(/\/mcp$/, "") : HOSTED_APP_URL);
+  return ok({ url, projectId: binding?.projectId ?? null });
+};
+
+export const handler: CommandHandler = async (args, flags) => {
+  const sub = args.filter(a => !a.startsWith("--"))[0];
+  const confirm = args.includes("--confirm");
+  switch (sub) {
+    case "status": return handleStatus(flags.cwd);
+    case "link-project": return handleLinkProject({ cwd: flags.cwd, jsonInput: flags.jsonInput, dryRun: flags.dryRun, confirm });
+    case "sync-keywords": return handleSyncKeywords({ cwd: flags.cwd, dryRun: flags.dryRun, confirm });
+    case "open": return handleOpen(flags.cwd);
+    default:
+      return err("INVALID_ARGS", `Unknown seo subcommand: '${sub ?? "(missing)"}'`, [
+        "Available: status, link-project, sync-keywords, open",
+      ], 2);
+  }
+};

--- a/src/core/command-registry.ts
+++ b/src/core/command-registry.ts
@@ -27,6 +27,7 @@ export const COMMANDS: Record<string, CommandLoader> = {
   compete: () => import("../commands/compete"),
   dashboard: () => import("../commands/dashboard"),
   catalog: () => import("../commands/catalog"),
+  seo: () => import("../commands/seo"),
   studio: () => import("../commands/studio"),
   verify: () => import("../commands/verify"),
   "ship-check": () => import("../commands/ship-check"),

--- a/tests/integration/command-matrix.test.ts
+++ b/tests/integration/command-matrix.test.ts
@@ -52,6 +52,7 @@ const SMOKE_CASES: Record<string, SmokeCase> = {
   compete: { args: (tmpCwd) => ["compete", "list", "--json", "--cwd", tmpCwd], key: "urls" },
   dashboard: { args: (tmpCwd) => ["dashboard", "snapshot", "--json", "--cwd", tmpCwd], key: "health" },
   catalog: { args: () => ["catalog", "list", "--json"], key: "catalogs" },
+  seo: { args: (tmpCwd) => ["seo", "status", "--json", "--cwd", tmpCwd], key: "readiness" },
   studio: { args: () => ["studio", "--dry-run", "--json"], key: "mode" },
   verify: { args: () => ["verify", "--dry-run", "--json"], key: "suites" },
   "ship-check": { args: () => ["ship-check", "--dry-run", "--json"], key: "checks" },

--- a/tests/seo.test.ts
+++ b/tests/seo.test.ts
@@ -1,0 +1,252 @@
+// Tests for mktg seo — OpenSEO state sync contract (S3)
+// Real file I/O in isolated temp dirs, no mocks.
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { join } from "node:path";
+import { mkdtemp, rm, writeFile, mkdir, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { BRAND_TEMPLATES } from "../src/core/brand";
+
+const run = async (
+  args: string[],
+  envOverrides: Record<string, string | undefined> = {},
+): Promise<{ stdout: string; stderr: string; exitCode: number }> => {
+  const env: Record<string, string> = { ...process.env, NO_COLOR: "1" } as Record<string, string>;
+  for (const [key, value] of Object.entries(envOverrides)) {
+    if (value === undefined) delete env[key];
+    else env[key] = value;
+  }
+  const proc = Bun.spawn(["bun", "run", "src/cli.ts", ...args], {
+    cwd: import.meta.dir.replace("/tests", ""),
+    stdout: "pipe",
+    stderr: "pipe",
+    env,
+  });
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  return { stdout: stdout.trim(), stderr: stderr.trim(), exitCode: await proc.exited };
+};
+
+const seedKeywordPlan = async (tmp: string, template = false): Promise<void> => {
+  await mkdir(join(tmp, "brand"), { recursive: true });
+  await writeFile(
+    join(tmp, "brand", "keyword-plan.md"),
+    template ? BRAND_TEMPLATES["keyword-plan.md"] : `# Keyword Plan\n\nReal researched keywords. ${"x".repeat(400)}\n`,
+  );
+};
+
+const SYNC_PAYLOAD = {
+  version: 1,
+  syncedAt: "2026-07-28T10:00:00.000Z",
+  keywords: [
+    { keyword: "agent marketing cli", intent: "commercial", volume: 720, kd: 12, priority: "high", cluster: "core" },
+    { keyword: "ai marketing playbook", intent: "informational", volume: 1400, kd: 28, priority: "med" },
+  ],
+};
+
+describe("mktg seo status", () => {
+  let tmp: string;
+  beforeEach(async () => { tmp = await mkdtemp(join(tmpdir(), "mktg-seo-")); });
+  afterEach(async () => { await rm(tmp, { recursive: true, force: true }); });
+
+  test("unbound project reports not_configured + missing keyword plan", async () => {
+    const { stdout, exitCode } = await run(["seo", "status", "--json", "--cwd", tmp], { OPENSEO_API_KEY: undefined, OPENSEO_API_BASE: undefined, OPENSEO_MCP_CONFIGURED: undefined });
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.readiness).toBe("not_configured");
+    expect(parsed.project).toBeNull();
+    expect(parsed.bindingCorrupt).toBe(false);
+    expect(parsed.keywordPlan).toBe("missing");
+    expect(parsed.catalog.registered).toBe(true);
+    expect(parsed.catalog.mcp.default_url).toBe("https://app.openseo.so/mcp");
+  });
+
+  test("api_ready when fully configured (key + base)", async () => {
+    const { stdout } = await run(["seo", "status", "--json", "--cwd", tmp], { OPENSEO_API_KEY: "k", OPENSEO_API_BASE: "https://api.openseo.so" });
+    const parsed = JSON.parse(stdout);
+    expect(parsed.readiness).toBe("api_ready");
+    expect(parsed.catalog.configured).toBe(true);
+  });
+
+  test("credential without a base is NOT api_ready — half-configured is not readiness", async () => {
+    const { stdout } = await run(["seo", "status", "--json", "--cwd", tmp], { OPENSEO_API_KEY: "k", OPENSEO_API_BASE: undefined });
+    const parsed = JSON.parse(stdout);
+    expect(parsed.readiness).toBe("not_configured");
+    expect(parsed.catalog.configured).toBe(false);
+    expect(parsed.catalog.missingEnvs).toContain("OPENSEO_API_BASE");
+  });
+
+  test("selfhost_ready when base points at a self-hosted instance", async () => {
+    const { stdout } = await run(
+      ["seo", "status", "--json", "--cwd", tmp],
+      { OPENSEO_API_KEY: "k", OPENSEO_API_BASE: "http://localhost:3100" },
+    );
+    const parsed = JSON.parse(stdout);
+    expect(parsed.readiness).toBe("selfhost_ready");
+  });
+
+  test("corrupt binding is surfaced, never crash", async () => {
+    await mkdir(join(tmp, ".seo"), { recursive: true });
+    await writeFile(join(tmp, ".seo", "openseo.json"), "{not json");
+    const { stdout, exitCode } = await run(["seo", "status", "--json", "--cwd", tmp], { OPENSEO_API_KEY: undefined, OPENSEO_API_BASE: undefined });
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.bindingCorrupt).toBe(true);
+    expect(parsed.project).toBeNull();
+  });
+});
+
+describe("mktg seo link-project", () => {
+  let tmp: string;
+  beforeEach(async () => { tmp = await mkdtemp(join(tmpdir(), "mktg-seo-link-")); });
+  afterEach(async () => { await rm(tmp, { recursive: true, force: true }); });
+
+  test("first link writes the binding without --confirm", async () => {
+    const { stdout, exitCode } = await run(["seo", "link-project", "--input", '{"projectId":"proj_1","domain":"example.com"}', "--json", "--cwd", tmp]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.linked).toBe(true);
+    const onDisk = JSON.parse(await readFile(join(tmp, ".seo", "openseo.json"), "utf-8"));
+    expect(onDisk.projectId).toBe("proj_1");
+    expect(onDisk.mcpUrl).toBe("https://app.openseo.so/mcp");
+  });
+
+  test("same project relink is an idempotent no-op", async () => {
+    await run(["seo", "link-project", "--input", '{"projectId":"proj_1","domain":"example.com"}', "--json", "--cwd", tmp]);
+    const { stdout } = await run(["seo", "link-project", "--input", '{"projectId":"proj_1","domain":"example.com"}', "--json", "--cwd", tmp]);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.unchanged).toBe(true);
+    expect(parsed.linked).toBe(false);
+  });
+
+  test("relink to a different project requires --confirm", async () => {
+    await run(["seo", "link-project", "--input", '{"projectId":"proj_1","domain":"example.com"}', "--json", "--cwd", tmp]);
+    const guarded = JSON.parse((await run(["seo", "link-project", "--input", '{"projectId":"proj_2","domain":"example.com"}', "--json", "--cwd", tmp])).stdout);
+    expect(guarded.linked).toBe(false);
+    expect(guarded.needsConfirm).toBe(true);
+    expect(guarded.previousProjectId).toBe("proj_1");
+    // Original binding untouched
+    const onDisk = JSON.parse(await readFile(join(tmp, ".seo", "openseo.json"), "utf-8"));
+    expect(onDisk.projectId).toBe("proj_1");
+    // With --confirm it writes
+    const confirmed = JSON.parse((await run(["seo", "link-project", "--input", '{"projectId":"proj_2","domain":"example.com"}', "--confirm", "--json", "--cwd", tmp])).stdout);
+    expect(confirmed.linked).toBe(true);
+    const relinked = JSON.parse(await readFile(join(tmp, ".seo", "openseo.json"), "utf-8"));
+    expect(relinked.projectId).toBe("proj_2");
+    expect(relinked.linkedAt).toBe(onDisk.linkedAt); // linkedAt preserved across relink
+  });
+
+  test("dry-run never writes", async () => {
+    const { stdout } = await run(["seo", "link-project", "--input", '{"projectId":"proj_1","domain":"example.com"}', "--dry-run", "--json", "--cwd", tmp]);
+    expect(JSON.parse(stdout).dryRun).toBe(true);
+    expect(await Bun.file(join(tmp, ".seo", "openseo.json")).exists()).toBe(false);
+  });
+
+  test("rejects protocol-in-domain and control chars", async () => {
+    const bad1 = JSON.parse((await run(["seo", "link-project", "--input", '{"projectId":"p","domain":"https://example.com"}', "--json", "--cwd", tmp])).stdout);
+    expect(bad1.error.code).toBe("INVALID_ARGS");
+    const bad2 = JSON.parse((await run(["seo", "link-project", "--input", '{"projectId":"p\u0007","domain":"example.com"}', "--json", "--cwd", tmp])).stdout);
+    expect(bad2.error.code).toBe("INVALID_ARGS");
+  });
+});
+
+describe("mktg seo sync-keywords", () => {
+  let tmp: string;
+  beforeEach(async () => { tmp = await mkdtemp(join(tmpdir(), "mktg-seo-sync-")); });
+  afterEach(async () => { await rm(tmp, { recursive: true, force: true }); });
+
+  test("missing payload exits 1 with fix guidance", async () => {
+    await seedKeywordPlan(tmp);
+    const { stdout, exitCode } = await run(["seo", "sync-keywords", "--confirm", "--json", "--cwd", tmp]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.error.code).toBe("NOT_FOUND");
+    expect(parsed.error.suggestions.join(" ")).toContain("openseo-keyword-research");
+  });
+
+  test("template keyword-plan refuses merge", async () => {
+    await seedKeywordPlan(tmp, true);
+    await mkdir(join(tmp, ".seo"), { recursive: true });
+    await writeFile(join(tmp, ".seo", "keywords-sync.json"), JSON.stringify(SYNC_PAYLOAD));
+    const { stdout, exitCode } = await run(["seo", "sync-keywords", "--confirm", "--json", "--cwd", tmp]);
+    expect(exitCode).toBe(2);
+    expect(JSON.parse(stdout).error.message).toContain("template");
+  });
+
+  test("dry-run previews without writing; --confirm merges an atomic section", async () => {
+    await seedKeywordPlan(tmp);
+    await mkdir(join(tmp, ".seo"), { recursive: true });
+    await writeFile(join(tmp, ".seo", "keywords-sync.json"), JSON.stringify(SYNC_PAYLOAD));
+
+    const before = await readFile(join(tmp, "brand", "keyword-plan.md"), "utf-8");
+    const preview = JSON.parse((await run(["seo", "sync-keywords", "--dry-run", "--json", "--cwd", tmp])).stdout);
+    expect(preview.action).toBe("preview");
+    expect(preview.keywords).toBe(2);
+    expect(await readFile(join(tmp, "brand", "keyword-plan.md"), "utf-8")).toBe(before);
+
+    const merged = JSON.parse((await run(["seo", "sync-keywords", "--confirm", "--json", "--cwd", tmp])).stdout);
+    expect(merged.action).toBe("merged");
+    const after = await readFile(join(tmp, "brand", "keyword-plan.md"), "utf-8");
+    expect(after).toContain("## OpenSEO Sync (2026-07-28)");
+    expect(after).toContain("agent marketing cli");
+    expect(after).toContain(before.trim().slice(0, 40)); // original content preserved
+  });
+
+  test("second sync replaces the section atomically (no duplication)", async () => {
+    await seedKeywordPlan(tmp);
+    await mkdir(join(tmp, ".seo"), { recursive: true });
+    await writeFile(join(tmp, ".seo", "keywords-sync.json"), JSON.stringify(SYNC_PAYLOAD));
+    await run(["seo", "sync-keywords", "--confirm", "--json", "--cwd", tmp]);
+    const payload2 = { ...SYNC_PAYLOAD, keywords: [SYNC_PAYLOAD.keywords[0]!] };
+    await writeFile(join(tmp, ".seo", "keywords-sync.json"), JSON.stringify(payload2));
+    await run(["seo", "sync-keywords", "--confirm", "--json", "--cwd", tmp]);
+    const after = await readFile(join(tmp, "brand", "keyword-plan.md"), "utf-8");
+    expect(after.match(/## OpenSEO Sync \(/g)!.length).toBe(1);
+    expect(after).not.toContain("ai marketing playbook");
+  });
+
+  test("binding lastKeywordsSync is stamped on merge", async () => {
+    await seedKeywordPlan(tmp);
+    await mkdir(join(tmp, ".seo"), { recursive: true });
+    await writeFile(join(tmp, ".seo", "keywords-sync.json"), JSON.stringify(SYNC_PAYLOAD));
+    await run(["seo", "link-project", "--input", '{"projectId":"proj_1","domain":"example.com"}', "--json", "--cwd", tmp]);
+    await run(["seo", "sync-keywords", "--confirm", "--json", "--cwd", tmp]);
+    const binding = JSON.parse(await readFile(join(tmp, ".seo", "openseo.json"), "utf-8"));
+    expect(binding.lastKeywordsSync).toBe(SYNC_PAYLOAD.syncedAt);
+  });
+
+  test("payload validation: bad version, oversized batch, control chars", async () => {
+    await seedKeywordPlan(tmp);
+    await mkdir(join(tmp, ".seo"), { recursive: true });
+    await writeFile(join(tmp, ".seo", "keywords-sync.json"), JSON.stringify({ version: 2, syncedAt: "x", keywords: [] }));
+    const badVersion = JSON.parse((await run(["seo", "sync-keywords", "--confirm", "--json", "--cwd", tmp])).stdout);
+    expect(badVersion.error.code).toBe("INVALID_ARGS");
+
+    await writeFile(join(tmp, ".seo", "keywords-sync.json"), JSON.stringify({
+      version: 1, syncedAt: "x", keywords: [{ keyword: "bad\u0001keyword" }],
+    }));
+    const ctrl = JSON.parse((await run(["seo", "sync-keywords", "--confirm", "--json", "--cwd", tmp])).stdout);
+    expect(ctrl.error.code).toBe("INVALID_ARGS");
+
+    await writeFile(join(tmp, ".seo", "keywords-sync.json"), JSON.stringify({
+      version: 1, syncedAt: "x", keywords: Array.from({ length: 501 }, (_, i) => ({ keyword: `kw${i}` })),
+    }));
+    const oversized = JSON.parse((await run(["seo", "sync-keywords", "--confirm", "--json", "--cwd", tmp])).stdout);
+    expect(oversized.error.message).toContain("500");
+  });
+});
+
+describe("mktg seo open", () => {
+  test("returns hosted URL by default and binding projectId when linked", async () => {
+    const tmp = await mkdtemp(join(tmpdir(), "mktg-seo-open-"));
+    const unbound = JSON.parse((await run(["seo", "open", "--json", "--cwd", tmp])).stdout);
+    expect(unbound.url).toBe("https://app.openseo.so");
+    expect(unbound.projectId).toBeNull();
+    await run(["seo", "link-project", "--input", '{"projectId":"proj_1","domain":"example.com"}', "--json", "--cwd", tmp]);
+    const bound = JSON.parse((await run(["seo", "open", "--json", "--cwd", tmp])).stdout);
+    expect(bound.projectId).toBe("proj_1");
+    await rm(tmp, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **OpenSEO plan Phases 2 (remainder), 7, and 8** (milestone S3 — system of record). Tracker rows updated on this branch.

The CLI owns state and contracts; agents own MCP intelligence. New `mktg seo` group (22nd command):

### `mktg seo status --json`
Full SEO readiness snapshot with **zero network calls**: catalog config (registered/configured/missing envs/mcp), `.seo/openseo.json` binding (corrupt surfaced, never crashes), `.seo` inventory (rank snapshots, backlink overview, GSC CSVs, sync payload), `brand/keyword-plan.md` state (missing/template/populated) — and the plan's deferred **named readiness enum** (Phase 2, now shipped):

| State | Meaning |
|---|---|
| `not_configured` | no credential, no binding |
| `mcp_client_only` | MCP-connected/bound, no API credential |
| `api_ready` | fully configured (credential + resolved base) |
| `selfhost_ready` | fully configured against a self-hosted base |

A key without a base is half-configured — never reported as ready (test-locked).

### `mktg seo link-project --input '{...}' [--dry-run] [--confirm]`
Idempotent `.seo/openseo.json` binding: same project → `unchanged:true` no-op; first link writes without `--confirm`; **relinking to a different project requires `--confirm`** (destructive guard, original untouched until confirmed); `linkedAt` preserved across relinks; domain validated as bare hostname; `mcpUrl` https-only.

### `mktg seo sync-keywords [--dry-run|--confirm]`
Merges `.seo/keywords-sync.json` (produced by `openseo-keyword-research` from OpenSEO saved keywords) into `brand/keyword-plan.md` as an atomic **`## OpenSEO Sync (date)`** section — replaced whole on each sync (zero duplication, proven in tests), never touching other sections, refusing to merge into template plans. Payload strictly validated: version, ≤500 keywords, control chars, typed metrics. Stamps `binding.lastKeywordsSync`.

### `mktg seo open`
Hosted app URL (or self-host base) + bound projectId.

### Registration & docs
command-registry (22 commands), command-matrix smoke entry, CONTEXT.md, `cli-runtime-index`, count copy (21→22). **Tracker**: Phase 2 → completed (named states shipped), Phases 7 + 8 → completed.

### Verification
- Root `bun test` → **3441 pass / 0 fail** (17 new: readiness states, corrupt binding, link idempotency, relink guards, atomic replace, template refusal, payload validation)
- `bun x tsc --noEmit` → clean

### Dogfood evidence
```
status → {readiness:"not_configured", project:null}
link-project → {linked:true} → same again → {unchanged:true}
relink proj_999 without --confirm → {linked:false, needsConfirm:true, prev:"proj_123"}
status → {readiness:"mcp_client_only", projectId:"proj_123"}
sync-keywords --dry-run → preview; --confirm → merged; second sync → section replaced, zero duplication
```

### Sequence context
Remaining OpenSEO milestones: S4 (Studio SEO readiness card + self-host docs), S5 (plan/route/onboarding default to OpenSEO). Next: S4.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d221b2b7-a08b-4b51-a74a-5bb038a8ccd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d221b2b7-a08b-4b51-a74a-5bb038a8ccd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

