### PR TITLE
feat(plan): OpenSEO backend-awareness + onboarding handoff (OpenSEO S5 — native feel)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -150,6 +150,20 @@ mktg seo sync-keywords --dry-run --json   # then --confirm
 
 **OpenSEO self-host (advanced).** Hosted MCP (`https://app.openseo.so/mcp`) is the default. To self-host: run OpenSEO via its Docker image (`ghcr.io/every-app/open-seo`) with your own DataForSEO key, then set `OPENSEO_API_BASE` to your instance and `OPENSEO_MCP_URL` to `https://<your-host>/mcp`. `mktg seo status` reports `selfhost_ready` when fully configured against a non-hosted base. WARNING: the Docker `local_noauth` mode disables auth — never expose it beyond localhost. Studio shows readiness + deep link on the Pulse tab (`GET /api/seo/status`).
 
+### 5c. The SEO loop end to end
+
+```text
+mktg doctor → mktg seo status (readiness)
+  → mktg seo link-project (bind .seo/openseo.json)
+  → openseo-keyword-research (measured KD/volume → brand/keyword-plan.md)
+  → openseo-keyword-clustering (marketing/seo/clusters/)
+  → seo-content / seo-machine (pages from validated targets)
+  → mktg seo sync-keywords --confirm (saved keywords → atomic plan section)
+  → off-page-seo + openseo-link-prospecting (.seo/backlink-targets.json)
+```
+
+No OpenSEO? Same loop on Exa/Firecrawl with every metric marked `unknown`. Never invented, either way.
+
 ### 6. Launch the studio dashboard
 
 Thin launcher for the bundled Studio dashboard (Bun API server + Next.js UI). The studio is a workspace member at `studio/` in this repo and ships inside the marketing-cli tarball, so `mktg studio` works on any machine that has the CLI installed. The launcher resolves `<repoRoot>/studio/bin/mktg-studio.ts` first, then a sibling `mktg-studio/` checkout, then `MKTG_STUDIO_BIN`, then `mktg-studio` on PATH.

--- a/docs/openseo-integration-plan.md
+++ b/docs/openseo-integration-plan.md
@@ -97,7 +97,7 @@ Playbooks stay in mktg. **Metrics, SERP truth, rank tracking, backlinks, GSC** c
 | 9 | Studio: SEO panel / deep links / status | `completed` | #51 | 2026-07-28 — Pulse SEO readiness card + `/api/seo/status` bridge + deep link |
 | 10 | Self-host launcher + compose helper | `completed` | #51 | 2026-07-28 — docs-only path (CONTEXT self-host block); no compose helper by design |
 | 11 | Tests, counts, release packaging | `completed` | #51 | bridge test for the route; counts/CI green throughout; no creds required in tests |
-| 12 | Ultimate hardening: single SEO OS UX | `pending` | | End-state polish |
+| 12 | Ultimate hardening: single SEO OS UX | `completed` | cursor/openseo-native-feel-ccd8 | 2026-07-28 — plan SEO-awareness tasks (link/connect), mktg-setup handoff, CONTEXT 5c loop; route already carries openseo-* triggers |
 
 ---
 
@@ -449,11 +449,11 @@ mktg seo link-project --input '{"projectId":"..."}' --json
 
 | Milestone | Phases | User-visible win |
 |---|---|---|
-| **S1 — Catalog foothold** | 1–4 | `openseo` in catalog/doctor/skills; docs for MCP |
-| **S2 — Workflow parity** | 5–6 | OpenSEO workflows + CMO prefers OpenSEO data |
-| **S3 — System of record** | 7–8 | Project link + keyword sync CLI |
-| **S4 — Productized** | 9–11 | Studio card, tests, optional self-host sugar |
-| **S5 — Native feel** | 12 | Plan/route/onboarding treat OpenSEO as default SEO backend |
+| **S1 — Catalog foothold** | 1–4 | `openseo` in catalog/doctor/skills; docs for MCP | ✅ #46 |
+| **S2 — Workflow parity** | 5–6 | OpenSEO workflows + CMO prefers OpenSEO data | ✅ #49 |
+| **S3 — System of record** | 7–8 | Project link + keyword sync CLI | ✅ #50 |
+| **S4 — Productized** | 9–11 | Studio card, tests, optional self-host sugar | ✅ #51 |
+| **S5 — Native feel** | 12 | Plan/route/onboarding treat OpenSEO as default SEO backend | ✅ this branch |
 
 ---
 

--- a/docs/openseo-integration-plan.md
+++ b/docs/openseo-integration-plan.md
@@ -97,7 +97,7 @@ Playbooks stay in mktg. **Metrics, SERP truth, rank tracking, backlinks, GSC** c
 | 9 | Studio: SEO panel / deep links / status | `completed` | #51 | 2026-07-28 — Pulse SEO readiness card + `/api/seo/status` bridge + deep link |
 | 10 | Self-host launcher + compose helper | `completed` | #51 | 2026-07-28 — docs-only path (CONTEXT self-host block); no compose helper by design |
 | 11 | Tests, counts, release packaging | `completed` | #51 | bridge test for the route; counts/CI green throughout; no creds required in tests |
-| 12 | Ultimate hardening: single SEO OS UX | `completed` | cursor/openseo-native-feel-ccd8 | 2026-07-28 — plan SEO-awareness tasks (link/connect), mktg-setup handoff, CONTEXT 5c loop; route already carries openseo-* triggers |
+| 12 | Ultimate hardening: single SEO OS UX | `completed` | #52 | 2026-07-28 — plan SEO-awareness tasks (link/connect), mktg-setup handoff, CONTEXT 5c loop; route already carries openseo-* triggers |
 
 ---
 

--- a/skills/mktg-setup/SKILL.md
+++ b/skills/mktg-setup/SKILL.md
@@ -200,6 +200,11 @@ test -d brand || mkdir -p brand
 
 ## Step 6 — Hand Off to /cmo
 
+**SEO backend handoff (before spawning agents):** run `mktg catalog info openseo --json --fields configured,missing_envs`. OpenSEO is the default SEO data plane (measured KD, volume, SERP, backlinks, GSC).
+
+- `configured: true` → tell the user: "OpenSEO is connected. After foundation, I'll link a project (`mktg seo link-project`) so keyword research uses measured metrics." After the foundation chain, if `.seo/openseo.json` is still missing, recommend `/openseo-project-setup` as the first SEO move.
+- `configured: false` → one line only, no blocking: "OpenSEO isn't set up — keyword metrics will be `unknown` until it is. Setup takes a minute: openseo.so → connect the MCP, or set OPENSEO_API_KEY." Never install anything or ask for keys inside the wizard.
+
 Tell the user clearly what's happening next. Tailor the closing line to their Studio choice:
 
 - **studio_enabled = yes** → "Recorded your preferences. Now I'm spawning 3 research agents in parallel — brand voice, audience, and competitors — to fill out your foundation. ~5 minutes. Then I'll auto-open the Studio dashboard."

--- a/src/commands/plan.ts
+++ b/src/commands/plan.ts
@@ -8,6 +8,7 @@ import { ok, err, type CommandHandler, type CommandSchema, type BrandFile } from
 import { getBrandStatus, isTemplateContent } from "../core/brand";
 import { loadManifest } from "../core/skills";
 import { buildGraph } from "../core/skill-lifecycle";
+import { loadCatalogManifest, computeConfiguredStatus } from "../core/catalogs";
 import { getRunSummary, type RunSummaryEntry } from "../core/run-log";
 import { rejectControlChars, validateResourceId } from "../core/errors";
 import { isTTY, writeStderr, bold, dim, green, yellow, red } from "../core/output";
@@ -233,6 +234,35 @@ const buildTasks = async (
       blocked: false,
     });
   }
+
+  // 6. SEO backend awareness (OpenSEO is the default SEO data plane — S5).
+  // Two gaps are actionable: configured-but-unbound (link a project), and
+  // populated-plan-but-unmeasured (connect OpenSEO so metrics stop being
+  // "unknown"). Anything else is correctly silent.
+  try {
+    const catalogResult = await loadCatalogManifest();
+    const openseo = catalogResult.ok ? catalogResult.manifest.catalogs["openseo"] ?? null : null;
+    if (openseo) {
+      const openseoStatus = computeConfiguredStatus(openseo);
+      const bindingExists = await Bun.file(join(cwd, ".seo", "openseo.json")).exists();
+      const keywordPlanPopulated = templateState.get("keyword-plan.md") === false;
+      if (openseoStatus.configured && !bindingExists) {
+        emitTask({
+          id: "seo-link-project", order: tasks.length, category: "setup",
+          action: "Link an OpenSEO project to this repo", command: "mktg seo status --json",
+          reason: "OpenSEO is configured but no project is bound — linking unlocks keyword/rank sync",
+          blocked: false,
+        });
+      } else if (!openseoStatus.configured && keywordPlanPopulated) {
+        emitTask({
+          id: "seo-connect-openseo", order: tasks.length, category: "setup",
+          action: "Connect OpenSEO for measured SEO metrics", command: "mktg catalog info openseo --json --fields missing_envs,mcp",
+          reason: "keyword-plan.md is populated but its metrics are unmeasured — OpenSEO adds KD, volume, SERP, backlinks, GSC",
+          blocked: false,
+        });
+      }
+    }
+  } catch { /* catalog issues are doctor's job, not plan's */ }
 
   // Health counts files with REAL content — templates don't count, so a
   // fresh scaffold can never report "ready". Files the populate section

--- a/tests/plan.test.ts
+++ b/tests/plan.test.ts
@@ -218,3 +218,80 @@ describe("plan honesty gates", () => {
     await rm(tmp, { recursive: true, force: true });
   });
 });
+
+// ==================== S5: OpenSEO backend awareness ====================
+
+const runWithEnv = async (
+  args: string[],
+  envOverrides: Record<string, string | undefined>,
+): Promise<{ stdout: string; exitCode: number }> => {
+  const env: Record<string, string> = { ...process.env, NO_COLOR: "1" } as Record<string, string>;
+  for (const [key, value] of Object.entries(envOverrides)) {
+    if (value === undefined) delete env[key];
+    else env[key] = value;
+  }
+  const proc = Bun.spawn(["bun", "run", "src/cli.ts", ...args], {
+    cwd: import.meta.dir.replace("/tests", ""),
+    stdout: "pipe", stderr: "pipe",
+    env,
+  });
+  const stdout = await new Response(proc.stdout).text();
+  return { stdout: stdout.trim(), exitCode: await proc.exited };
+};
+
+describe("plan OpenSEO backend awareness (S5)", () => {
+  test("configured OpenSEO + no binding → seo-link-project task", async () => {
+    const tmp = await mkdtemp(join(tmpdir(), "mktg-plan-seo-"));
+    await seedBrandTemplates(tmp);
+    const { stdout } = await runWithEnv(
+      ["plan", "--json", "--cwd", tmp],
+      { OPENSEO_API_KEY: "k", OPENSEO_API_BASE: "https://api.openseo.so" },
+    );
+    const parsed = JSON.parse(stdout);
+    expect(parsed.tasks.some((t: { id: string }) => t.id === "seo-link-project")).toBe(true);
+    await rm(tmp, { recursive: true, force: true });
+  });
+
+  test("configured OpenSEO + binding present → no seo-link-project task", async () => {
+    const tmp = await mkdtemp(join(tmpdir(), "mktg-plan-seo-"));
+    await seedBrandTemplates(tmp);
+    await mkdir(join(tmp, ".seo"), { recursive: true });
+    await writeFile(join(tmp, ".seo", "openseo.json"), JSON.stringify({
+      version: 1, projectId: "p1", domain: "example.com", mcpUrl: "https://app.openseo.so/mcp",
+      linkedAt: "2026-07-01T00:00:00.000Z", updatedAt: "2026-07-01T00:00:00.000Z",
+    }));
+    const { stdout } = await runWithEnv(
+      ["plan", "--json", "--cwd", tmp],
+      { OPENSEO_API_KEY: "k", OPENSEO_API_BASE: "https://api.openseo.so" },
+    );
+    const parsed = JSON.parse(stdout);
+    expect(parsed.tasks.some((t: { id: string }) => t.id === "seo-link-project")).toBe(false);
+    await rm(tmp, { recursive: true, force: true });
+  });
+
+  test("unconfigured OpenSEO + populated keyword plan → seo-connect-openseo task", async () => {
+    const tmp = await mkdtemp(join(tmpdir(), "mktg-plan-seo-"));
+    await seedBrandTemplates(tmp);
+    await writeFile(join(tmp, "brand", "keyword-plan.md"), "# Keyword Plan\n\nReal researched keywords. " + "x".repeat(400));
+    const { stdout } = await runWithEnv(
+      ["plan", "--json", "--cwd", tmp],
+      { OPENSEO_API_KEY: undefined, OPENSEO_API_BASE: undefined },
+    );
+    const parsed = JSON.parse(stdout);
+    expect(parsed.tasks.some((t: { id: string }) => t.id === "seo-connect-openseo")).toBe(true);
+    await rm(tmp, { recursive: true, force: true });
+  });
+
+  test("unconfigured OpenSEO + template keyword plan → correctly silent", async () => {
+    const tmp = await mkdtemp(join(tmpdir(), "mktg-plan-seo-"));
+    await seedBrandTemplates(tmp);
+    const { stdout } = await runWithEnv(
+      ["plan", "--json", "--cwd", tmp],
+      { OPENSEO_API_KEY: undefined, OPENSEO_API_BASE: undefined },
+    );
+    const parsed = JSON.parse(stdout);
+    expect(parsed.tasks.some((t: { id: string }) => t.id === "seo-connect-openseo")).toBe(false);
+    expect(parsed.tasks.some((t: { id: string }) => t.id === "seo-link-project")).toBe(false);
+    await rm(tmp, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **OpenSEO plan Phase 12** (milestone S5 — native feel). **This completes the OpenSEO integration** — all 5 milestones shipped. Tracker updated on this branch.

### What ships

- **`mktg plan` section 6 — SEO backend awareness.** Two actionable gaps, everything else correctly silent:
  - OpenSEO **configured but no binding** → `seo-link-project` task ("link to unlock keyword/rank sync")
  - **Populated keyword plan + unconfigured** → `seo-connect-openseo` task ("metrics are unmeasured — OpenSEO adds KD, volume, SERP, backlinks, GSC")
  - Template plans and bound projects produce no noise (test-locked)
- **`mktg-setup` onboarding handoff**: checks catalog readiness before spawning foundation agents; recommends `/openseo-project-setup` as the first SEO move when connected; names the `unknown`-metrics gap when not — never blocks the wizard, never asks for keys in-flow
- **CONTEXT.md §5c "The SEO loop end to end"** — the full loop from doctor to off-page, with the no-OpenSEO fallback in the same breath
- Route already carries `openseo-*` triggers (verified in S2); the playbook's Backend Selection owns the runtime backend choice by design

### Verification

- Root `bun test` → **3445 pass / 0 fail** (4 new awareness cases)
- `bun x tsc --noEmit` → clean

### Dogfood evidence (no-creds path, per the resume protocol)

```
catalog info openseo   → configured:false, missing_envs:[BASE, KEY]
seo status             → {readiness:"not_configured", keywordPlan:"populated"}
plan                   → ["seo-connect-openseo"] (gap surfaced)
seo link-project       → {linked:true}
run openseo-keyword-research → {event:"loaded"}
```

### Integration epilogue

| Milestone | PR |
|---|---|
| S1 catalog foothold | #46 |
| S2 workflow parity | #49 |
| S3 system of record | #50 |
| S4 productized | #51 |
| S5 native feel | this PR |
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d221b2b7-a08b-4b51-a74a-5bb038a8ccd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d221b2b7-a08b-4b51-a74a-5bb038a8ccd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

