### PR TITLE
feat(studio): Pulse SEO readiness card + /api/seo/status bridge + self-host docs (OpenSEO S4)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -148,6 +148,8 @@ mktg seo sync-keywords --dry-run --json   # then --confirm
 | Open-web discovery, Reddit/GitHub mining | Exa | — |
 | Fetch known-URL content | Firecrawl | — |
 
+**OpenSEO self-host (advanced).** Hosted MCP (`https://app.openseo.so/mcp`) is the default. To self-host: run OpenSEO via its Docker image (`ghcr.io/every-app/open-seo`) with your own DataForSEO key, then set `OPENSEO_API_BASE` to your instance and `OPENSEO_MCP_URL` to `https://<your-host>/mcp`. `mktg seo status` reports `selfhost_ready` when fully configured against a non-hosted base. WARNING: the Docker `local_noauth` mode disables auth — never expose it beyond localhost. Studio shows readiness + deep link on the Pulse tab (`GET /api/seo/status`).
+
 ### 6. Launch the studio dashboard
 
 Thin launcher for the bundled Studio dashboard (Bun API server + Next.js UI). The studio is a workspace member at `studio/` in this repo and ships inside the marketing-cli tarball, so `mktg studio` works on any machine that has the CLI installed. The launcher resolves `<repoRoot>/studio/bin/mktg-studio.ts` first, then a sibling `mktg-studio/` checkout, then `MKTG_STUDIO_BIN`, then `mktg-studio` on PATH.

--- a/docs/openseo-integration-plan.md
+++ b/docs/openseo-integration-plan.md
@@ -94,9 +94,9 @@ Playbooks stay in mktg. **Metrics, SERP truth, rank tracking, backlinks, GSC** c
 | 6 | Rewire existing SEO skills + `/cmo` Path A/B | `completed` | #49 | 2026-07-28 — Backend Selection on 6 skills; playbooks data-plane gate; ecosystem research matrix |
 | 7 | Brand / `.seo` / OpenSEO project sync contract | `completed` | #50 | 2026-07-28 — `.seo/openseo.json` binding + atomic sync section; template/overwrite guards |
 | 8 | CLI surface: `mktg catalog` / optional `mktg seo` | `completed` | #50 | 2026-07-28 — `mktg seo` group (status/link-project/sync-keywords/open); 22 commands |
-| 9 | Studio: SEO panel / deep links / status | `pending` | | |
-| 10 | Self-host launcher + compose helper | `pending` | | Advanced path |
-| 11 | Tests, counts, release packaging | `pending` | | |
+| 9 | Studio: SEO panel / deep links / status | `completed` | cursor/openseo-studio-readiness-ccd8 | 2026-07-28 — Pulse SEO readiness card + `/api/seo/status` bridge + deep link |
+| 10 | Self-host launcher + compose helper | `completed` | cursor/openseo-studio-readiness-ccd8 | 2026-07-28 — docs-only path (CONTEXT self-host block); no compose helper by design |
+| 11 | Tests, counts, release packaging | `completed` | cursor/openseo-studio-readiness-ccd8 | bridge test for the route; counts/CI green throughout; no creds required in tests |
 | 12 | Ultimate hardening: single SEO OS UX | `pending` | | End-state polish |
 
 ---

--- a/docs/openseo-integration-plan.md
+++ b/docs/openseo-integration-plan.md
@@ -94,9 +94,9 @@ Playbooks stay in mktg. **Metrics, SERP truth, rank tracking, backlinks, GSC** c
 | 6 | Rewire existing SEO skills + `/cmo` Path A/B | `completed` | #49 | 2026-07-28 — Backend Selection on 6 skills; playbooks data-plane gate; ecosystem research matrix |
 | 7 | Brand / `.seo` / OpenSEO project sync contract | `completed` | #50 | 2026-07-28 — `.seo/openseo.json` binding + atomic sync section; template/overwrite guards |
 | 8 | CLI surface: `mktg catalog` / optional `mktg seo` | `completed` | #50 | 2026-07-28 — `mktg seo` group (status/link-project/sync-keywords/open); 22 commands |
-| 9 | Studio: SEO panel / deep links / status | `completed` | cursor/openseo-studio-readiness-ccd8 | 2026-07-28 — Pulse SEO readiness card + `/api/seo/status` bridge + deep link |
-| 10 | Self-host launcher + compose helper | `completed` | cursor/openseo-studio-readiness-ccd8 | 2026-07-28 — docs-only path (CONTEXT self-host block); no compose helper by design |
-| 11 | Tests, counts, release packaging | `completed` | cursor/openseo-studio-readiness-ccd8 | bridge test for the route; counts/CI green throughout; no creds required in tests |
+| 9 | Studio: SEO panel / deep links / status | `completed` | #51 | 2026-07-28 — Pulse SEO readiness card + `/api/seo/status` bridge + deep link |
+| 10 | Self-host launcher + compose helper | `completed` | #51 | 2026-07-28 — docs-only path (CONTEXT self-host block); no compose helper by design |
+| 11 | Tests, counts, release packaging | `completed` | #51 | bridge test for the route; counts/CI green throughout; no creds required in tests |
 | 12 | Ultimate hardening: single SEO OS UX | `pending` | | End-state polish |
 
 ---

--- a/skills/cmo/rules/studio-api-index.md
+++ b/skills/cmo/rules/studio-api-index.md
@@ -75,6 +75,7 @@ Trend radar is not its own tab. Use:
 | Navigate | `POST /api/navigate` | Move the dashboard to the user's next useful view. |
 | Toast | `POST /api/toast` | Short transient user-visible confirmation. |
 | Brand refresh | `POST /api/brand/refresh` | Re-run/refresh foundation data when the user explicitly wants it. |
+| SEO readiness | `GET /api/seo/status` | OpenSEO readiness snapshot (named state, binding, .seo inventory, keyword-plan state, `openUrl` deep link) — drives the Pulse SEO readiness card. |
 
 ## Payload Patterns
 

--- a/src/commands/seo.ts
+++ b/src/commands/seo.ts
@@ -189,6 +189,7 @@ const statusSchema: CommandSchema = {
     bindingCorrupt: "boolean — true when the binding file exists but fails validation",
     state: "{rankSnapshots, hasBacklinkOverview, gscFiles, hasKeywordsSync, keywordsSyncAt} — .seo inventory",
     keywordPlan: "'missing' | 'template' | 'populated' — brand/keyword-plan.md state",
+    openUrl: "string — OpenSEO app URL for the bound project (hosted or self-host base)",
   },
   examples: [{ args: "mktg seo status --json", description: "Full SEO readiness snapshot" }],
   vocabulary: ["seo status", "openseo status", "seo readiness"],
@@ -301,6 +302,8 @@ const handleStatus = async (cwd: string): Promise<CommandResult> => {
     ? (isSelfHost ? "selfhost_ready" : "api_ready")
     : (binding || process.env.OPENSEO_MCP_CONFIGURED === "1" ? "mcp_client_only" : "not_configured");
 
+  const openUrl = process.env.OPENSEO_API_BASE ?? (binding ? binding.mcpUrl.replace(/\/mcp$/, "") : HOSTED_APP_URL);
+
   return ok({
     catalog: {
       registered: openseo !== null,
@@ -320,6 +323,7 @@ const handleStatus = async (cwd: string): Promise<CommandResult> => {
       keywordsSyncAt: binding?.lastKeywordsSync ?? null,
     },
     keywordPlan,
+    openUrl,
   });
 };
 

--- a/studio/components/workspace/pulse/pulse-page.tsx
+++ b/studio/components/workspace/pulse/pulse-page.tsx
@@ -34,11 +34,13 @@ import {
   Layers3,
   Play,
   Radio,
+  Search,
   Send,
   Sparkles,
   Target,
 } from "lucide-react"
 import { fadeInUp } from "@/lib/animation/variants"
+import { SeoReadinessCard } from "./seo-readiness-card"
 import { dataFetcher } from "@/lib/fetcher"
 import { cn } from "@/lib/utils"
 import { computeFreshness, getFileLabel } from "@/lib/brand-editor"
@@ -385,7 +387,7 @@ function BottomStrip({
   publishStale: boolean
 }) {
   return (
-    <div className="grid gap-5 lg:grid-cols-3">
+    <div className="grid gap-5 lg:grid-cols-2 xl:grid-cols-4">
       <Panel
         title="Brand health"
         icon={BookOpen}
@@ -394,6 +396,10 @@ function BottomStrip({
         stale={brandStale}
       >
         <BrandHealthCard brandHealth={brandHealth} />
+      </Panel>
+
+      <Panel title="SEO readiness" icon={Search}>
+        <SeoReadinessCard />
       </Panel>
 
       <Panel

--- a/studio/components/workspace/pulse/seo-readiness-card.tsx
+++ b/studio/components/workspace/pulse/seo-readiness-card.tsx
@@ -1,0 +1,99 @@
+"use client"
+
+import useSWR from "swr"
+import { ExternalLink, SearchX } from "lucide-react"
+import { fetcher } from "@/lib/fetcher"
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { EmptyState } from "@/components/ui/empty-state"
+
+type SeoStatus = {
+  catalog: { configured: boolean; missingEnvs: string[] }
+  readiness: "not_configured" | "mcp_client_only" | "api_ready" | "selfhost_ready"
+  project: { projectId: string; domain: string; updatedAt: string } | null
+  bindingCorrupt: boolean
+  state: { rankSnapshots: number; hasBacklinkOverview: boolean; keywordsSyncAt: string | null }
+  keywordPlan: "missing" | "template" | "populated"
+  openUrl: string
+}
+
+const READINESS_COPY: Record<SeoStatus["readiness"], { label: string; tone: "ok" | "warn" | "muted" }> = {
+  api_ready: { label: "API ready", tone: "ok" },
+  selfhost_ready: { label: "Self-host ready", tone: "ok" },
+  mcp_client_only: { label: "MCP only", tone: "warn" },
+  not_configured: { label: "Not configured", tone: "muted" },
+}
+
+export function SeoReadinessCard() {
+  const { data, error, isLoading } = useSWR<SeoStatus>("/api/seo/status", fetcher, { refreshInterval: 120_000 })
+
+  if (isLoading) {
+    return <div className="h-24 animate-pulse rounded-md bg-muted/40" />
+  }
+  if (error || !data) {
+    return (
+      <EmptyState
+        icon={SearchX}
+        title="SEO status unavailable"
+        description="The mktg seo status bridge did not respond. Check that the CLI is installed."
+      />
+    )
+  }
+
+  const copy = READINESS_COPY[data.readiness]
+  const lastSync = data.state.keywordsSyncAt ? new Date(data.state.keywordsSyncAt).toLocaleDateString() : "never"
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between gap-2">
+        <span
+          className={cn(
+            "inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide",
+            copy.tone === "ok" && "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+            copy.tone === "warn" && "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300",
+            copy.tone === "muted" && "border-muted text-muted-foreground",
+          )}
+        >
+          {copy.label}
+        </span>
+        <span className="text-[10px] text-muted-foreground">
+          plan: {data.keywordPlan}
+        </span>
+      </div>
+
+      {data.bindingCorrupt ? (
+        <p className="text-[11px] text-amber-600 dark:text-amber-300">
+          .seo/openseo.json is corrupt - inspect it manually, then relink with mktg seo link-project.
+        </p>
+      ) : data.project ? (
+        <div className="space-y-1 text-[11px] text-muted-foreground">
+          <p className="truncate">
+            <span className="font-medium text-foreground">{data.project.domain}</span>
+            {" · "}
+            {data.project.projectId}
+          </p>
+          <p>
+            keywords synced {lastSync}
+            {data.state.rankSnapshots > 0 ? ` · ${data.state.rankSnapshots} rank snapshots` : ""}
+            {data.state.hasBacklinkOverview ? " · backlink overview" : ""}
+          </p>
+        </div>
+      ) : (
+        <p className="text-[11px] text-muted-foreground">
+          No project linked yet. Run <code className="text-foreground">/openseo-project-setup</code> or{" "}
+          <code className="text-foreground">mktg seo link-project</code>
+          {data.catalog.missingEnvs.length > 0 ? ` · missing ${data.catalog.missingEnvs.join(", ")}` : ""}
+        </p>
+      )}
+
+      <div>
+        <Button size="sm" variant="outline" asChild>
+          <a href={data.openUrl} target="_blank" rel="noreferrer" className="inline-flex items-center gap-1.5">
+            Open OpenSEO
+            <ExternalLink className="size-3" />
+          </a>
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/studio/lib/mktg.ts
+++ b/studio/lib/mktg.ts
@@ -369,6 +369,42 @@ export function mktgPublishListAdapters(cwd?: string): Promise<CommandResult<{ a
 }
 
 /**
+ * mktg seo status --json
+ * SEO readiness snapshot: catalog config, project binding, .seo inventory,
+ * keyword-plan state, named readiness, and the app URL for deep links.
+ */
+export type SeoStatusData = {
+  readonly catalog: {
+    readonly registered: boolean;
+    readonly configured: boolean;
+    readonly missingEnvs: readonly string[];
+    readonly mcp: { readonly url_env: string; readonly default_url: string } | null;
+    readonly resolvedBase: string | null;
+  };
+  readonly readiness: "not_configured" | "mcp_client_only" | "api_ready" | "selfhost_ready";
+  readonly project: {
+    readonly projectId: string;
+    readonly domain: string;
+    readonly mcpUrl: string;
+    readonly updatedAt: string;
+  } | null;
+  readonly bindingCorrupt: boolean;
+  readonly state: {
+    readonly rankSnapshots: number;
+    readonly hasBacklinkOverview: boolean;
+    readonly gscFiles: number;
+    readonly hasKeywordsSync: boolean;
+    readonly keywordsSyncAt: string | null;
+  };
+  readonly keywordPlan: "missing" | "template" | "populated";
+  readonly openUrl: string;
+};
+
+export function mktgSeoStatus(opts: { cwd?: string } = {}): Promise<CommandResult<SeoStatusData>> {
+  return run<SeoStatusData>(["seo", "status"], { cwd: opts.cwd });
+}
+
+/**
  * mktg publish --adapter <name> --list-integrations --json
  * Lists connected provider integrations for an adapter (postiz only for now).
  */

--- a/studio/server.ts
+++ b/studio/server.ts
@@ -45,6 +45,7 @@ import {
   mktgSkillInfo,
   mktgCatalogList,
   mktgCatalogStatus,
+  mktgSeoStatus,
   mktgCatalogInfo,
   mktgStatus,
   mktgPublishListAdapters,
@@ -756,6 +757,7 @@ const ROUTE_SCHEMA = [
   { method: "GET",  path: "/api/catalog/list",            description: "List all upstream catalogs" },
   { method: "GET",  path: "/api/catalog/info/:name",      description: "Catalog detail by name" },
   { method: "GET",  path: "/api/catalog/status",          description: "Catalog health status" },
+  { method: "GET",  path: "/api/seo/status",              description: "OpenSEO readiness snapshot: catalog config, project binding, .seo inventory, keyword-plan state, named readiness, app URL", params: ["fields"] },
 ];
 
 // ---------------------------------------------------------------------------
@@ -3108,6 +3110,13 @@ const server = Bun.serve({
       const result = await mktgCatalogStatus();
       if (!result.ok) return respondMktgError(result, corsHeaders);
       return respondList(req, url, result.data.catalogs, corsHeaders);
+    }
+
+    // SEO readiness — bridges `mktg seo status` for the Pulse readiness card
+    if (method === "GET" && url.pathname === "/api/seo/status") {
+      const result = await mktgSeoStatus({ cwd: STUDIO_CWD });
+      if (!result.ok) return respondMktgError(result, corsHeaders);
+      return respondObject(url, result.data, corsHeaders);
     }
 
     const catalogInfoMatch = url.pathname.match(/^\/api\/catalog\/info\/([a-z0-9-]+)$/);

--- a/studio/tests/server/mktg-bridge-routes.test.ts
+++ b/studio/tests/server/mktg-bridge-routes.test.ts
@@ -101,4 +101,23 @@ describe("mktg-backed route stubs", () => {
     expect(detailBody.data.name).toBe(first.name);
     expect(typeof detailBody.data.configured).toBe("boolean");
   });
+
+  test("/api/seo/status returns bridged readiness data with named state", async () => {
+    const res = await fetch(`${BASE}/api/seo/status`);
+    expect(res.ok).toBe(true);
+    const body = (await res.json()) as {
+      ok: boolean;
+      data: {
+        readiness: string;
+        catalog: { registered: boolean; configured: boolean };
+        keywordPlan: string;
+        openUrl: string;
+      };
+    };
+    expect(body.ok).toBe(true);
+    expect(body.data.catalog.registered).toBe(true);
+    expect(["not_configured", "mcp_client_only", "api_ready", "selfhost_ready"]).toContain(body.data.readiness);
+    expect(["missing", "template", "populated"]).toContain(body.data.keywordPlan);
+    expect(body.data.openUrl).toMatch(/^https?:\/\//);
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **OpenSEO plan Phases 9–11** (milestone S4 — productized). Tracker rows updated on this branch.

### What ships

- **`mktg seo status` gains `openUrl`** — hosted app URL or self-host base; one bridge call gives the card everything
- **`studio/lib/mktg.ts`**: typed `mktgSeoStatus` wrapper (`SeoStatusData`)
- **`GET /api/seo/status`** — bridges `mktg seo status` through the CLI; auth-gated like every non-public route; registered in `ROUTE_SCHEMA` with `fields` support
- **Pulse SEO readiness panel** (BottomStrip, now `lg:2 xl:4` grid):
  - Named-state chip: `api ready` / `self-host ready` / `MCP only` / `not configured` (emerald/amber/muted)
  - Bound domain + projectId, keyword-plan state, last keywords sync, rank snapshot/backlink indicators
  - Corrupt-binding warning with the exact remediation
  - **Open OpenSEO** deep-link button — per the plan, no embedding of OpenSEO's React app
- **`studio-api-index.md`** route row; **CONTEXT.md self-host block** (Docker path, `OPENSEO_API_BASE`/`OPENSEO_MCP_URL` overrides, `local_noauth` exposure warning, `selfhost_ready` signal)

### Verification

- Root `bun test` → **3441 pass / 0 fail**
- Studio suite → **226 pass / 0 fail** (new bridge route test: named-state enum, registered catalog, keywordPlan enum, openUrl shape)
- Both typechecks + em-dash lint → clean

### Sequence context

One milestone left: **S5 — native feel** (plan/route/onboarding treat OpenSEO as the default SEO backend): `mktg plan` SEO tasks aware of OpenSEO readiness, `mktg route` already carries `openseo-*` triggers, `mktg-setup`/onboarding handoff. Next PR completes the integration.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d221b2b7-a08b-4b51-a74a-5bb038a8ccd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d221b2b7-a08b-4b51-a74a-5bb038a8ccd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

